### PR TITLE
hpsdr: add ppm frequency correction

### DIFF
--- a/crates/sdroxide-types/src/radio.rs
+++ b/crates/sdroxide-types/src/radio.rs
@@ -335,6 +335,10 @@ pub struct HpsdrConfig {
     /// that works.
     #[serde(default = "HpsdrConfig::default_invert_spectrum")]
     pub invert_spectrum: bool,
+    /// Crystal/TCXO error in ppm, applied to RX/TX frequency before it's sent
+    /// to the board's NCO.
+    #[serde(default)]
+    pub ppm: f64,
 }
 
 impl Default for HpsdrConfig {
@@ -346,6 +350,7 @@ impl Default for HpsdrConfig {
             lna_gain_db: Self::default_lna_gain_db(),
             filter_board: HpsdrFilterBoard::None,
             invert_spectrum: Self::default_invert_spectrum(),
+            ppm: 0.0,
         }
     }
 }
@@ -358,6 +363,8 @@ impl HpsdrConfig {
     /// rather than in `sdroxide-hpsdr` so the (wasm-safe) settings UI can address
     /// the same element without depending on the native backend crate.
     pub const LNA_GAIN_ELEMENT: &'static str = "LNA";
+    /// Ppm correction, riding `SetGain` like [`RtlSdrConfig::PPM_ELEMENT`].
+    pub const PPM_ELEMENT: &'static str = "PPM";
 
     /// Mid-scale default: sensitive enough on a quiet band without clipping the
     /// ADC on a real antenna.
@@ -387,6 +394,11 @@ impl HpsdrConfig {
     /// `None` means "discover and use the first responder".
     pub fn target_ip(&self) -> Option<&str> {
         self.manual_ip.as_deref().filter(|s| !s.trim().is_empty()).or(self.selected_ip.as_deref())
+    }
+
+    /// Scale `hz` by a ppm correction.
+    pub fn apply_ppm(hz: f64, ppm: f64) -> f64 {
+        hz * (1.0 + ppm / 1e6)
     }
 }
 
@@ -719,5 +731,13 @@ mod tests {
         let back: HpsdrConfig =
             serde_json::from_str(&serde_json::to_string(&cfg).unwrap()).unwrap();
         assert_eq!(cfg, back);
+    }
+
+    #[test]
+    fn ppm_scales_frequency_proportionally() {
+        assert_eq!(HpsdrConfig::apply_ppm(14_000_000.0, 0.0), 14_000_000.0);
+        // +1 ppm at 14 MHz is +14 Hz.
+        assert!((HpsdrConfig::apply_ppm(14_000_000.0, 1.0) - 14_000_014.0).abs() < 1e-6);
+        assert!((HpsdrConfig::apply_ppm(14_000_000.0, -1.0) - 13_999_986.0).abs() < 1e-6);
     }
 }

--- a/crates/sdroxide-ui/src/app/settings/radio.rs
+++ b/crates/sdroxide-ui/src/app/settings/radio.rs
@@ -261,6 +261,23 @@ pub(in crate::app) fn settings_hpsdr_tab(
              wrong sideband and FT8 returns no decodes at all.",
         );
         ui.end_row();
+
+        ui.label("Frequency correction").on_hover_text(
+            "Crystal/TCXO error in ppm, applied to RX and TX. Applies immediately.",
+        );
+        let mut ppm = cfg.hpsdr.ppm;
+        let resp = ui.add(
+            egui::DragValue::new(&mut ppm).range(-100.0..=100.0).speed(0.1).suffix(" ppm"),
+        );
+        if resp.changed() {
+            cfg.hpsdr.ppm = ppm;
+            cmds.push(Command::SetGain {
+                dir: Direction::Rx,
+                element: HpsdrConfig::PPM_ELEMENT.to_string(),
+                db: ppm,
+            });
+        }
+        ui.end_row();
     });
     ui.add_space(6.0);
     ui.label(

--- a/src/hpsdr_source.rs
+++ b/src/hpsdr_source.rs
@@ -18,6 +18,8 @@ const SILENCE_BEFORE_REOPEN: Duration = Duration::from_secs(5);
 pub struct HpsdrSource {
     handle: HpsdrHandle,
     center: f64,
+    /// See [`sdroxide_types::HpsdrConfig::ppm`].
+    ppm: f64,
     rx_scratch: Vec<f32>,
     tx_scratch: Vec<f32>,
     label: String,
@@ -40,7 +42,7 @@ impl HpsdrSource {
             cfg.filter_board,
             cfg.invert_spectrum,
         )?;
-        handle.set_rx_freq(center_hz);
+        handle.set_rx_freq(sdroxide_types::HpsdrConfig::apply_ppm(center_hz, cfg.ppm));
         let label =
             format!("HPSDR {} @ {ip} ({:.3} Msps)", handle.board, handle.sample_rate_hz / 1e6);
         tracing::info!(
@@ -49,6 +51,7 @@ impl HpsdrSource {
         );
         Ok(HpsdrSource {
             center: center_hz,
+            ppm: cfg.ppm,
             rx_scratch: Vec::new(),
             tx_scratch: Vec::new(),
             label,
@@ -85,7 +88,7 @@ impl IqSource for HpsdrSource {
 
     fn set_center_hz(&mut self, hz: f64) -> Result<()> {
         self.center = hz;
-        self.handle.set_rx_freq(hz);
+        self.handle.set_rx_freq(sdroxide_types::HpsdrConfig::apply_ppm(hz, self.ppm));
         Ok(())
     }
 
@@ -117,6 +120,9 @@ impl IqSource for HpsdrSource {
     fn set_gain_element(&mut self, name: &str, db: f64) -> Result<()> {
         if name == LNA_GAIN_ELEMENT {
             self.handle.set_lna_gain_db(db);
+        } else if name == sdroxide_types::HpsdrConfig::PPM_ELEMENT {
+            self.ppm = db;
+            self.handle.set_rx_freq(sdroxide_types::HpsdrConfig::apply_ppm(self.center, self.ppm));
         }
         Ok(())
     }
@@ -138,7 +144,7 @@ impl IqSource for HpsdrSource {
     }
 
     fn tx_begin(&mut self, center_hz: f64, _rate: f64) -> Result<f64> {
-        Ok(self.handle.tx_begin(center_hz))
+        Ok(self.handle.tx_begin(sdroxide_types::HpsdrConfig::apply_ppm(center_hz, self.ppm)))
     }
 
     fn tx_write(&mut self, samples: &[Complex32]) -> Result<()> {


### PR DESCRIPTION
My Radioberry is slightly off frequency, and I haven't found a way to fix it through sdroxide

<img width="661" height="419" alt="image" src="https://github.com/user-attachments/assets/cd0f9838-04ab-4ce2-bf2b-2abe83572119" />


btw, thanks for the software. it is really awesome
