### PR TITLE
radio: discard stale RX backlog on unkey across all backends

### DIFF
--- a/crates/sdroxide-hpsdr/src/net.rs
+++ b/crates/sdroxide-hpsdr/src/net.rs
@@ -630,6 +630,13 @@ impl HpsdrHandle {
         }
         n
     }
+
+    /// Drop whatever the network thread queued in the RX ring. The radio
+    /// keeps streaming I/Q for the whole over, so `rx_read` would otherwise
+    /// replay a stale backlog after `tx_end`.
+    pub fn discard_pending_rx(&mut self) {
+        while self.rx.pop().is_ok() {}
+    }
 }
 
 impl Drop for HpsdrHandle {

--- a/crates/sdroxide-radio/src/device.rs
+++ b/crates/sdroxide-radio/src/device.rs
@@ -510,6 +510,26 @@ impl IqSource for SoapyRxSource {
         Ok(())
     }
 
+    /// On full-duplex hardware the RX stream stays active for the whole over,
+    /// so the driver keeps buffering internally; flush it with zero-timeout
+    /// reads so the first post-TX block isn't a stale backlog. Half-duplex
+    /// hardware already gets a fresh, empty stream from `tx_end` above.
+    fn discard_pending_rx(&mut self) {
+        if !self.caps.full_duplex {
+            return;
+        }
+        let Some(stream) = self.rx_stream.as_mut() else { return };
+        let mut scratch = [Complex32::new(0.0, 0.0); 4096];
+        // Bounded: a driver that never reports empty must not spin forever.
+        for _ in 0..64 {
+            match stream.read(&mut [&mut scratch], 0) {
+                Ok(0) => break,
+                Ok(_) => continue,
+                Err(_) => break,
+            }
+        }
+    }
+
     fn set_tx_gain_element(&mut self, name: &str, db: f64) -> Result<()> {
         self.dev()?.set_gain_element(Direction::Tx, self.channel, name, db)?;
         remember_gain(&mut self.tx_gains, name, db);

--- a/crates/sdroxide-radio/src/engine.rs
+++ b/crates/sdroxide-radio/src/engine.rs
@@ -4576,6 +4576,10 @@ impl Engine {
             if let Err(e) = self.source.tx_end() {
                 warn!("tx_end: {e}");
             }
+            // The radio kept streaming RX for the whole over; PTT only
+            // stopped us polling it. Drop the backlog instead of replaying
+            // it as fresh RX on the next read.
+            self.source.discard_pending_rx();
             self.tx = None;
             self.tx_active = false;
             self.tx_pace = None;

--- a/crates/sdroxide-radio/src/source.rs
+++ b/crates/sdroxide-radio/src/source.rs
@@ -93,6 +93,10 @@ pub trait IqSource: Send {
     fn tx_end(&mut self) -> Result<()> {
         Ok(())
     }
+    /// Discard any RX samples buffered while transmitting, so the first read
+    /// after [`Self::tx_end`] returns fresh data instead of a stale backlog.
+    /// Default no-op: most sources have no such buffer.
+    fn discard_pending_rx(&mut self) {}
     fn set_tx_gain_element(&mut self, _name: &str, _db: f64) -> Result<()> {
         Ok(())
     }

--- a/crates/sdroxide-smartsdr/src/net.rs
+++ b/crates/sdroxide-smartsdr/src/net.rs
@@ -445,6 +445,13 @@ impl FlexHandle {
         n
     }
 
+    /// Drop whatever the network thread queued in the RX ring. The radio
+    /// keeps streaming I/Q for the whole over, so `rx_read` would otherwise
+    /// replay a stale backlog after `tx_end`.
+    pub fn discard_pending_rx(&mut self) {
+        while self.rx.pop().is_ok() {}
+    }
+
     /// Drain changes the operator made on the radio.
     pub fn poll_updates(&self) -> Vec<FlexUpdate> {
         self.updates.try_iter().collect()

--- a/crates/sdroxide-tci/src/net.rs
+++ b/crates/sdroxide-tci/src/net.rs
@@ -293,6 +293,13 @@ impl TciHandle {
         n
     }
 
+    /// Drop whatever the network thread queued in the RX ring. The rig keeps
+    /// streaming I/Q for the whole over, so `rx_read` would otherwise replay
+    /// a stale backlog after `tx_end`.
+    pub fn discard_pending_rx(&mut self) {
+        while self.rx.pop().is_ok() {}
+    }
+
     /// Drain any rig-reported frequency/mode changes.
     pub fn poll_updates(&self) -> Vec<TciUpdate> {
         self.updates.try_iter().collect()

--- a/src/audio_cat_source.rs
+++ b/src/audio_cat_source.rs
@@ -312,6 +312,11 @@ impl IqSource for AudioCatSource {
         Ok(())
     }
 
+    fn discard_pending_rx(&mut self) {
+        // The capture callback keeps filling this ring during TX too.
+        while self.in_consumer.pop().is_ok() {}
+    }
+
     fn tx_telemetry(&mut self) -> Option<TxTelemetry> {
         // The CI-V thread polls SWR at ~5 Hz; latch its latest reading so the
         // engine's 100 ms meter tick always has a value to show.

--- a/src/hpsdr_source.rs
+++ b/src/hpsdr_source.rs
@@ -162,4 +162,8 @@ impl IqSource for HpsdrSource {
         self.handle.tx_end();
         Ok(())
     }
+
+    fn discard_pending_rx(&mut self) {
+        self.handle.discard_pending_rx();
+    }
 }

--- a/src/smartsdr_source.rs
+++ b/src/smartsdr_source.rs
@@ -219,6 +219,10 @@ impl IqSource for SmartSdrSource {
         Ok(())
     }
 
+    fn discard_pending_rx(&mut self) {
+        self.handle.discard_pending_rx();
+    }
+
     fn tx_telemetry(&mut self) -> Option<TxTelemetry> {
         if let Some(t) = self.handle.poll_telemetry() {
             self.last_telem = Some(t);

--- a/src/tci_source.rs
+++ b/src/tci_source.rs
@@ -124,6 +124,10 @@ impl IqSource for TciSource {
         Ok(())
     }
 
+    fn discard_pending_rx(&mut self) {
+        self.handle.discard_pending_rx();
+    }
+
     fn tx_telemetry(&mut self) -> Option<TxTelemetry> {
         if let Some(t) = self.handle.poll_telemetry() {
             self.last_telem = Some(t);


### PR DESCRIPTION
Extends the discard_pending_rx fix from HPSDR/TCI/audio-CAT to SmartSDR and full-duplex SoapySDR sources, so pressing unkey never briefly replays the operator's own TX audio as RX on any backend.