### PR TITLE
modulator: follow rx filter for tx passband

### DIFF
--- a/crates/sdroxide-digi/examples/rifp_iq.rs
+++ b/crates/sdroxide-digi/examples/rifp_iq.rs
@@ -66,7 +66,8 @@ fn send(args: &[String]) -> Result<(), Box<dyn std::error::Error>> {
 
     let mut tx = RifpController::new(cfg, RATE);
     tx.set_rifp_image(img.into_raw(), w, h);
-    let mut modulator = make_modulator(Mode::Rifp, RATE).ok_or("no RIFP modulator")?;
+    let mut modulator =
+        make_modulator(Mode::Rifp, RATE, Mode::Rifp.default_filter()).ok_or("no RIFP modulator")?;
 
     let mut out: Vec<u8> = Vec::new();
     let mut symbols = [0.0f32; BLOCK];

--- a/crates/sdroxide-digi/src/rifp_controller.rs
+++ b/crates/sdroxide-digi/src/rifp_controller.rs
@@ -972,7 +972,8 @@ mod tests {
         let mut tx = RifpController::new(cfg.clone(), OUT_RATE);
         tx.set_rifp_image(rgb.clone(), w, h);
         let mut modulator =
-            sdroxide_dsp::make_modulator(Mode::Rifp, OUT_RATE).expect("RIFP modulator");
+            sdroxide_dsp::make_modulator(Mode::Rifp, OUT_RATE, Mode::Rifp.default_filter())
+                .expect("RIFP modulator");
         let mut demod = sdroxide_dsp::make_demod(Mode::Rifp, OUT_RATE).expect("RIFP demodulator");
         let mut rx = RifpController::new(cfg, OUT_RATE);
 

--- a/crates/sdroxide-dsp/src/modulator.rs
+++ b/crates/sdroxide-dsp/src/modulator.rs
@@ -10,13 +10,24 @@ const TX_TAPS: usize = 331;
 pub trait Modulator: Send {
     /// Consume audio, append complex baseband samples (same rate).
     fn process(&mut self, audio: &[f32], out: &mut Vec<Complex32>);
+
+    /// Retune the transmit passband. No-op for modulators with a fixed
+    /// bandwidth (AM, FM, CW, RIFP).
+    fn set_filter(&mut self, _lo_hz: f32, _hi_hz: f32) {}
 }
 
 /// Modulator for a mode. `None` = the mode has no audio-driven transmit (SPEC,
 /// WFM broadcast, and CW) — the engine transmits a plain carrier for those when
 /// keyed.
-pub fn make_modulator(mode: Mode, rate: f64) -> Option<Box<dyn Modulator>> {
-    let (lo, hi) = mode.default_filter();
+///
+/// `passband` is the SSB filter's band-pass edges for plain voice (USB/LSB),
+/// so transmit bandwidth follows the operator's receive filter. Other modes
+/// ignore it and use their own fixed passband.
+pub fn make_modulator(mode: Mode, rate: f64, passband: (f32, f32)) -> Option<Box<dyn Modulator>> {
+    let (lo, hi) = match mode {
+        Mode::Lsb | Mode::Usb => passband,
+        _ => mode.default_filter(),
+    };
     match mode {
         // FT8/FT4 modulate as USB: the synthesized 12 kHz audio (resampled to
         // 48 k, injected as "mic") is USB-modulated exactly like a real radio.
@@ -57,6 +68,7 @@ pub fn make_modulator(mode: Mode, rate: f64) -> Option<Box<dyn Modulator>> {
 pub struct SsbMod {
     fir: ComplexFir,
     complex_in: Vec<Complex32>,
+    rate: f64,
 }
 
 impl SsbMod {
@@ -64,6 +76,7 @@ impl SsbMod {
         SsbMod {
             fir: ComplexFir::new(bandpass_taps(TX_TAPS, lo as f64, hi as f64, rate)),
             complex_in: Vec::new(),
+            rate,
         }
     }
 }
@@ -78,6 +91,10 @@ impl Modulator for SsbMod {
         for z in &mut out[before..] {
             *z *= 2.0;
         }
+    }
+
+    fn set_filter(&mut self, lo_hz: f32, hi_hz: f32) {
+        self.fir.set_taps(bandpass_taps(TX_TAPS, lo_hz as f64, hi_hz as f64, self.rate));
     }
 }
 

--- a/crates/sdroxide-dsp/tests/chain.rs
+++ b/crates/sdroxide-dsp/tests/chain.rs
@@ -177,7 +177,7 @@ fn wfm_demod_recovers_tone_without_dc() {
 #[test]
 fn ssb_modulator_places_single_sideband() {
     let rate = 48_000.0;
-    let mut m = make_modulator(Mode::Usb, rate).unwrap();
+    let mut m = make_modulator(Mode::Usb, rate, Mode::Usb.default_filter()).unwrap();
     let audio: Vec<f32> = (0..48_000)
         .map(|i| (std::f64::consts::TAU * 1_000.0 * i as f64 / rate).sin() as f32)
         .collect();
@@ -190,7 +190,7 @@ fn ssb_modulator_places_single_sideband() {
     let f = mean_freq(tail, rate);
     assert!((f - 1_000.0).abs() < 5.0, "USB tone at {f} Hz");
 
-    let mut m = make_modulator(Mode::Lsb, rate).unwrap();
+    let mut m = make_modulator(Mode::Lsb, rate, Mode::Lsb.default_filter()).unwrap();
     let mut out = Vec::new();
     for chunk in audio.chunks(1024) {
         m.process(chunk, &mut out);
@@ -203,7 +203,7 @@ fn ssb_modulator_places_single_sideband() {
 #[test]
 fn ssb_tx_rx_loopback() {
     let rate = 48_000.0;
-    let mut m = make_modulator(Mode::Usb, rate).unwrap();
+    let mut m = make_modulator(Mode::Usb, rate, Mode::Usb.default_filter()).unwrap();
     let mut d = make_demod(Mode::Usb, rate).unwrap();
     let audio: Vec<f32> = (0..48_000)
         .map(|i| 0.5 * (std::f64::consts::TAU * 1_500.0 * i as f64 / rate).sin() as f32)

--- a/crates/sdroxide-radio/src/engine.rs
+++ b/crates/sdroxide-radio/src/engine.rs
@@ -946,9 +946,9 @@ fn utc_civil(secs: u64) -> (i64, u32, u32, u32, u32, u32) {
 }
 
 impl TxChain {
-    fn new(mode: Mode, tx_rate: f64) -> Self {
+    fn new(mode: Mode, tx_rate: f64, passband: (f32, f32)) -> Self {
         TxChain {
-            modulator: make_modulator(mode, 48_000.0),
+            modulator: make_modulator(mode, 48_000.0, passband),
             dc: DcBlock::new(100.0, 48_000.0),
             duc: Duc::new(48_000.0, tx_rate),
             tx_rate,
@@ -2799,6 +2799,20 @@ impl Engine {
                 (r.filter_lo, r.filter_hi) = (lo, hi);
                 if let Some(d) = self.chain_mut(rx).and_then(|c| c.demod.as_mut()) {
                     d.set_filter(lo, hi);
+                }
+                // The main receiver's filter is also the transmit passband.
+                // Retune it live, mid-over, rather than at the next PTT. An
+                // inverting transponder flips the sideband, which mirrors the
+                // filter edges the same way `tx_begin` does.
+                if rx == RxId::Main {
+                    let inverting = self
+                        .sat_lock
+                        .as_ref()
+                        .is_some_and(|l| l.cfg.uplink.is_some_and(|u| u.inverting));
+                    let (lo, hi) = if inverting { (-hi, -lo) } else { (lo, hi) };
+                    if let Some(m) = self.tx.as_mut().and_then(|tx| tx.modulator.as_mut()) {
+                        m.set_filter(lo, hi);
+                    }
                 }
             }
             SetAgc { rx, agc } => {
@@ -5673,7 +5687,8 @@ impl Engine {
                         // Across an inverting transponder the sideband flips:
                         // transmit LSB to come out of the downlink as the USB
                         // it is being listened to on.
-                        let mut mode = self.state.rx[0].mode;
+                        let rx0 = &self.state.rx[0];
+                        let mut mode = rx0.mode;
                         let inverting = self
                             .sat_lock
                             .as_ref()
@@ -5685,7 +5700,15 @@ impl Engine {
                                 m => m,
                             };
                         }
-                        self.tx = Some(TxChain::new(mode, tx_rate));
+                        // A flipped sideband also mirrors the filter edges:
+                        // USB's positive Hz-from-carrier range becomes LSB's
+                        // negative one (and back), keeping the same width.
+                        let passband = if inverting {
+                            (-rx0.filter_hi, -rx0.filter_lo)
+                        } else {
+                            (rx0.filter_lo, rx0.filter_hi)
+                        };
+                        self.tx = Some(TxChain::new(mode, tx_rate, passband));
                     }
                     self.tx_center_hz = txf;
                     // Seed the TX-side Doppler NCO before the first block goes


### PR DESCRIPTION
it seems like the TX passband bandwidth was around 2.7 kHz for SSB (technically, (150.0, 2850.0)). now one can change the TX filter following the RX filter but also by moving the passband during TX.