### PR TITLE
radio: record both sides of a QSO, fix stale RX replay on unkey

### DIFF
--- a/crates/sdroxide-proto/src/lib.rs
+++ b/crates/sdroxide-proto/src/lib.rs
@@ -175,7 +175,11 @@ use sdroxide_types::{
 /// commands (`SetScannerConfig`, `SetScanning`, `ScanNext`, `ScanSkip`) drive
 /// it. The commands are appended, but the added `RadioState` field changes the
 /// layout of every message carrying one, postcard not being self-describing.
-pub const PROTO_VERSION: u16 = 41;
+/// v42: recording both sides of the QSO (RX left, TX right) instead of just
+/// the receiver, plus an optional mono downmix — `Command::SetRecordingMono`
+/// (appended) and `RadioState.recording_mono` (changes the layout of every
+/// message carrying `RadioState`).
+pub const PROTO_VERSION: u16 = 42;
 const VERSION_BYTE: u8 = 0x12;
 
 #[derive(Debug, thiserror::Error)]

--- a/crates/sdroxide-radio/src/engine.rs
+++ b/crates/sdroxide-radio/src/engine.rs
@@ -32,7 +32,7 @@ use sdroxide_types::{
     ScanKind, ScanResume, SpectrumConfig, SpectrumFrame, TciServerConfig, TxMeters, Vfo,
 };
 
-use crate::recorder::Recorder;
+use crate::recorder::{Recorder, RecordingChannels};
 use crate::voice::VoiceKeyer;
 use crate::{Complex32, ControlUpdate, IqSource};
 
@@ -217,6 +217,12 @@ struct RxChain {
     out_buf_r: Vec<f32>,
     /// Resamples L and R together so the two can't drift a sample apart.
     stereo_rs: Option<StereoResampler>,
+    /// Post-squelch audio at `out_rate`, same shape as `out_buf`/`out_buf_r`,
+    /// but without the AF volume/mute scaling applied to those — the QSO
+    /// recorder taps this instead, so turning down the AF knob or hitting
+    /// mute doesn't touch the archived recording. See [`RxChain::take_rec_audio`].
+    rec_buf: Vec<f32>,
+    rec_buf_r: Vec<f32>,
 }
 
 impl RxChain {
@@ -246,6 +252,8 @@ impl RxChain {
             lr_out: Vec::new(),
             out_buf_r: Vec::new(),
             stereo_rs: None,
+            rec_buf: Vec::new(),
+            rec_buf_r: Vec::new(),
         };
         chain.build_for_mode(rx);
         chain
@@ -303,6 +311,8 @@ impl RxChain {
         self.out_buf.clear();
         self.out_buf_r.clear();
         if self.demod.is_none() {
+            self.rec_buf.clear();
+            self.rec_buf_r.clear();
             return (&self.out_buf, None);
         }
         let demod = self.demod.as_mut().expect("checked above");
@@ -382,23 +392,24 @@ impl RxChain {
         let tone_ok = rx.tone_sql.is_none_or(|want| demod.sub_tone() == Some(want));
         let open = demod.power_dbfs() >= rx.squelch_db && tone_ok;
         let sq_target = if open { 1.0 } else { 0.0 };
-        let vol = if rx.muted { 0.0 } else { rx.volume * rx.volume };
+        // AF volume/mute is applied further down, after the recorder tap is
+        // snapshotted — squelch is the only gate shared by both.
         if stereo {
             // A single loop over both: `sq_gain` advances per *sample*, so
             // gating the two channels in separate passes would run the gate
             // twice as fast and hand them different gains.
             for (m, sd) in self.audio_buf.iter_mut().zip(self.side_buf.iter_mut()) {
                 self.sq_gain += (sq_target - self.sq_gain) * 0.002;
-                let g = vol * self.sq_gain;
-                *m *= g;
-                *sd *= g;
+                *m *= self.sq_gain;
+                *sd *= self.sq_gain;
             }
         } else {
             for s in &mut self.audio_buf {
                 self.sq_gain += (sq_target - self.sq_gain) * 0.002;
-                *s *= vol * self.sq_gain;
+                *s *= self.sq_gain;
             }
         }
+        let vol = if rx.muted { 0.0 } else { rx.volume * rx.volume };
 
         if !stereo {
             match &mut self.resampler {
@@ -408,6 +419,13 @@ impl RxChain {
             // Clamp after resampling so interpolation overshoot can't escape.
             for s in &mut self.out_buf {
                 *s = s.clamp(-1.0, 1.0);
+            }
+            // Recorder tap: post-squelch, pre-volume/mute (see `rec_buf`).
+            self.rec_buf.clear();
+            self.rec_buf.extend_from_slice(&self.out_buf);
+            self.rec_buf_r.clear();
+            for s in &mut self.out_buf {
+                *s *= vol;
             }
             return (&self.out_buf, None);
         }
@@ -434,7 +452,26 @@ impl RxChain {
             self.out_buf.push(f[0].clamp(-1.0, 1.0));
             self.out_buf_r.push(f[1].clamp(-1.0, 1.0));
         }
+        // Recorder tap: post-squelch, pre-volume/mute (see `rec_buf`).
+        self.rec_buf.clear();
+        self.rec_buf.extend_from_slice(&self.out_buf);
+        self.rec_buf_r.clear();
+        self.rec_buf_r.extend_from_slice(&self.out_buf_r);
+        for s in &mut self.out_buf {
+            *s *= vol;
+        }
+        for s in &mut self.out_buf_r {
+            *s *= vol;
+        }
         (&self.out_buf, Some(&self.out_buf_r))
+    }
+
+    /// The recorder's copy of the last [`RxChain::run`] block: post-squelch,
+    /// pre-AF-volume/mute. Shape matches `run`'s return (second slice present
+    /// only in the stereo case).
+    fn take_rec_audio(&self) -> (&[f32], Option<&[f32]>) {
+        let right = (!self.rec_buf_r.is_empty()).then_some(self.rec_buf_r.as_slice());
+        (&self.rec_buf, right)
     }
 
     fn power_dbfs(&self) -> Option<f32> {
@@ -509,9 +546,24 @@ struct StereoMixer {
     main_q: Vec<f32>,
     sub_q: Vec<f32>,
     dropped: u64,
-    /// When recording, a copy of each interleaved L/R output frame is pushed
-    /// here.
+    /// When recording: RX in the left channel, TX audio in the right (or both
+    /// time-multiplexed onto a single channel — see `rec_mono`).
     rec_tap: Option<rtrb::Producer<f32>>,
+    /// Fed from `push`'s `rec_left`/`rec_right`, which the caller builds
+    /// independent of the speaker path's AF volume/mute — see `RxChain::run`.
+    /// Queued separately from `main_q`/`sub_q` so the two can drain at
+    /// different times without one starving the other.
+    rec_main_q: Vec<f32>,
+    rec_sub_q: Vec<f32>,
+    /// Resamples TX audio to `rec_tap`'s rate. `None` if they already match.
+    tx_rec_rs: Option<MonoResampler>,
+    tx_rec_scratch: Vec<f32>,
+    /// False while transmitting, so a full-duplex source's live RX push
+    /// doesn't land in the recording tap alongside `push_tx`'s TX audio.
+    rx_rec_enabled: bool,
+    /// Whether `rec_tap` was opened for a mono recording (one channel) rather
+    /// than stereo (two) — must match what `Recorder::start` configured.
+    rec_mono: bool,
 }
 
 /// Bound on per-channel queueing (≈¼ s at 48 kHz) so a stalled side can't
@@ -520,10 +572,25 @@ const MIXER_CAP: usize = 12_000;
 
 impl StereoMixer {
     fn new(out: rtrb::Producer<f32>) -> Self {
-        StereoMixer { out, main_q: Vec::new(), sub_q: Vec::new(), dropped: 0, rec_tap: None }
+        StereoMixer {
+            out,
+            main_q: Vec::new(),
+            sub_q: Vec::new(),
+            dropped: 0,
+            rec_tap: None,
+            rec_main_q: Vec::new(),
+            rec_sub_q: Vec::new(),
+            tx_rec_rs: None,
+            tx_rec_scratch: Vec::new(),
+            rx_rec_enabled: true,
+            rec_mono: false,
+        }
     }
 
-    fn push(&mut self, left: &[f32], right: Option<&[f32]>) {
+    /// `left`/`right` are the speaker path (post AF-volume/mute); `rec_left`/
+    /// `rec_right` are what the recorder sees instead, so turning down the AF
+    /// knob or hitting mute doesn't touch the archived recording.
+    fn push(&mut self, left: &[f32], right: Option<&[f32]>, rec_left: &[f32], rec_right: Option<&[f32]>) {
         self.main_q.extend_from_slice(left);
         let dual = match right {
             Some(s) => {
@@ -535,20 +602,56 @@ impl StereoMixer {
                 false
             }
         };
+        self.rec_main_q.extend_from_slice(rec_left);
+        let rec_dual = match rec_right {
+            Some(s) => {
+                self.rec_sub_q.extend_from_slice(s);
+                true
+            }
+            None => {
+                self.rec_sub_q.clear();
+                false
+            }
+        };
 
         let n = if dual { self.main_q.len().min(self.sub_q.len()) } else { self.main_q.len() };
-        if n > 0 {
-            // Recording tap: mono downmix of the finished samples, independent of
-            // whether the speaker ring has room (records even during underruns).
-            if let Some(rec) = self.rec_tap.as_mut() {
-                for i in 0..n {
-                    let l = self.main_q[i];
-                    let r = if dual { self.sub_q[i] } else { l };
-                    // Interleaved L/R, the same frames the speakers get.
-                    let _ = rec.push(l); // drop if the recorder stalls
-                    let _ = rec.push(r);
+        let rec_n = if rec_dual {
+            self.rec_main_q.len().min(self.rec_sub_q.len())
+        } else {
+            self.rec_main_q.len()
+        };
+
+        if rec_n > 0 {
+            // Recording tap: RX left, sub receiver (if any) right, silence
+            // otherwise. Suppressed by rx_rec_enabled while transmitting.
+            if self.rx_rec_enabled {
+                if let Some(rec) = self.rec_tap.as_mut() {
+                    let need = if self.rec_mono { 1 } else { 2 };
+                    for i in 0..rec_n {
+                        // Never write a partial frame: a ring with one free
+                        // slot pushing just the left sample would desync
+                        // every following sample by a channel.
+                        if rec.slots() < need {
+                            continue;
+                        }
+                        let l = self.rec_main_q[i];
+                        if self.rec_mono {
+                            let _ = rec.push(l);
+                        } else {
+                            let r = if rec_dual { self.rec_sub_q[i] } else { 0.0 };
+                            let _ = rec.push(l);
+                            let _ = rec.push(r);
+                        }
+                    }
                 }
             }
+            self.rec_main_q.drain(..rec_n);
+            if rec_dual {
+                self.rec_sub_q.drain(..rec_n);
+            }
+        }
+
+        if n > 0 {
             if self.out.slots() >= n * 2 {
                 for i in 0..n {
                     let l = self.main_q[i];
@@ -575,6 +678,44 @@ impl StereoMixer {
         if self.sub_q.len() > MIXER_CAP {
             let cut = self.sub_q.len() - MIXER_CAP;
             self.sub_q.drain(..cut);
+        }
+        if self.rec_main_q.len() > MIXER_CAP {
+            let cut = self.rec_main_q.len() - MIXER_CAP;
+            self.rec_main_q.drain(..cut);
+        }
+        if self.rec_sub_q.len() > MIXER_CAP {
+            let cut = self.rec_sub_q.len() - MIXER_CAP;
+            self.rec_sub_q.drain(..cut);
+        }
+    }
+
+    /// Recording tap for TX audio: right channel, silence in the left (or the
+    /// sole channel in mono). Resampled from `TX_MONITOR_RATE` to match
+    /// `rec_tap`.
+    fn push_tx(&mut self, tx: &[f32]) {
+        if self.rec_tap.is_none() {
+            return;
+        }
+        let samples: &[f32] = match self.tx_rec_rs.as_mut() {
+            Some(rs) => {
+                self.tx_rec_scratch.clear();
+                rs.push(tx, &mut self.tx_rec_scratch);
+                &self.tx_rec_scratch
+            }
+            None => tx,
+        };
+        let rec = self.rec_tap.as_mut().expect("checked above");
+        let need = if self.rec_mono { 1 } else { 2 };
+        for &s in samples {
+            if rec.slots() < need {
+                continue;
+            }
+            if self.rec_mono {
+                let _ = rec.push(s);
+            } else {
+                let _ = rec.push(0.0);
+                let _ = rec.push(s);
+            }
         }
     }
 }
@@ -837,6 +978,11 @@ struct Engine {
     /// Right channel of the main chain, non-empty only while WFM stereo is
     /// decoding and the sub receiver is off.
     main_play_r: Vec<f32>,
+    /// The recorder's copy of this block — see [`RxChain::take_rec_audio`].
+    /// Independent of `main_play`/`main_play_r` once AF volume/mute (and the
+    /// voice-keyer/digital-voice overrides) are applied to those.
+    main_play_rec: Vec<f32>,
+    main_play_r_rec: Vec<f32>,
     /// True while the current over is fed by a TCI client's audio stream.
     tci_tx: bool,
     /// Consecutive short TX blocks this over, for the dead-client unkey.
@@ -854,6 +1000,8 @@ struct Engine {
     /// Scratch real-audio buffers for audio mode.
     audio_re: Vec<f32>,
     audio_play: Vec<f32>,
+    /// The recorder's copy of `audio_play`, pre-volume/mute — see `main_play_rec`.
+    audio_play_rec: Vec<f32>,
     /// Resamples the radio's audio to the speaker rate in audio mode.
     audio_resampler: Option<MonoResampler>,
     /// Rebuilds the IQ source when the operator switches radio interface at
@@ -1095,6 +1243,8 @@ fn engine_thread(
         voice_play: Vec::new(),
         main_play: Vec::new(),
         main_play_r: Vec::new(),
+        main_play_rec: Vec::new(),
+        main_play_r_rec: Vec::new(),
         tci_tx: false,
         tci_tx_starved: 0,
         tci_last_snap: None,
@@ -1103,6 +1253,7 @@ fn engine_thread(
         audio_bw,
         audio_re: Vec::new(),
         audio_play: Vec::new(),
+        audio_play_rec: Vec::new(),
         audio_resampler,
         reopen: engine_cfg.reopen.map(|f| Arc::new(Mutex::new(f))),
         retry: None,
@@ -1405,6 +1556,13 @@ impl Engine {
         if let Some(r) = right {
             self.main_play_r.extend_from_slice(r);
         }
+        self.main_play_rec.clear();
+        self.main_play_r_rec.clear();
+        let (rec_audio, rec_right) = main.take_rec_audio();
+        self.main_play_rec.extend_from_slice(rec_audio);
+        if let Some(r) = rec_right {
+            self.main_play_r_rec.extend_from_slice(r);
+        }
 
         // Feed the digital-mode decoder from the clean tap (not the mixed,
         // possibly-muted output).
@@ -1424,17 +1582,29 @@ impl Engine {
             self.main_play.clear();
             self.main_play.extend_from_slice(&self.voice_prev_out);
             self.main_play_r.clear();
+            // Unscaled in both cases: preview audio was never subject to the
+            // AF knob to begin with.
+            self.main_play_rec.clear();
+            self.main_play_rec.extend_from_slice(&self.voice_prev_out);
+            self.main_play_r_rec.clear();
         } else if self.take_voice_audio(out_rate) {
             let rx0 = &self.state.rx[0];
             let vol = if rx0.muted { 0.0 } else { rx0.volume * rx0.volume };
             self.main_play.clear();
             self.main_play.extend(self.voice_play.iter().map(|s| s * vol));
             self.main_play_r.clear();
+            // Recorder gets the decoded speech unscaled — same reasoning as
+            // the demodulated-audio tap above.
+            self.main_play_rec.clear();
+            self.main_play_rec.extend_from_slice(&self.voice_play);
+            self.main_play_r_rec.clear();
         } else if self.mutes_analog_audio() {
             // Silenced in place rather than dropped: the block still has to
             // reach the mixer to keep the output paced.
             self.main_play.fill(0.0);
             self.main_play_r.fill(0.0);
+            self.main_play_rec.fill(0.0);
+            self.main_play_r_rec.fill(0.0);
         }
 
         let sub_audio: Option<&[f32]> = match (&mut self.sub, self.state.sub_rx_enabled) {
@@ -1455,8 +1625,16 @@ impl Engine {
             None if !self.main_play_r.is_empty() => Some(&self.main_play_r),
             None => None,
         };
+        // The recorder's right channel follows the same priority. The sub
+        // receiver's own volume/mute is left as-is here — its recording tap
+        // isn't what the reviewer's pre-volume concern was about.
+        let rec_right: Option<&[f32]> = match sub_audio {
+            Some(a) => Some(a),
+            None if !self.main_play_r_rec.is_empty() => Some(&self.main_play_r_rec),
+            None => None,
+        };
         if let Some(mixer) = self.mixer.as_mut() {
-            mixer.push(&self.main_play, right);
+            mixer.push(&self.main_play, right, &self.main_play_rec, rec_right);
         }
         // Feed the high-resolution channel spectrum from the DDC output.
         if let (Some(ca), Some(main)) = (self.channel_analyzer.as_mut(), self.main.as_ref()) {
@@ -1582,6 +1760,10 @@ impl Engine {
             Some(rs) => rs.push(&self.audio_re, &mut self.audio_play),
             None => self.audio_play.extend_from_slice(&self.audio_re),
         }
+        // Recorder tap: same signal, without the volume/mute scaling below —
+        // see `RxChain::rec_buf` for why.
+        self.audio_play_rec.clear();
+        self.audio_play_rec.extend_from_slice(&self.audio_play);
         if vol != 1.0 {
             for s in self.audio_play.iter_mut() {
                 *s *= vol;
@@ -1593,14 +1775,19 @@ impl Engine {
         if self.take_preview_audio(self.audio_out_rate, block) {
             self.audio_play.clear();
             self.audio_play.extend_from_slice(&self.voice_prev_out);
+            self.audio_play_rec.clear();
+            self.audio_play_rec.extend_from_slice(&self.voice_prev_out);
         } else if self.take_voice_audio(self.audio_out_rate) {
             self.audio_play.clear();
             self.audio_play.extend(self.voice_play.iter().map(|s| s * vol));
+            self.audio_play_rec.clear();
+            self.audio_play_rec.extend_from_slice(&self.voice_play);
         } else if self.mutes_analog_audio() {
             self.audio_play.fill(0.0);
+            self.audio_play_rec.fill(0.0);
         }
         if let Some(mixer) = self.mixer.as_mut() {
-            mixer.push(&self.audio_play, None);
+            mixer.push(&self.audio_play, None, &self.audio_play_rec, None);
         }
     }
 
@@ -2329,6 +2516,7 @@ impl Engine {
                     self.stop_recording();
                 }
             }
+            SetRecordingMono(on) => self.state.recording_mono = on,
             SetSubRx(on) => {
                 self.state.sub_rx_enabled = on;
                 if on && self.sub.is_none() && self.main.is_some() {
@@ -2859,10 +3047,12 @@ impl Engine {
         let _ = self.event_tx.send(RadioEvent::State(self.state.clone()));
     }
 
-    /// Begin recording the receiver audio to a new MP3 file. The filename
-    /// encodes the UTC date/time, dial frequency and mode; the file lands in the
-    /// user's music directory (or the config dir as a fallback). No-op if already
-    /// recording; reports a [`RadioEvent::Notice`] if it can't start.
+    /// Begin recording both sides of the QSO to a new MP3 file (RX left, TX
+    /// right — or a single mixed channel if `recording_mono` is set). The
+    /// filename encodes the UTC date/time, dial frequency and mode; the file
+    /// lands in the user's music directory (or the config dir as a fallback).
+    /// No-op if already recording; reports a [`RadioEvent::Notice`] if it
+    /// can't start.
     fn start_recording(&mut self) {
         if self.recorder.is_some() {
             return;
@@ -2883,9 +3073,17 @@ impl Engine {
         };
         let name = self.recording_filename();
         let path = dir.join(&name);
-        match Recorder::start(path, self.audio_out_rate) {
+        let channels = if self.state.recording_mono {
+            RecordingChannels::Mono
+        } else {
+            RecordingChannels::Stereo
+        };
+        match Recorder::start(path, self.audio_out_rate, channels) {
             Ok((rec, prod)) => {
-                self.mixer.as_mut().expect("checked above").rec_tap = Some(prod);
+                let mixer = self.mixer.as_mut().expect("checked above");
+                mixer.rec_tap = Some(prod);
+                mixer.rec_mono = self.state.recording_mono;
+                mixer.tx_rec_rs = MonoResampler::new(TX_MONITOR_RATE, self.audio_out_rate);
                 self.recorder = Some(rec);
                 self.state.recording = true;
                 self.state.recording_file = Some(name);
@@ -2901,6 +3099,7 @@ impl Engine {
     fn stop_recording(&mut self) {
         if let Some(mixer) = self.mixer.as_mut() {
             mixer.rec_tap = None; // stop feeding before the worker drains + closes
+            mixer.tx_rec_rs = None;
         }
         if let Some(rec) = self.recorder.take() {
             rec.stop();
@@ -4563,6 +4762,9 @@ impl Engine {
                     }
                     self.tx_center_hz = txf;
                     self.tx_active = true;
+                    if let Some(mixer) = self.mixer.as_mut() {
+                        mixer.rx_rec_enabled = false;
+                    }
                     // Start the TX monitor + the real-time pacer clean (no residue
                     // from a prior burst/over) and drop any stale mic audio so the
                     // feed can't start already behind.
@@ -4578,6 +4780,9 @@ impl Engine {
             }
             self.tx = None;
             self.tx_active = false;
+            if let Some(mixer) = self.mixer.as_mut() {
+                mixer.rx_rec_enabled = true;
+            }
             self.tx_pace = None;
             // Drop the transmit residue so the first receive frames aren't a
             // blend of TX samples and fresh RX.
@@ -4953,6 +5158,22 @@ impl Engine {
             let level = self.state.tx.tune_drive.clamp(0.0, 1.0);
             tx.mod_buf.resize(TX_AUDIO_BLOCK, Complex32::new(level, 0.0));
             self.mic_fifo.clear();
+            // The recording tap has no other source of TX audio during tune —
+            // without this the tap goes quiet for the tune's duration and
+            // drifts out of sync with RX, worse with every tune. Same audible
+            // tone `tx_block_audio`'s tune branch already generates.
+            if let Some(mixer) = self.mixer.as_mut() {
+                let mut tone = [0.0f32; TX_AUDIO_BLOCK];
+                let inc = std::f32::consts::TAU * 1000.0 / TX_MONITOR_RATE as f32;
+                for a in &mut tone {
+                    *a = self.tune_phase.cos() * level;
+                    self.tune_phase += inc;
+                    if self.tune_phase > std::f32::consts::TAU {
+                        self.tune_phase -= std::f32::consts::TAU;
+                    }
+                }
+                mixer.push_tx(&tone);
+            }
         } else {
             let mut audio = [0.0f32; TX_AUDIO_BLOCK];
             let take = self.mic_fifo.len().min(TX_AUDIO_BLOCK);
@@ -4964,6 +5185,9 @@ impl Engine {
             let mic_gain = if tci_tx { 1.0 } else { self.state.tx.mic_gain * 2.0 };
             for a in &mut audio {
                 *a = tx.dc.run(*a) * mic_gain;
+            }
+            if let Some(mixer) = self.mixer.as_mut() {
+                mixer.push_tx(&audio);
             }
             let modulator = tx.modulator.as_mut().expect("checked above");
             modulator.process(&audio, &mut tx.mod_buf);
@@ -5011,6 +5235,9 @@ impl Engine {
             Some(d) => d.fill_tx_block(&mut audio),
             None => true,
         };
+        if let Some(mixer) = self.mixer.as_mut() {
+            mixer.push_tx(&audio);
+        }
 
         tx.mod_buf.clear();
         // Every mode that reaches here rides single sideband, so the chain has
@@ -5136,6 +5363,10 @@ impl Engine {
         self.tx_mon_buf.clear();
         self.tx_mon_buf.extend(audio.iter().map(|&a| Complex32::new(a, 0.0)));
         self.tx_analyzer.process(&self.tx_mon_buf);
+
+        if let Some(mixer) = self.mixer.as_mut() {
+            mixer.push_tx(&audio);
+        }
 
         self.source.tx_write_audio(&audio)?;
 

--- a/crates/sdroxide-radio/src/recorder.rs
+++ b/crates/sdroxide-radio/src/recorder.rs
@@ -1,15 +1,14 @@
-//! Off-thread MP3 recorder for the receiver audio.
+//! Off-thread MP3 recorder for a QSO: RX in the left channel, TX in the right
+//! — or, in mono mode, both time-multiplexed onto a single channel.
 //!
-//! The engine's audio loop pushes interleaved L/R frames straight off the
-//! stereo mixer into a lock-free ring; a dedicated thread drains it, resamples
-//! to 48 kHz, and encodes to MP3 with the pure-Rust `shine_rs` encoder, writing
+//! The engine's audio loop pushes interleaved frames straight off the stereo
+//! mixer into a lock-free ring; a dedicated thread drains it, resamples to
+//! 48 kHz, and encodes to MP3 with the pure-Rust `shine_rs` encoder, writing
 //! to the file. Encoding and file I/O never touch the real-time audio thread.
 //!
-//! Always two channels, in every mode. Joint stereo costs almost nothing when
-//! the two are identical (which is the usual case — a mono demod duplicated to
-//! both ears), and recording a fixed channel count means WFM stereo coming and
-//! going, or the sub receiver being switched on, never has to reinitialise the
-//! encoder mid-file.
+//! A fixed channel count for the life of the recording (chosen at
+//! [`Recorder::start`]), so WFM stereo coming and going, or the sub receiver
+//! being switched on, never has to reinitialise the encoder mid-file.
 
 use std::fs::File;
 use std::io::{BufWriter, Write};
@@ -26,17 +25,43 @@ use shine_rs::encoder::{
 };
 use tracing::{info, warn};
 
-use sdroxide_dsp::StereoResampler;
+use sdroxide_dsp::{MonoResampler, StereoResampler};
 
 /// MP3 encode target — a universally-valid MPEG-1 Layer III rate.
 const MP3_RATE: i32 = 48_000;
-/// Constant bitrate (kbps). Ample for two channels of communications audio,
-/// and joint stereo spends almost none of it when L and R are identical.
+/// Constant bitrate (kbps). Ample for communications audio, and joint stereo
+/// spends almost none of it when L and R are identical.
 const MP3_BITRATE: i32 = 192;
 /// shine channel mode MPG_MD_JOINT_STEREO.
 const MODE_JOINT_STEREO: i32 = 1;
-/// Interleaved channels per frame.
-const CHANNELS: usize = 2;
+/// shine channel mode MPG_MD_MONO.
+const MODE_MONO: i32 = 3;
+
+/// How many interleaved channels a recording carries.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RecordingChannels {
+    /// RX in the left channel, TX in the right.
+    Stereo,
+    /// RX and TX time-multiplexed onto a single channel — for RX-only
+    /// listening, or anyone who doesn't want split-ear audio.
+    Mono,
+}
+
+impl RecordingChannels {
+    fn count(self) -> usize {
+        match self {
+            RecordingChannels::Stereo => 2,
+            RecordingChannels::Mono => 1,
+        }
+    }
+
+    fn shine_mode(self) -> i32 {
+        match self {
+            RecordingChannels::Stereo => MODE_JOINT_STEREO,
+            RecordingChannels::Mono => MODE_MONO,
+        }
+    }
+}
 
 /// A running recording. Feed it through the paired [`Producer`] (held by the
 /// mixer); drop-finalize by calling [`Recorder::stop`].
@@ -48,21 +73,25 @@ pub struct Recorder {
 }
 
 impl Recorder {
-    /// Start recording interleaved stereo audio arriving at `in_rate` Hz per
-    /// channel to `path`. Returns the recorder plus the producer the caller
-    /// feeds L/R frames into. Fails only if the file can't be created (encoder
-    /// setup happens on the worker thread).
-    pub fn start(path: PathBuf, in_rate: f64) -> std::io::Result<(Recorder, Producer<f32>)> {
+    /// Start recording interleaved audio arriving at `in_rate` Hz per channel
+    /// to `path`, with `channels` interleaved channels per frame. Returns the
+    /// recorder plus the producer the caller feeds frames into. Fails only if
+    /// the file can't be created (encoder setup happens on the worker thread).
+    pub fn start(
+        path: PathBuf,
+        in_rate: f64,
+        channels: RecordingChannels,
+    ) -> std::io::Result<(Recorder, Producer<f32>)> {
         let file = File::create(&path)?;
         // ~4 s of slack so a brief disk stall drops nothing.
-        let cap = (in_rate as usize).max(MP3_RATE as usize) * 4 * CHANNELS;
+        let cap = (in_rate as usize).max(MP3_RATE as usize) * 4 * channels.count();
         let (prod, cons) = RingBuffer::<f32>::new(cap);
         let stop = Arc::new(AtomicBool::new(false));
         let stop_worker = stop.clone();
         let path_worker = path.clone();
         let join = std::thread::Builder::new()
             .name("mp3-recorder".into())
-            .spawn(move || encode_loop(cons, file, in_rate, stop_worker, path_worker))
+            .spawn(move || encode_loop(cons, file, in_rate, channels, stop_worker, path_worker))
             .expect("spawn recorder thread");
         info!(path = %path.display(), "recording started");
         Ok((Recorder { stop, join: Some(join), path }, prod))
@@ -83,13 +112,15 @@ fn encode_loop(
     mut cons: Consumer<f32>,
     file: File,
     in_rate: f64,
+    channels: RecordingChannels,
     stop: Arc<AtomicBool>,
     path: PathBuf,
 ) {
+    let ch = channels.count();
     let cfg = ShineConfig {
-        wave: ShineWave { channels: CHANNELS as i32, samplerate: MP3_RATE },
+        wave: ShineWave { channels: ch as i32, samplerate: MP3_RATE },
         mpeg: ShineMpeg {
-            mode: MODE_JOINT_STEREO,
+            mode: channels.shine_mode(),
             bitr: MP3_BITRATE,
             emph: 0,
             copyright: 0,
@@ -106,10 +137,13 @@ fn encode_loop(
     let spp = shine_samples_per_pass(&enc) as usize; // samples per channel per frame
 
     let mut file = BufWriter::new(file);
-    let mut resampler = StereoResampler::new(in_rate, MP3_RATE as f64);
+    // Exactly one of these is live, matching `ch`; `None` when the rates
+    // already match (see `StereoResampler`/`MonoResampler::new`).
+    let mut stereo_rs = (ch == 2).then(|| StereoResampler::new(in_rate, MP3_RATE as f64)).flatten();
+    let mut mono_rs = (ch == 1).then(|| MonoResampler::new(in_rate, MP3_RATE as f64)).flatten();
     let mut drained: Vec<f32> = Vec::new();
     let mut resampled: Vec<f32> = Vec::new();
-    let mut pending: Vec<f32> = Vec::new(); // 48 kHz interleaved L/R awaiting a frame
+    let mut pending: Vec<f32> = Vec::new(); // 48 kHz interleaved, awaiting a frame
     // shine takes one pointer per channel, so the frame is de-interleaved here.
     let mut pcm_l = vec![0i16; spp];
     let mut pcm_r = vec![0i16; spp];
@@ -126,38 +160,29 @@ fn encode_loop(
             std::thread::sleep(Duration::from_millis(5));
             continue;
         }
-        match resampler.as_mut() {
-            Some(r) => {
+        match (stereo_rs.as_mut(), mono_rs.as_mut()) {
+            (Some(r), _) => {
                 resampled.clear();
                 r.push(&drained, &mut resampled);
                 pending.extend_from_slice(&resampled);
             }
-            None => pending.extend_from_slice(&drained),
+            (None, Some(r)) => {
+                resampled.clear();
+                r.push(&drained, &mut resampled);
+                pending.extend_from_slice(&resampled);
+            }
+            (None, None) => pending.extend_from_slice(&drained),
         }
-        while pending.len() >= spp * CHANNELS {
-            encode_frame(
-                &mut file,
-                &mut enc,
-                &pending[..spp * CHANNELS],
-                &mut pcm_l,
-                &mut pcm_r,
-                &path,
-            );
-            pending.drain(..spp * CHANNELS);
+        while pending.len() >= spp * ch {
+            encode_frame(&mut file, &mut enc, &pending[..spp * ch], ch, &mut pcm_l, &mut pcm_r, &path);
+            pending.drain(..spp * ch);
         }
     }
 
     // Final partial frame (zero-padded) so no tail is dropped, then flush.
     if !pending.is_empty() {
-        pending.resize(spp * CHANNELS, 0.0);
-        encode_frame(
-            &mut file,
-            &mut enc,
-            &pending[..spp * CHANNELS],
-            &mut pcm_l,
-            &mut pcm_r,
-            &path,
-        );
+        pending.resize(spp * ch, 0.0);
+        encode_frame(&mut file, &mut enc, &pending[..spp * ch], ch, &mut pcm_l, &mut pcm_r, &path);
     }
     let (tail, n) = shine_flush(&mut enc);
     if n > 0 {
@@ -167,21 +192,30 @@ fn encode_loop(
     shine_close(enc);
 }
 
-/// De-interleave one frame of f32 L/R into per-channel i16 and encode it,
-/// writing the MP3 bytes.
+/// De-interleave one frame of f32 samples into per-channel i16 and encode it,
+/// writing the MP3 bytes. `pcm_r` is unused (but still sized) when `channels == 1`.
 fn encode_frame(
     file: &mut BufWriter<File>,
     enc: &mut shine_rs::ShineGlobalConfig,
     frame: &[f32],
+    channels: usize,
     pcm_l: &mut [i16],
     pcm_r: &mut [i16],
     path: &std::path::Path,
 ) {
-    for (i, lr) in frame.chunks_exact(CHANNELS).enumerate() {
-        pcm_l[i] = (lr[0].clamp(-1.0, 1.0) * 32767.0) as i16;
-        pcm_r[i] = (lr[1].clamp(-1.0, 1.0) * 32767.0) as i16;
-    }
-    match shine_encode_buffer(enc, &[pcm_l.as_ptr(), pcm_r.as_ptr()]) {
+    let result = if channels == 2 {
+        for (i, lr) in frame.chunks_exact(2).enumerate() {
+            pcm_l[i] = (lr[0].clamp(-1.0, 1.0) * 32767.0) as i16;
+            pcm_r[i] = (lr[1].clamp(-1.0, 1.0) * 32767.0) as i16;
+        }
+        shine_encode_buffer(enc, &[pcm_l.as_ptr(), pcm_r.as_ptr()])
+    } else {
+        for (i, &s) in frame.iter().enumerate() {
+            pcm_l[i] = (s.clamp(-1.0, 1.0) * 32767.0) as i16;
+        }
+        shine_encode_buffer(enc, &[pcm_l.as_ptr()])
+    };
+    match result {
         Ok((mp3, n)) => {
             if n > 0 {
                 if let Err(e) = file.write_all(mp3) {
@@ -203,7 +237,9 @@ mod tests {
         let path =
             std::env::temp_dir().join(format!("sdroxide-rec-test-{}.mp3", std::process::id()));
         let _ = std::fs::remove_file(&path);
-        let (rec, mut prod) = Recorder::start(path.clone(), 48_000.0).expect("start recorder");
+        let (rec, mut prod) =
+            Recorder::start(path.clone(), 48_000.0, RecordingChannels::Stereo)
+                .expect("start recorder");
 
         // ~1 s at 48 kHz: 1 kHz in the left ear, 400 Hz in the right, so the
         // two channels are genuinely different, fed as it drains.
@@ -224,6 +260,31 @@ mod tests {
         let _ = std::fs::remove_file(&path);
         assert!(bytes.len() > 2_000, "mp3 suspiciously small: {} bytes", bytes.len());
         // First frame must start with an 11-bit MPEG sync word (0xFFE..).
+        assert_eq!(bytes[0], 0xFF, "no MP3 frame sync");
+        assert_eq!(bytes[1] & 0xE0, 0xE0, "no MP3 frame sync in byte 1");
+    }
+
+    #[test]
+    fn records_a_valid_mono_mp3() {
+        let path = std::env::temp_dir()
+            .join(format!("sdroxide-rec-test-mono-{}.mp3", std::process::id()));
+        let _ = std::fs::remove_file(&path);
+        let (rec, mut prod) = Recorder::start(path.clone(), 48_000.0, RecordingChannels::Mono)
+            .expect("start recorder");
+
+        for i in 0..48_000 {
+            let t = i as f32 / 48_000.0;
+            let s = 0.5 * (std::f32::consts::TAU * 1000.0 * t).sin();
+            while prod.push(s).is_err() {
+                std::thread::sleep(Duration::from_millis(1));
+            }
+        }
+        std::thread::sleep(Duration::from_millis(100));
+        rec.stop();
+
+        let bytes = std::fs::read(&path).expect("read mp3");
+        let _ = std::fs::remove_file(&path);
+        assert!(bytes.len() > 1_000, "mp3 suspiciously small: {} bytes", bytes.len());
         assert_eq!(bytes[0], 0xFF, "no MP3 frame sync");
         assert_eq!(bytes[1] & 0xE0, 0xE0, "no MP3 frame sync in byte 1");
     }

--- a/crates/sdroxide-types/src/command.rs
+++ b/crates/sdroxide-types/src/command.rs
@@ -84,10 +84,15 @@ pub enum Command {
         enabled: bool,
         hz: i32,
     },
-    /// Start (`true`) or stop (`false`) recording the receiver audio to an MP3
-    /// file. The engine names the file (date/time/frequency/mode) and stores it
-    /// in the user's music directory (or the config dir as a fallback).
+    /// Start (`true`) or stop (`false`) recording both sides of the QSO (RX
+    /// left, TX right) to an MP3 file. The engine names the file (date/time/
+    /// frequency/mode) and stores it in the user's music directory (or the
+    /// config dir as a fallback).
     SetRecording(bool),
+    /// Whether the *next* recording mixes RX/TX down to a single channel
+    /// instead of splitting them left/right. No effect on a recording already
+    /// in progress.
+    SetRecordingMono(bool),
 
     // Transmit
     SetPtt(bool),

--- a/crates/sdroxide-types/src/state.rs
+++ b/crates/sdroxide-types/src/state.rs
@@ -167,6 +167,12 @@ pub struct RadioState {
     /// when not recording.
     #[serde(default)]
     pub recording_file: Option<String>,
+    /// Mix both sides down to a single channel instead of RX left / TX right —
+    /// for RX-only listening, or anyone who doesn't want split-ear audio.
+    /// Takes effect on the next `SetRecording(true)`, not on an already-running
+    /// recording.
+    #[serde(default)]
+    pub recording_mono: bool,
     /// The engine will key outside the amateur bands.
     ///
     /// Set by the `--oob-tx` command-line flag, never by anything in the UI:
@@ -207,6 +213,7 @@ impl Default for RadioState {
             antenna_tx: String::new(),
             recording: false,
             recording_file: None,
+            recording_mono: false,
             oob_tx: false,
         }
     }

--- a/crates/sdroxide-ui/src/app/top_bar.rs
+++ b/crates/sdroxide-ui/src/app/top_bar.rs
@@ -844,7 +844,7 @@ impl SdroxideApp {
             {
                 cmds.push(Command::SetMute { rx: RxId::Main, muted: !muted });
             }
-            // Record receiver audio to an MP3 file (toggling).
+            // Record both sides of the QSO to an MP3 file (toggling).
             let recording = self.state.recording;
             let rec = crate::chrome::chip_accent(
                 ui,
@@ -855,10 +855,32 @@ impl SdroxideApp {
             )
             .on_hover_text(match &self.state.recording_file {
                 Some(f) => format!("Recording to {f} — click to stop"),
-                None => "Record receiver audio to MP3".to_string(),
+                None => "Record RX (left) and TX (right) audio to MP3".to_string(),
             });
             if rec.clicked() {
                 cmds.push(Command::SetRecording(!recording));
+            }
+            // Channel layout for the *next* recording — has no effect on one
+            // already running, hence the disabled look while `recording`.
+            let mono = self.state.recording_mono;
+            let mono_chip = ui
+                .add_enabled_ui(!recording, |ui| {
+                    crate::chrome::chip_accent(
+                        ui,
+                        mono,
+                        "MONO",
+                        crate::theme::PINK,
+                        Color32::WHITE,
+                    )
+                })
+                .inner
+                .on_hover_text(if mono {
+                    "Recording mixes RX/TX to one channel — click for RX left / TX right"
+                } else {
+                    "Recording splits RX left / TX right — click for a single mixed channel"
+                });
+            if mono_chip.clicked() {
+                cmds.push(Command::SetRecordingMono(!mono));
             }
             // WFM broadcast stereo: lit while a 19 kHz pilot is locked,
             // click to force mono. Only WFM has a pilot to find.


### PR DESCRIPTION
I was trying to record both sides of the QSO (RX on the left channel, TX on the right channel) when I noticed that, for a very brief period, on unkey, I heard back part of my transmission as fallback audio. 

I did a screen recording of a QSO where the unkey bug shows clearly: https://www.youtube.com/watch?v=1lBMSVBbU8o


So this PR addresses both things; just let me know if you prefer two separate pull requests to address each thing separately.

Audio recording looks like the following:

<img width="1373" height="388" alt="image" src="https://github.com/user-attachments/assets/8bb937bc-81ed-40ca-b0ad-b9ec5c8e3fb2" />
