### PR TITLE
session: persist volume, RX gain, drive and mic gain across restarts

### DIFF
--- a/crates/sdroxide-config/src/lib.rs
+++ b/crates/sdroxide-config/src/lib.rs
@@ -258,10 +258,10 @@ impl Settings {
     }
 }
 
-/// Where the operator left the radio (`session.json`): the dial, the mode and
-/// the selected antennas. Restored on the next start, so the program comes back
-/// up where it was instead of on a fixed default frequency and whichever port
-/// the driver happens to power up on.
+/// Where the operator left the radio (`session.json`): the dial, the mode, the
+/// selected antennas, and the audio/RF levels. Restored on the next start, so
+/// the program comes back up where it was instead of on a fixed default
+/// frequency and whichever port and level the driver happens to power up on.
 ///
 /// Deliberately not part of `config.toml`. That file holds preferences the
 /// operator sets once; this is written by the engine as the radio is used, and
@@ -280,6 +280,18 @@ pub struct Session {
     pub antenna_rx: Option<String>,
     /// TX antenna port, likewise ("BAND1", "BAND2").
     pub antenna_tx: Option<String>,
+    /// Main receiver's AF volume, 0.0..=1.0.
+    pub volume: f32,
+    /// Main receiver's manual (AGC-off) gain, in dB.
+    pub rx_gain_db: f32,
+    /// Main receiver's AGC mode.
+    pub agc: sdroxide_types::AgcMode,
+    /// TX drive, 0.0..=1.0 fraction of maximum.
+    pub drive: f32,
+    /// Drive used while tuning, 0.0..=1.0 fraction of maximum.
+    pub tune_drive: f32,
+    /// Mic gain, 0.0..=1.0.
+    pub mic_gain: f32,
 }
 
 impl Default for Session {
@@ -289,7 +301,22 @@ impl Default for Session {
         let (freq_hz, mode) = sdroxide_types::Band::M20.default_entry();
         // No antenna preference: whatever the driver selects on open stands,
         // which is what every start did before this was remembered.
-        Session { freq_hz, mode, antenna_rx: None, antenna_tx: None }
+        // Levels match `RadioState::default()` so an operator who has never
+        // touched them comes up at the same drive and mic gain a fresh start
+        // always used, rather than a dead mic.
+        let radio = sdroxide_types::RadioState::default();
+        Session {
+            freq_hz,
+            mode,
+            antenna_rx: None,
+            antenna_tx: None,
+            volume: radio.rx[0].volume,
+            rx_gain_db: radio.rx[0].manual_gain_db,
+            agc: radio.rx[0].agc,
+            drive: radio.tx.drive,
+            tune_drive: radio.tx.tune_drive,
+            mic_gain: radio.tx.mic_gain,
+        }
     }
 }
 
@@ -819,9 +846,31 @@ mod tests {
             mode: sdroxide_types::Mode::Ft8,
             antenna_rx: Some("LNAW".into()),
             antenna_tx: Some("BAND2".into()),
+            volume: 0.8,
+            rx_gain_db: 35.0,
+            agc: sdroxide_types::AgcMode::Fast,
+            drive: 0.4,
+            tune_drive: 0.2,
+            mic_gain: 0.6,
         };
         let back: Session = serde_json::from_str(&serde_json::to_string(&s).unwrap()).unwrap();
         assert_eq!(back, s);
+    }
+
+    /// Every `session.json` written before the levels were remembered has to
+    /// keep restoring its dial and mode, and fall back to the levels a fresh
+    /// start has always come up at.
+    #[test]
+    fn a_session_written_before_levels_still_loads() {
+        let old: Session =
+            serde_json::from_str(r#"{"freq_hz":7074000.0,"mode":"Ft8"}"#).expect("parses");
+        let radio = sdroxide_types::RadioState::default();
+        assert_eq!(old.volume, radio.rx[0].volume);
+        assert_eq!(old.rx_gain_db, radio.rx[0].manual_gain_db);
+        assert_eq!(old.agc, radio.rx[0].agc);
+        assert_eq!(old.drive, radio.tx.drive);
+        assert_eq!(old.tune_drive, radio.tx.tune_drive);
+        assert_eq!(old.mic_gain, radio.tx.mic_gain);
     }
 
     /// The first run, and every run before this file existed, has to land where

--- a/crates/sdroxide-radio/src/engine.rs
+++ b/crates/sdroxide-radio/src/engine.rs
@@ -1006,6 +1006,18 @@ fn engine_thread(
     // CAT rig reporting its own) is a difference like any other, and gets
     // written even if nothing is touched afterwards.
     let session = engine_cfg.remember_session.then(sdroxide_config::load_session);
+    // Volume, RX gain, AGC mode, drive and mic gain have no command-line
+    // override, so the remembered session (if any) always wins over the
+    // hardcoded defaults `RadioState::default()` / `engine_cfg.initial_mode`
+    // set above.
+    if let Some(s) = session.as_ref() {
+        state.rx[0].volume = s.volume;
+        state.rx[0].manual_gain_db = s.rx_gain_db;
+        state.rx[0].agc = s.agc;
+        state.tx.drive = s.drive;
+        state.tx.tune_drive = s.tune_drive;
+        state.tx.mic_gain = s.mic_gain;
+    }
     // The command line outranks the remembered session, exactly as it does for
     // the dial and the mode.
     let (cli_rx, cli_tx) = engine_cfg.initial_antenna;
@@ -4077,10 +4089,10 @@ impl Engine {
         }
     }
 
-    /// Write the dial, mode and antennas to `session.json` if any of them has
-    /// moved since the last write, so the next start comes up here rather than
-    /// on the default frequency. A no-op on an engine that isn't remembering its
-    /// session.
+    /// Write the dial, mode, antennas and levels to `session.json` if any of
+    /// them has moved since the last write, so the next start comes up here
+    /// rather than on the default frequency and levels. A no-op on an engine
+    /// that isn't remembering its session.
     ///
     /// Compared before writing rather than written on every change: the dial
     /// moves continuously while it is being spun, and none of those hundreds of
@@ -4099,6 +4111,12 @@ impl Engine {
             mode: self.state.rx[0].mode,
             antenna_rx: keep(&self.state.antenna_rx).or_else(|| saved.antenna_rx.clone()),
             antenna_tx: keep(&self.state.antenna_tx).or_else(|| saved.antenna_tx.clone()),
+            volume: self.state.rx[0].volume,
+            rx_gain_db: self.state.rx[0].manual_gain_db,
+            agc: self.state.rx[0].agc,
+            drive: self.state.tx.drive,
+            tune_drive: self.state.tx.tune_drive,
+            mic_gain: self.state.tx.mic_gain,
         };
         if now == *saved {
             return;
@@ -4106,7 +4124,7 @@ impl Engine {
         match sdroxide_config::save_session(&now) {
             Ok(()) => self.session = Some(now),
             // Don't latch the new value on failure, so the next tick retries.
-            Err(e) => warn!("saving the session (dial + mode + antennas): {e}"),
+            Err(e) => warn!("saving the session (dial + mode + antennas + levels): {e}"),
         }
     }
 


### PR DESCRIPTION
i found that some settings do not persist across restarts