### PR TITLE
hpsdr: conjugate TX I/Q on protocol 1, matching RX

### DIFF
--- a/crates/sdroxide-hpsdr/src/protocol1.rs
+++ b/crates/sdroxide-hpsdr/src/protocol1.rs
@@ -563,6 +563,9 @@ pub(crate) fn run(ctx: ThreadCtx) {
                     tx_scratch.extend_from_slice(b);
                     pair.commit_all();
                 }
+                if invert_spectrum {
+                    conjugate(&mut tx_scratch);
+                }
             }
             let cc = regs.cc(rot.take(&regs));
             let mox = if regs.ptt { 1 } else { 0 };


### PR DESCRIPTION
My Radioberry also wants IQ swapped, but I found that it also crosses the SSB sides, so when I am in LSB, it transmits in USB, heh.

I guess this is related to https://github.com/dividebysandwich/sdroxide/issues/7