### PR TITLE
hpsdr: add configurable transmit-buffer cushion for lossy links

### DIFF
--- a/crates/sdroxide-radio/src/engine.rs
+++ b/crates/sdroxide-radio/src/engine.rs
@@ -951,16 +951,15 @@ const TX_MON_HEADROOM_DB: f32 = -30.0;
 /// backpressure, but only *once the ring is full* — that is the latency. This
 /// caps the feed AT real time (never slower: `checked_sub` yields no sleep when
 /// we're already behind), so it can only *reduce* buffering, never starve a
-/// consumer that was keeping up. A few-block head-start leaves a small cushion
-/// against jitter/clock drift before pacing engages.
-fn pace_tx_block(tx_pace: &mut Option<(Instant, u64)>) {
-    /// ~30 ms of slack fed out before pacing kicks in, so the hardware/network
-    /// consumer has a buffer and never underruns on scheduling jitter or a
-    /// consumer clock slightly faster than nominal 48 kHz.
-    const CUSHION: u64 = 3 * TX_AUDIO_BLOCK as u64;
+/// consumer that was keeping up. A head-start of `cushion_ms` is fed out before
+/// pacing engages, so the hardware/network consumer downstream has that much
+/// slack against jitter or a consumer clock slightly faster than nominal
+/// 48 kHz — see [`IqSource::tx_pace_cushion_ms`].
+fn pace_tx_block(tx_pace: &mut Option<(Instant, u64)>, cushion_ms: f64) {
+    let cushion = (cushion_ms.max(0.0) / 1000.0 * TX_MONITOR_RATE) as u64;
     let (start, fed) = tx_pace.get_or_insert_with(|| (Instant::now(), 0));
     *fed += TX_AUDIO_BLOCK as u64;
-    let paced = fed.saturating_sub(CUSHION);
+    let paced = fed.saturating_sub(cushion);
     let target = Duration::from_secs_f64(paced as f64 / TX_MONITOR_RATE);
     if let Some(d) = target.checked_sub(start.elapsed()) {
         std::thread::sleep(d);
@@ -6655,7 +6654,7 @@ impl Engine {
         }
         // Keep the device/network TX ring near-empty (HPSDR ≈ 0.5 s, SoapySDR
         // varies) rather than letting a fast loop fill it and delay the signal.
-        pace_tx_block(&mut self.tx_pace);
+        pace_tx_block(&mut self.tx_pace, self.source.tx_pace_cushion_ms());
         Ok(())
     }
 
@@ -6716,7 +6715,7 @@ impl Engine {
         }
         // Pace the burst to real time so it isn't raced into the device ring
         // (which would drop PTT early — the tail matters for FT8 decode).
-        pace_tx_block(&mut self.tx_pace);
+        pace_tx_block(&mut self.tx_pace, self.source.tx_pace_cushion_ms());
 
         if done {
             // Burst finished: drain any queued audio, then unkey and let the QSO
@@ -6818,7 +6817,7 @@ impl Engine {
         // starving the mic FIFO (choppy audio), and a CAT rig buffered its ~1 s
         // output ring before the sound card's own backpressure engaged (voice
         // delayed by ~1 s). Pacing keeps every backend's ring near-empty.
-        pace_tx_block(&mut self.tx_pace);
+        pace_tx_block(&mut self.tx_pace, self.source.tx_pace_cushion_ms());
 
         if burst_done {
             // Let any queued audio play out before dropping PTT, so the rig

--- a/crates/sdroxide-radio/src/source.rs
+++ b/crates/sdroxide-radio/src/source.rs
@@ -322,6 +322,26 @@ pub trait IqSource: Send {
     /// without cutting off the tail of a burst. Default: nothing is buffered.
     fn tx_drain(&mut self) {}
 
+    /// How far ahead of real time the engine may fill this source's transmit
+    /// ring before it paces production back down to real time, in ms.
+    ///
+    /// The engine feeds TX audio at real time plus this cushion (see
+    /// `pace_tx_block` in `engine.rs`) so the device/network ring downstream
+    /// stays near-empty rather than filling to its full depth — that ring's
+    /// depth is otherwise wasted as pure latency. The cushion is what absorbs
+    /// jitter between one feed and the next before the ring runs dry: a stall
+    /// (scheduling, USB round trip, network transit) shorter than this many ms
+    /// is invisible; a longer one underruns and is heard as a chopped
+    /// transmission. Default `30.0` ms is right for hardware reached directly
+    /// (sound card, USB, LAN) whose own jitter is negligible. A source
+    /// reached over a link with real jitter — WiFi, a VPN — should report
+    /// more, trading transmit-audio and PTT latency for headroom, the same
+    /// tradeoff the Icom LAN backend's `tx_latency_ms` setting makes
+    /// explicit.
+    fn tx_pace_cushion_ms(&self) -> f64 {
+        30.0
+    }
+
     /// A user-facing warning captured while opening the source (e.g. the radio
     /// audio device was unavailable, or a mono card was selected for IQ), or
     /// `None` when the source came up cleanly. Surfaced in the UI so a silent
@@ -642,6 +662,10 @@ impl IqSource for ConvertedSource {
 
     fn tx_drain(&mut self) {
         self.inner.tx_drain();
+    }
+
+    fn tx_pace_cushion_ms(&self) -> f64 {
+        self.inner.tx_pace_cushion_ms()
     }
 
     fn open_status(&self) -> Option<String> {

--- a/crates/sdroxide-types/src/radio.rs
+++ b/crates/sdroxide-types/src/radio.rs
@@ -620,6 +620,17 @@ pub struct HpsdrConfig {
     /// `radio.json` on DDC 0, exactly as before.
     #[serde(default)]
     pub ddc: u8,
+    /// How far ahead of real time the engine may fill this board's transmit
+    /// ring before it paces production back down, in ms. Unlike
+    /// [`IcomNetConfig::tx_latency_ms`], the board holds no such buffer itself
+    /// — OpenHPSDR has no such setting — so this only widens the cushion the
+    /// engine leaves in the ring on *this* side of the network. Higher
+    /// survives a worse link (WiFi, a VPN) at the cost of transmit-audio and
+    /// PTT latency; the low default is right for a direct wired connection,
+    /// where the link's own jitter is negligible. See
+    /// [`HpsdrConfig::default_tx_latency_ms`].
+    #[serde(default = "HpsdrConfig::default_tx_latency_ms")]
+    pub tx_latency_ms: f64,
 }
 
 impl Default for HpsdrConfig {
@@ -635,6 +646,7 @@ impl Default for HpsdrConfig {
             io_rx_input: HpsdrIoRxInput::Radio,
             ppm: 0.0,
             ddc: 0,
+            tx_latency_ms: Self::default_tx_latency_ms(),
         }
     }
 }
@@ -668,6 +680,19 @@ impl HpsdrConfig {
     pub fn default_pa_enable() -> bool {
         true
     }
+
+    /// Matches the cushion every other backend gets: enough to absorb ordinary
+    /// scheduling jitter on a direct wired connection, short enough to keep
+    /// transmit-audio and PTT latency unnoticeable. See
+    /// [`HpsdrConfig::tx_latency_ms`].
+    pub fn default_tx_latency_ms() -> f64 {
+        30.0
+    }
+
+    /// Range offered in the UI. The floor keeps the round trip to the board
+    /// from dominating; the ceiling is Icom LAN's own transmit-buffer ceiling,
+    /// so the two controls read the same way.
+    pub const TX_LATENCY_MS_RANGE: std::ops::RangeInclusive<f64> = 10.0..=1000.0;
 
     /// Supported DDC sample rates (Hz) for Protocol 2 boards.
     pub const SAMPLE_RATES: [f64; 6] =

--- a/crates/sdroxide-ui/src/app/settings/radio.rs
+++ b/crates/sdroxide-ui/src/app/settings/radio.rs
@@ -371,6 +371,22 @@ pub(in crate::app) fn settings_hpsdr_tab(
             });
         }
         ui.end_row();
+
+        ui.label("Transmit buffer");
+        ui.add(
+            egui::DragValue::new(&mut cfg.hpsdr.tx_latency_ms)
+                .range(HpsdrConfig::TX_LATENCY_MS_RANGE)
+                .suffix(" ms"),
+        )
+        .on_hover_text(
+            "How far ahead of real time transmit audio is fed to the board over the network, \
+             before sdroxide slows down to match it. The board itself holds no such buffer — \
+             this only widens sdroxide's own margin. Raise it on a WiFi link or a VPN, where \
+             the low default (right for a direct wired connection) is not enough headroom \
+             against jitter and the transmitted audio or PTT stutters; higher costs transmit \
+             latency.",
+        );
+        ui.end_row();
     });
     ui.add_space(6.0);
     ui.label(

--- a/src/hpsdr_source.rs
+++ b/src/hpsdr_source.rs
@@ -47,6 +47,8 @@ pub struct HpsdrSource {
     /// wants an edge.
     ptt: bool,
     label: String,
+    /// See [`sdroxide_types::HpsdrConfig::tx_latency_ms`].
+    tx_latency_ms: f64,
 }
 
 impl HpsdrSource {
@@ -100,6 +102,7 @@ impl HpsdrSource {
             label,
             rx: Some(rx),
             board: Some(board),
+            tx_latency_ms: cfg.tx_latency_ms,
         })
     }
 
@@ -268,5 +271,13 @@ impl IqSource for HpsdrSource {
         if let Some(rx) = self.rx.as_mut() {
             rx.discard_pending_rx();
         }
+    }
+
+    /// See [`sdroxide_types::HpsdrConfig::tx_latency_ms`]: this board holds no
+    /// transmit buffer of its own to widen, so raising this only widens the
+    /// cushion the engine leaves before the board's TX ring on this side of
+    /// the network.
+    fn tx_pace_cushion_ms(&self) -> f64 {
+        self.tx_latency_ms
     }
 }


### PR DESCRIPTION
I noticed some audio stutter/clipping when operating sdroxide over Wi-Fi, so a configurable buffer came in handy.