### PR TITLE
Add an SWR guard: stop transmitting into a fault, and latch until acknowledged

### DIFF
--- a/crates/sdroxide-config/src/lib.rs
+++ b/crates/sdroxide-config/src/lib.rs
@@ -88,6 +88,15 @@ pub struct Settings {
     pub server_port: u16,
     /// Refuse to transmit outside amateur bands.
     pub tx_ham_only: bool,
+    /// Abort the transmission and latch out further transmit when the rig
+    /// reports an SWR at or above [`Self::swr_limit`].
+    ///
+    /// Only rigs that actually measure SWR and report it over CAT/TCI can arm
+    /// this; on anything that leaves `TxTelemetry::swr` as `None` it is inert,
+    /// so it costs nothing to leave on.
+    pub swr_guard: bool,
+    /// The SWR ratio the guard trips at, e.g. `2.5` = 2.5:1.
+    pub swr_limit: f32,
     /// Preferred audio output device name; `None` = system default.
     pub audio_output: Option<String>,
     /// Preferred audio input (microphone) device name; `None` = system default.
@@ -137,6 +146,13 @@ impl Default for Settings {
             server_bind: "0.0.0.0".into(),
             server_port: 4950,
             tx_ham_only: true,
+            // On by default, and defensible: it cannot fire on a rig that does
+            // not report SWR, and on one that does, the case it prevents is
+            // transmitting into a fault. 2.5:1 is high enough not to trip on a
+            // normally-tuned antenna near a band edge and low enough to catch a
+            // disconnected feeder or a stuck relay.
+            swr_guard: true,
+            swr_limit: 2.5,
             audio_output: None,
             audio_input: None,
             region: sdroxide_types::Region::default(),

--- a/crates/sdroxide-radio/src/engine.rs
+++ b/crates/sdroxide-radio/src/engine.rs
@@ -1619,6 +1619,11 @@ fn engine_thread(
     // Published so every UI attached to this engine — including a remote one
     // started by somebody else — can warn about it.
     state.oob_tx = !engine_cfg.tx_ham_only;
+    // Seeded here, next to the other config-derived state, so the very first
+    // broadcast carries the real guard settings and no client ever renders the
+    // 0.0 that `TxState::default()` would give it.
+    state.tx.swr_guard = engine_cfg.swr_guard;
+    state.tx.swr_limit = engine_cfg.swr_limit.clamp(1.1, 10.0);
     if let Some(mode) = engine_cfg.initial_mode {
         for rx in &mut state.rx {
             *rx = RxState::with_mode(mode);
@@ -1777,7 +1782,7 @@ fn engine_thread(
         tx_center_hz: 0.0,
         tx_ham_only: engine_cfg.tx_ham_only,
         swr_guard: engine_cfg.swr_guard,
-        swr_limit: engine_cfg.swr_limit,
+        swr_limit: engine_cfg.swr_limit.clamp(1.1, 10.0),
         swr_over: 0,
         swr_tripped: None,
         wide_scratch: Vec::new(),
@@ -3803,6 +3808,27 @@ impl Engine {
                 if self.tx_active {
                     self.source.set_tx_drive(self.tx_power_level() as f64);
                 }
+            }
+            SetSwrGuard { enabled, limit } => {
+                // Clamped, not trusted. Below about 1.1:1 no real antenna ever
+                // sits, so a low value would refuse every transmission and look
+                // like a broken radio; and the field is `0.0` in a default
+                // `TxState`, so an early edit from a client that has not yet
+                // heard from the engine would otherwise arm exactly that.
+                let limit = limit.clamp(1.1, 10.0);
+                self.swr_guard = enabled;
+                self.swr_limit = limit;
+                self.state.tx.swr_guard = enabled;
+                self.state.tx.swr_limit = limit;
+                self.swr_over = 0;
+                // Disarming clears a standing trip: leaving transmit latched
+                // out by a guard that is no longer on would be unexplainable
+                // from the screen.
+                if !enabled && self.swr_tripped.take().is_some() {
+                    self.state.tx.swr_tripped = None;
+                    self.clear_notice();
+                }
+                self.emit_state();
             }
             ClearSwrTrip => {
                 if let Some(swr) = self.swr_tripped.take() {

--- a/crates/sdroxide-radio/src/engine.rs
+++ b/crates/sdroxide-radio/src/engine.rs
@@ -2209,10 +2209,13 @@ fn engine_thread(
                                 // TCI starvation unkey uses.
                                 engine.apply(Command::SetTune(false));
                                 engine.apply(Command::SetPtt(false));
+                                // Short on purpose. This lands on a banner in
+                                // front of an operator who has just had a
+                                // transmission cut off, and the two things worth
+                                // reading are the figure and what to look at.
                                 engine.notice(&format!(
-                                    "transmit stopped — SWR {swr:.1}:1 is at or above the \
-                                     {limit:.1}:1 limit. CHECK YOUR ANTENNA. Transmit stays \
-                                     locked out until you acknowledge this."
+                                    "Transmit stopped. SWR {swr:.1}:1, limit {limit:.1}:1. \
+                                     Check the antenna."
                                 ));
                                 engine.emit_state();
                             }
@@ -7461,8 +7464,7 @@ impl Engine {
             // to key into a fault.
             if let Some(swr) = self.swr_tripped {
                 return self.deny_tx(&format!(
-                    "SWR guard tripped at {swr:.1}:1 — CHECK YOUR ANTENNA, then acknowledge it to \
-                     transmit again"
+                    "SWR guard tripped at {swr:.1}:1. Acknowledge it to transmit again"
                 ));
             }
             // The station's transmit interlock: one radio on the air at a

--- a/crates/sdroxide-radio/src/engine.rs
+++ b/crates/sdroxide-radio/src/engine.rs
@@ -47,6 +47,17 @@ pub const DISPLAY_BINS: usize = 2048;
 /// the remote-client WebSocket.
 const METER_INTERVAL: Duration = Duration::from_millis(33);
 
+/// Consecutive over-limit SWR readings required before the guard fires. At the
+/// 33 ms meter interval this is about a fifth of a second of genuinely bad SWR,
+/// which is long enough to ride out the key-up transient and short enough that
+/// the transmitter is not left into a fault.
+const SWR_TRIP_SAMPLES: u8 = 6;
+
+/// Forward power below which an SWR reading is ignored. Reflection is a ratio,
+/// and at nearly no forward power the ratio is noise: rigs commonly report wild
+/// SWR in the first milliseconds of an over, and during a barely-driven one.
+const SWR_MIN_FWD_W: f32 = 5.0;
+
 /// How often the RDS snapshot goes out. Far slower than the meters: a station
 /// name changes never, radio text every few seconds, and the only thing arriving
 /// continuously is the diagnostics log, which is a delta and so costs the same
@@ -136,6 +147,11 @@ pub struct EngineConfig {
     pub initial_antenna: (Option<String>, Option<String>),
     /// Refuse to key up outside amateur bands.
     pub tx_ham_only: bool,
+    /// Abort the over and latch out transmit when the rig reports an SWR at or
+    /// above [`Self::swr_limit`]. Inert on rigs that do not measure SWR.
+    pub swr_guard: bool,
+    /// The SWR ratio the guard trips at.
+    pub swr_limit: f32,
     /// Rebuilds the IQ source at runtime when the operator switches interfaces.
     /// `None` disables runtime interface switching (a restart is then required).
     pub reopen: Option<ReopenFn>,
@@ -185,6 +201,8 @@ impl Default for EngineConfig {
             initial_mode: None,
             initial_antenna: (None, None),
             tx_ham_only: true,
+            swr_guard: true,
+            swr_limit: 2.5,
             reopen: None,
             remember_session: false,
             store: sdroxide_config::Store::station(),
@@ -1171,6 +1189,26 @@ struct Engine {
     tx_freq_told: Option<f64>,
     tx_center_hz: f64,
     tx_ham_only: bool,
+    /// SWR guard: trip threshold, and the latch it sets.
+    ///
+    /// ⚠️ The count is the part that makes this usable rather than infuriating.
+    /// SWR is meaningless until forward power has actually risen, and the first
+    /// readings after key-up are routinely nonsense, so a bare `swr > limit`
+    /// would abort a large share of perfectly good overs — and a protection
+    /// that cries wolf gets switched off, which leaves the operator worse off
+    /// than having none. It therefore needs [`SWR_TRIP_SAMPLES`] consecutive
+    /// readings over the limit, each with forward power above
+    /// [`SWR_MIN_FWD_W`], before it fires.
+    swr_guard: bool,
+    swr_limit: f32,
+    /// Consecutive over-limit meter samples seen so far this over.
+    swr_over: u8,
+    /// Set when the guard has fired, holding the SWR that fired it. While this
+    /// is `Some`, transmit is refused. Cleared only by the operator
+    /// acknowledging it ([`Command::ClearSwrTrip`]), which is the "latch"
+    /// half: a fault that clears itself the moment you release PTT teaches you
+    /// nothing and lets you keep transmitting into it.
+    swr_tripped: Option<f32>,
     /// TX monitor: FFTs the transmitted 48 kHz baseband (the modulator output,
     /// or the outgoing audio for a CAT rig) so the operator sees their own signal
     /// on the panadapter while transmitting.
@@ -1738,6 +1776,10 @@ fn engine_thread(
         tx_freq_told: None,
         tx_center_hz: 0.0,
         tx_ham_only: engine_cfg.tx_ham_only,
+        swr_guard: engine_cfg.swr_guard,
+        swr_limit: engine_cfg.swr_limit,
+        swr_over: 0,
+        swr_tripped: None,
         wide_scratch: Vec::new(),
         wide_seq: 0,
         wide_levels: None,
@@ -2094,6 +2136,53 @@ fn engine_thread(
                 // Clients that asked for `tx_sensors` get the same figures.
                 if let Some(srv) = engine.tci_srv.as_ref() {
                     srv.push_telemetry(tele);
+                }
+                // The SWR guard. Placed here because this is the one point in
+                // the engine where a fresh SWR reading and `tx_active` are both
+                // in hand; it runs before the meters are published so the trip
+                // and the reading the operator sees cannot disagree.
+                if engine.swr_guard && engine.swr_tripped.is_none() {
+                    match (tele.swr, tele.fwd_w) {
+                        // Both figures required. `fwd_w` is what makes the
+                        // reading meaningful, and a rig that reports SWR but no
+                        // forward power cannot be vetted, so it is left alone
+                        // rather than guessed at.
+                        (Some(swr), Some(fwd)) if fwd >= SWR_MIN_FWD_W && swr >= engine.swr_limit => {
+                            engine.swr_over = engine.swr_over.saturating_add(1);
+                            if engine.swr_over >= SWR_TRIP_SAMPLES {
+                                let limit = engine.swr_limit;
+                                warn!(swr, limit, "SWR guard tripped, unkeying");
+                                // Latch FIRST, so the transmitter cannot be
+                                // re-keyed in the window between unkeying and
+                                // the operator seeing the warning.
+                                engine.swr_tripped = Some(swr);
+                                engine.state.tx.swr_tripped = Some(swr);
+                                engine.swr_over = 0;
+                                // ⛔ NOT `deny_tx`, and the difference matters.
+                                // That helper only sets the state flags, on the
+                                // documented assumption that every deny happens
+                                // BEFORE the transmitter keyed — true of the
+                                // rails in `sync_tx_state`, false here, where
+                                // the rig is keyed and on the air right now.
+                                // Keying never touches `tx_active` directly; it
+                                // goes through `Command::SetPtt` so the guards
+                                // and the hardware both follow. Same route the
+                                // TCI starvation unkey uses.
+                                engine.apply(Command::SetTune(false));
+                                engine.apply(Command::SetPtt(false));
+                                engine.notice(&format!(
+                                    "transmit stopped — SWR {swr:.1}:1 is at or above the \
+                                     {limit:.1}:1 limit. CHECK YOUR ANTENNA. Transmit stays \
+                                     locked out until you acknowledge this."
+                                ));
+                                engine.emit_state();
+                            }
+                        }
+                        // Any good reading resets the run. The count is for
+                        // CONSECUTIVE samples: an isolated spike is exactly what
+                        // the debounce exists to ignore.
+                        _ => engine.swr_over = 0,
+                    }
                 }
                 Some(Meters {
                     s_dbm: -127.0,
@@ -3713,6 +3802,18 @@ impl Engine {
                 // left the rig alone — swap the power level over by hand.
                 if self.tx_active {
                     self.source.set_tx_drive(self.tx_power_level() as f64);
+                }
+            }
+            ClearSwrTrip => {
+                if let Some(swr) = self.swr_tripped.take() {
+                    info!(swr, "SWR guard acknowledged, transmit re-enabled");
+                    self.swr_over = 0;
+                    self.state.tx.swr_tripped = None;
+                    self.emit_state();
+                    // Clears the persistent warning raised by `deny_tx`, so the
+                    // banner goes when the condition it reports has been dealt
+                    // with, and not before.
+                    self.clear_notice();
                 }
             }
             SetTxDrive(v) => {
@@ -6402,6 +6503,11 @@ impl Engine {
         let _ = self.event_tx.send(RadioEvent::Notice(Some(text.to_string())));
     }
 
+    /// Withdraw the persistent notice. `Notice(None)` is the documented clear.
+    fn clear_notice(&self) {
+        let _ = self.event_tx.send(RadioEvent::Notice(None));
+    }
+
     fn emit_state(&self) {
         let _ = self.event_tx.send(RadioEvent::State(self.state.clone()));
     }
@@ -7273,6 +7379,17 @@ impl Engine {
             return;
         }
         if want_tx {
+            // The SWR latch comes before every other rail, including the
+            // station interlock. It is a pure state check with no side effects
+            // to unwind, and it is the one refusal that says the antenna system
+            // itself is suspect: there is no point acquiring the transmit gate
+            // to key into a fault.
+            if let Some(swr) = self.swr_tripped {
+                return self.deny_tx(&format!(
+                    "SWR guard tripped at {swr:.1}:1 — CHECK YOUR ANTENNA, then acknowledge it to \
+                     transmit again"
+                ));
+            }
             // The station's transmit interlock: one radio on the air at a
             // time. First among the rails, before anything with side effects,
             // so a refused key-up on this radio leaves it exactly as it was.
@@ -7414,6 +7531,10 @@ impl Engine {
             self.source.discard_pending_rx();
             self.tx = None;
             self.tx_active = false;
+            // The run of over-limit readings belongs to the over that just
+            // ended. The LATCH deliberately survives: that is what makes it a
+            // latch rather than a per-over warning.
+            self.swr_over = 0;
             self.release_tx_gate();
             if let Some(mixer) = self.mixer.as_mut() {
                 mixer.rx_rec_enabled = true;

--- a/crates/sdroxide-radio/src/engine.rs
+++ b/crates/sdroxide-radio/src/engine.rs
@@ -2173,12 +2173,20 @@ fn engine_thread(
                     && engine.swr_tripped.is_none()
                     && engine.swr_settle > SWR_SETTLE_SAMPLES
                 {
-                    match (tele.swr, tele.fwd_w) {
-                        // Both figures required. `fwd_w` is what makes the
-                        // reading meaningful, and a rig that reports SWR but no
-                        // forward power cannot be vetted, so it is left alone
-                        // rather than guessed at.
-                        (Some(swr), Some(fwd)) if fwd >= SWR_MIN_FWD_W && swr >= engine.swr_limit => {
+                    // ⛔ FORWARD POWER IS OPTIONAL AND MUST STAY OPTIONAL. This
+                    // read `(Some(swr), Some(fwd))` until 17 August 2026, on the
+                    // reasoning that a rig reporting SWR without power "cannot be
+                    // vetted". That reasoning cost two failed live tests: the
+                    // CI-V driver sends `TxTelemetry { fwd_w: None, swr: Some(v) }`,
+                    // so on every Icom the arm could never match and the guard
+                    // was dead code. Requiring a figure the most common rig
+                    // family never sends is not caution, it is a silent
+                    // disablement.
+                    match tele.swr {
+                        Some(swr)
+                            if swr >= engine.swr_limit
+                                && tele.fwd_w.map_or(true, |f| f >= SWR_MIN_FWD_W) =>
+                        {
                             engine.swr_over = engine.swr_over.saturating_add(1);
                             if engine.swr_over >= SWR_TRIP_SAMPLES {
                                 let limit = engine.swr_limit;
@@ -2209,10 +2217,17 @@ fn engine_thread(
                                 engine.emit_state();
                             }
                         }
-                        // Any good reading resets the run. The count is for
+                        // A reading that is fine resets the run. The count is for
                         // CONSECUTIVE samples: an isolated spike is exactly what
                         // the debounce exists to ignore.
-                        _ => engine.swr_over = 0,
+                        Some(_) => engine.swr_over = 0,
+                        // ⚠️ NO READING IS NOT A GOOD READING. Neither advance
+                        // nor reset: the rig has simply not said anything yet.
+                        // Resetting here would have been the same class of bug
+                        // as the one above, quietly holding the count at zero on
+                        // any rig whose telemetry arrives slower than the meter
+                        // tick.
+                        None => {}
                     }
                 }
                 Some(Meters {

--- a/crates/sdroxide-radio/src/engine.rs
+++ b/crates/sdroxide-radio/src/engine.rs
@@ -53,10 +53,27 @@ const METER_INTERVAL: Duration = Duration::from_millis(33);
 /// the transmitter is not left into a fault.
 const SWR_TRIP_SAMPLES: u8 = 6;
 
-/// Forward power below which an SWR reading is ignored. Reflection is a ratio,
-/// and at nearly no forward power the ratio is noise: rigs commonly report wild
-/// SWR in the first milliseconds of an over, and during a barely-driven one.
-const SWR_MIN_FWD_W: f32 = 5.0;
+/// Meter samples to ignore after key-up before the SWR is believed at all.
+///
+/// This is the right way to discard the key-up transient, and it replaced a
+/// forward-power floor that looked equivalent and was not. See
+/// [`SWR_MIN_FWD_W`].
+const SWR_SETTLE_SAMPLES: u8 = 6;
+
+/// Forward power below which an SWR reading is ignored, purely to reject a
+/// reading taken when the transmitter is not really producing anything.
+///
+/// ⛔ THIS MUST STAY LOW. It was 5.0 W until 17 August 2026 and that was a real
+/// bug, found on the first live test: a rig with SWR foldback REDUCES POWER
+/// BECAUSE THE SWR IS BAD. Rodger's IC-7300 dropped to 3 W into a 7.5:1 load,
+/// every reading was therefore discarded as untrustworthy, and the guard sat
+/// silent through exactly the fault it exists to catch. A power floor high
+/// enough to be useful as a transient filter is high enough to gate out the
+/// emergency.
+///
+/// Discarding the transient is [`SWR_SETTLE_SAMPLES`]'s job, which is what a
+/// key-up transient actually is: a property of time, not of power.
+const SWR_MIN_FWD_W: f32 = 0.5;
 
 /// How often the RDS snapshot goes out. Far slower than the meters: a station
 /// name changes never, radio text every few seconds, and the only thing arriving
@@ -1203,6 +1220,10 @@ struct Engine {
     swr_limit: f32,
     /// Consecutive over-limit meter samples seen so far this over.
     swr_over: u8,
+    /// Meter samples since this over began, counted so the key-up transient can
+    /// be ignored by TIME rather than by forward power. See [`SWR_MIN_FWD_W`]
+    /// for why the power-based version of this was wrong.
+    swr_settle: u8,
     /// Set when the guard has fired, holding the SWR that fired it. While this
     /// is `Some`, transmit is refused. Cleared only by the operator
     /// acknowledging it ([`Command::ClearSwrTrip`]), which is the "latch"
@@ -1784,6 +1805,7 @@ fn engine_thread(
         swr_guard: engine_cfg.swr_guard,
         swr_limit: engine_cfg.swr_limit.clamp(1.1, 10.0),
         swr_over: 0,
+        swr_settle: 0,
         swr_tripped: None,
         wide_scratch: Vec::new(),
         wide_seq: 0,
@@ -2146,7 +2168,11 @@ fn engine_thread(
                 // the engine where a fresh SWR reading and `tx_active` are both
                 // in hand; it runs before the meters are published so the trip
                 // and the reading the operator sees cannot disagree.
-                if engine.swr_guard && engine.swr_tripped.is_none() {
+                engine.swr_settle = engine.swr_settle.saturating_add(1);
+                if engine.swr_guard
+                    && engine.swr_tripped.is_none()
+                    && engine.swr_settle > SWR_SETTLE_SAMPLES
+                {
                     match (tele.swr, tele.fwd_w) {
                         // Both figures required. `fwd_w` is what makes the
                         // reading meaningful, and a rig that reports SWR but no
@@ -2197,6 +2223,14 @@ fn engine_thread(
                     tone: None,
                 })
             } else {
+                // Not transmitting: both SWR counters belong to an over, so they
+                // reset here. Doing it on every receive sample rather than at
+                // one un-key site means no path out of transmit can leave a
+                // stale count behind to blank or trip the NEXT over.
+                // ⚠️ The LATCH is deliberately not touched: it survives until
+                // acknowledged, which is the whole point of it.
+                engine.swr_over = 0;
+                engine.swr_settle = 0;
                 let stereo = engine.main.as_ref().is_some_and(|c| c.stereo_locked());
                 let tone = engine.main.as_ref().and_then(|c| c.sub_tone());
                 engine.rx_signal_dbm().map(|s_dbm| Meters {

--- a/crates/sdroxide-radio/tests/swr_guard.rs
+++ b/crates/sdroxide-radio/tests/swr_guard.rs
@@ -1,0 +1,197 @@
+//! The SWR guard: stop transmitting into a fault, and stay stopped.
+//!
+//! Every test here is a bug that reached a live radio. The guard was written on
+//! 17 August 2026 and failed its first two on-air tests in a row, both times by
+//! sitting silent through a genuine 7.5:1 while the operator watched. Neither
+//! failure was in the threshold or the debounce; both were in what the guard
+//! demanded before it would believe a reading at all.
+//!
+//! 1. It required forward power of at least 5 W. A rig with SWR protection
+//!    folds its power back BECAUSE the SWR is bad — the IC-7300 dropped to 3 W —
+//!    so the floor gated out precisely the emergency it was guarding against.
+//! 2. It required forward power to be reported at all. The CI-V driver sends
+//!    `TxTelemetry { fwd_w: None, swr: Some(v) }`, so on every Icom the match
+//!    arm could never fire and the whole feature was dead code.
+//!
+//! `trips_with_no_forward_power_reported` is the regression for both, and is
+//! the shape of a real Icom: SWR present, forward power absent.
+
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
+
+use sdroxide_radio::{Complex32, EngineConfig, IqSource, Result, start_engine};
+use sdroxide_types::{Command, DeviceCaps, RadioEvent, TxTelemetry, Vfo};
+
+/// A transmit-capable stand-in that reports whatever telemetry the test sets,
+/// and records whether the transmitter is currently running.
+struct MockRig {
+    rate: f64,
+    center: f64,
+    telem: Arc<Mutex<Option<TxTelemetry>>>,
+    keyed: Arc<Mutex<bool>>,
+}
+
+impl IqSource for MockRig {
+    fn sample_rate(&self) -> f64 {
+        self.rate
+    }
+    fn center_hz(&self) -> f64 {
+        self.center
+    }
+    fn set_center_hz(&mut self, hz: f64) -> Result<()> {
+        self.center = hz;
+        Ok(())
+    }
+    fn read(&mut self, buf: &mut [Complex32]) -> Result<usize> {
+        std::thread::sleep(Duration::from_millis(5));
+        let n = buf.len().min(2048);
+        buf[..n].fill(Complex32::new(0.0, 0.0));
+        Ok(n)
+    }
+    fn describe(&self) -> String {
+        "mock rig".into()
+    }
+    fn tx_begin(&mut self, _center_hz: f64, rate: f64) -> Result<f64> {
+        *self.keyed.lock().unwrap() = true;
+        Ok(rate)
+    }
+    fn tx_write(&mut self, _samples: &[Complex32]) -> Result<()> {
+        Ok(())
+    }
+    fn tx_write_audio(&mut self, _audio: &[f32]) -> Result<()> {
+        Ok(())
+    }
+    fn tx_end(&mut self) -> Result<()> {
+        *self.keyed.lock().unwrap() = false;
+        Ok(())
+    }
+    /// Latched, exactly as `AudioCatSource` latches the ~5 Hz CI-V reading so
+    /// the engine's meter tick always has a value.
+    fn tx_telemetry(&mut self) -> Option<TxTelemetry> {
+        *self.telem.lock().unwrap()
+    }
+}
+
+fn caps() -> DeviceCaps {
+    DeviceCaps {
+        driver: "mock".into(),
+        label: "mock".into(),
+        rx_channels: 1,
+        tx_channels: 1,
+        sample_rates: vec![600_000.0],
+        freq_ranges_rx: vec![(1.0e6, 60.0e6)],
+        freq_ranges_tx: vec![(1.0e6, 60.0e6)],
+        ..DeviceCaps::default()
+    }
+}
+
+struct Outcome {
+    tripped_at: Option<f32>,
+    /// Whether the transmitter was still running when the test gave up.
+    still_keyed: bool,
+    /// Whether a key-up attempted AFTER the trip was allowed through.
+    keyed_again: bool,
+}
+
+/// Key up with `telem` reported throughout, wait for a verdict, then try to key
+/// up a second time to see whether the latch holds.
+fn run(telem: TxTelemetry, limit: f32, guard: bool) -> Outcome {
+    let telem = Arc::new(Mutex::new(Some(telem)));
+    let keyed = Arc::new(Mutex::new(false));
+    let src = MockRig {
+        rate: 600_000.0,
+        center: 14.1e6,
+        telem: Arc::clone(&telem),
+        keyed: Arc::clone(&keyed),
+    };
+    let cfg = EngineConfig {
+        tx_ham_only: false,
+        swr_guard: guard,
+        swr_limit: limit,
+        ..Default::default()
+    };
+    let mut h = start_engine(Box::new(src), caps(), cfg);
+    let thread = h.thread.take();
+
+    h.cmd_tx.send(Command::SetVfo { vfo: Vfo::A, hz: 14.1e6 }).unwrap();
+    h.cmd_tx.send(Command::SetPtt(true)).unwrap();
+
+    // Long enough for the settle window plus the debounce several times over,
+    // so a pass here is not a race.
+    let mut tripped_at = None;
+    let deadline = Instant::now() + Duration::from_secs(3);
+    while Instant::now() < deadline && tripped_at.is_none() {
+        while let Ok(ev) = h.event_rx.try_recv() {
+            if let RadioEvent::State(s) = ev {
+                if let Some(swr) = s.tx.swr_tripped {
+                    tripped_at = Some(swr);
+                }
+            }
+        }
+        std::thread::sleep(Duration::from_millis(20));
+    }
+    let still_keyed = *keyed.lock().unwrap();
+
+    // The latch: a second key-up must be refused while it stands.
+    h.cmd_tx.send(Command::SetPtt(true)).unwrap();
+    std::thread::sleep(Duration::from_millis(400));
+    while h.event_rx.try_recv().is_ok() {}
+    let keyed_again = *keyed.lock().unwrap();
+
+    drop(h.cmd_tx);
+    if let Some(t) = thread {
+        let _ = t.join();
+    }
+    Outcome { tripped_at, still_keyed, keyed_again }
+}
+
+/// ⭐ THE REGRESSION. An Icom reports SWR and no forward power at all. This is
+/// the exact shape of the telemetry that twice failed on air.
+#[test]
+fn trips_with_no_forward_power_reported() {
+    let o = run(TxTelemetry { fwd_w: None, swr: Some(7.5) }, 2.5, true);
+    assert_eq!(o.tripped_at, Some(7.5), "a 7.5:1 with no power figure must trip a 2.5:1 guard");
+    assert!(!o.still_keyed, "the transmitter must actually stop, not just set a flag");
+    assert!(!o.keyed_again, "the latch must refuse the next key-up until acknowledged");
+}
+
+/// The other half of the live failure: the rig folds back to a few watts
+/// BECAUSE the SWR is bad, so a low power reading must not excuse it.
+#[test]
+fn trips_when_the_rig_has_folded_its_power_back() {
+    let o = run(TxTelemetry { fwd_w: Some(3.0), swr: Some(7.5) }, 2.5, true);
+    assert_eq!(o.tripped_at, Some(7.5), "3 W at 7.5:1 is the fault, not a reason to ignore it");
+    assert!(!o.still_keyed);
+}
+
+#[test]
+fn leaves_a_good_swr_alone() {
+    let o = run(TxTelemetry { fwd_w: Some(50.0), swr: Some(1.3) }, 2.5, true);
+    assert_eq!(o.tripped_at, None, "1.3:1 must not trip a 2.5:1 guard");
+    assert!(o.still_keyed, "a good match must be left transmitting");
+}
+
+/// Disarmed is disarmed, however bad the antenna is.
+#[test]
+fn does_nothing_when_disarmed() {
+    let o = run(TxTelemetry { fwd_w: None, swr: Some(9.9) }, 2.5, false);
+    assert_eq!(o.tripped_at, None);
+    assert!(o.still_keyed);
+}
+
+/// A rig that reports no SWR at all must be left entirely alone, rather than
+/// having its silence read as either safe or dangerous.
+#[test]
+fn inert_when_the_rig_reports_no_swr() {
+    let o = run(TxTelemetry { fwd_w: Some(50.0), swr: None }, 2.5, true);
+    assert_eq!(o.tripped_at, None);
+    assert!(o.still_keyed);
+}
+
+/// Genuinely no forward power means the transmitter is producing nothing, and
+/// the ratio is then noise. This is the only thing the power floor may do.
+#[test]
+fn ignores_a_reading_taken_at_no_power() {
+    let o = run(TxTelemetry { fwd_w: Some(0.0), swr: Some(9.9) }, 2.5, true);
+    assert_eq!(o.tripped_at, None, "0 W means the reading is meaningless, not that the SWR is bad");
+}

--- a/crates/sdroxide-types/src/command.rs
+++ b/crates/sdroxide-types/src/command.rs
@@ -109,6 +109,10 @@ pub enum Command {
     // Transmit
     SetPtt(bool),
     SetTune(bool),
+    /// Arm or disarm the SWR guard and set the ratio it trips at.
+    ///
+    /// The engine clamps `limit`; see [`crate::TxState::swr_limit`].
+    SetSwrGuard { enabled: bool, limit: f32 },
     /// Acknowledge a tripped SWR guard and allow transmit again.
     ///
     /// Deliberately its own command rather than a side effect of the next

--- a/crates/sdroxide-types/src/command.rs
+++ b/crates/sdroxide-types/src/command.rs
@@ -109,6 +109,13 @@ pub enum Command {
     // Transmit
     SetPtt(bool),
     SetTune(bool),
+    /// Acknowledge a tripped SWR guard and allow transmit again.
+    ///
+    /// Deliberately its own command rather than a side effect of the next
+    /// key-up: the operator confirming they have looked at the antenna is the
+    /// entire point of latching, and a latch any old PTT press clears is not a
+    /// latch.
+    ClearSwrTrip,
     SetTxDrive(f32),
     SetTuneDrive(f32),
     SetMicGain(f32),

--- a/crates/sdroxide-types/src/state.rs
+++ b/crates/sdroxide-types/src/state.rs
@@ -109,6 +109,15 @@ pub struct TxState {
     pub mic_gain: f32,
     /// Parametric EQ on the mic/modulator audio (voice modes only).
     pub eq: TxEqState,
+    /// Set when the SWR guard has tripped, holding the SWR that tripped it.
+    /// While it is `Some`, transmit is refused until the operator acknowledges
+    /// it with [`Command::ClearSwrTrip`].
+    ///
+    /// It lives in the shared state rather than being inferred from the notice
+    /// text so that every client, native and remote, can offer the
+    /// acknowledgement and can grey out transmit for the right reason. Matching
+    /// on a human-readable string would break the moment the wording changed.
+    pub swr_tripped: Option<f32>,
 }
 
 /// One band of [`TxEqState`]: corner/center frequency and gain, plus either Q

--- a/crates/sdroxide-types/src/state.rs
+++ b/crates/sdroxide-types/src/state.rs
@@ -109,6 +109,19 @@ pub struct TxState {
     pub mic_gain: f32,
     /// Parametric EQ on the mic/modulator audio (voice modes only).
     pub eq: TxEqState,
+    /// Whether the SWR guard is armed, and the ratio it trips at.
+    ///
+    /// Carried in the broadcast state rather than read from `config.toml` by
+    /// each client, because the guard is a property of the RADIO's antenna
+    /// system and the config file of a remote client is on the wrong machine
+    /// entirely — the same reasoning that keeps the IARU region here.
+    ///
+    /// ⚠️ `TxState` derives `Default`, so `swr_limit` is `0.0` until the engine
+    /// has spoken. The engine sets both at construction and clamps anything it
+    /// is sent to a sane range, so a client that edits the field before the
+    /// first state arrives cannot arm a zero threshold.
+    pub swr_guard: bool,
+    pub swr_limit: f32,
     /// Set when the SWR guard has tripped, holding the SWR that tripped it.
     /// While it is `Some`, transmit is refused until the operator acknowledges
     /// it with [`Command::ClearSwrTrip`].

--- a/crates/sdroxide-ui/src/app/frame.rs
+++ b/crates/sdroxide-ui/src/app/frame.rs
@@ -208,15 +208,11 @@ impl eframe::App for SdroxideApp {
                             // actually clears it in the engine.
                             if let Some(swr) = self.state.tx.swr_tripped {
                                 if ui
-                                    .button(
-                                        RichText::new("Acknowledge and re-enable transmit")
-                                            .size(13.0),
-                                    )
+                                    .button(RichText::new("Acknowledge").size(13.0))
                                     .on_hover_text(format!(
-                                        "The rig reported {swr:.1}:1. Check the antenna, feeder \
-                                         and any switch or ATU before transmitting again. If the \
-                                         fault is still there, the guard will stop the next \
-                                         transmission too."
+                                        "Re-enables transmit after {swr:.1}:1. Check the antenna \
+                                         first: if the fault is still there, the next \
+                                         transmission stops too."
                                     ))
                                     .clicked()
                                 {

--- a/crates/sdroxide-ui/src/app/frame.rs
+++ b/crates/sdroxide-ui/src/app/frame.rs
@@ -198,7 +198,32 @@ impl eframe::App for SdroxideApp {
                         ui.label(RichText::new("⚠").size(15.0).color(mark));
                         ui.label(RichText::new(notice).size(13.0).color(ink));
                         ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
-                            if ui.small_button("Dismiss").clicked() {
+                            // ⛔ A TRIPPED SWR GUARD IS NOT DISMISSIBLE, and the
+                            // distinction is the point. Plain "Dismiss" clears
+                            // the banner locally and changes nothing in the
+                            // engine, which for a latch would be the worst of
+                            // both worlds: the warning gone and transmit still
+                            // locked out, with nothing left on screen saying
+                            // why. The latch therefore gets its own button that
+                            // actually clears it in the engine.
+                            if let Some(swr) = self.state.tx.swr_tripped {
+                                if ui
+                                    .button(
+                                        RichText::new("Acknowledge and re-enable transmit")
+                                            .size(13.0),
+                                    )
+                                    .on_hover_text(format!(
+                                        "The rig reported {swr:.1}:1. Check the antenna, feeder \
+                                         and any switch or ATU before transmitting again. If the \
+                                         fault is still there, the guard will stop the next \
+                                         transmission too."
+                                    ))
+                                    .clicked()
+                                {
+                                    cmds.push(Command::ClearSwrTrip);
+                                    self.radio_notice = None;
+                                }
+                            } else if ui.small_button("Dismiss").clicked() {
                                 self.radio_notice = None;
                             }
                         });

--- a/crates/sdroxide-ui/src/app/settings/general.rs
+++ b/crates/sdroxide-ui/src/app/settings/general.rs
@@ -238,10 +238,12 @@ impl SdroxideApp {
                  or above this figure, stops the transmission and locks transmit out until you \
                  acknowledge it. Meant for the antenna that is not connected, the feeder that has \
                  failed, or the switch left on the wrong port. It needs a rig that reports SWR \
-                 over CAT; on one that does not, it never fires. It ignores the first fraction of \
-                 a second of each transmission and anything under 5 W, because the reading is not \
-                 trustworthy until power has risen. Acknowledging does not fix anything: if the \
-                 fault is still there, the next transmission is stopped too.",
+                 over CAT; on one that does not, it never fires. It ignores the first fifth of a \
+                 second of each transmission, because the reading is not trustworthy until the \
+                 transmitter has settled. It does NOT wait for high power: a rig that folds its \
+                 power back on high SWR is doing so because the SWR is bad, and that is precisely \
+                 when this has to work. Acknowledging does not fix anything: if the fault is \
+                 still there, the next transmission is stopped too.",
             )
             .size(10.5)
             .color(crate::theme::gray(140)),

--- a/crates/sdroxide-ui/src/app/settings/general.rs
+++ b/crates/sdroxide-ui/src/app/settings/general.rs
@@ -234,16 +234,11 @@ impl SdroxideApp {
         ui.add_space(6.0);
         ui.label(
             RichText::new(
-                "Reads the SWR the radio itself measures while transmitting, and if it stays at \
-                 or above this figure, stops the transmission and locks transmit out until you \
-                 acknowledge it. Meant for the antenna that is not connected, the feeder that has \
-                 failed, or the switch left on the wrong port. It needs a rig that reports SWR \
-                 over CAT; on one that does not, it never fires. It ignores the first fifth of a \
-                 second of each transmission, because the reading is not trustworthy until the \
-                 transmitter has settled. It does NOT wait for high power: a rig that folds its \
-                 power back on high SWR is doing so because the SWR is bad, and that is precisely \
-                 when this has to work. Acknowledging does not fix anything: if the fault is \
-                 still there, the next transmission is stopped too.",
+                "Stops the transmission when the radio reports an SWR at or above this figure, and \
+                 keeps transmit locked out until you acknowledge it. Catches a disconnected \
+                 antenna, a failed feeder, or a switch left on the wrong port.\n\n\
+                 Needs a rig that reports SWR over CAT. Ignores the first fifth of a second of \
+                 each transmission, and does not wait for high power.",
             )
             .size(10.5)
             .color(crate::theme::gray(140)),

--- a/crates/sdroxide-ui/src/app/settings/general.rs
+++ b/crates/sdroxide-ui/src/app/settings/general.rs
@@ -4,8 +4,8 @@
 //! the CAT / Audio interface, since every other backend carries its audio
 //! in-band.
 
-use eframe::egui::{self, ComboBox, RichText};
-use sdroxide_types::{Region, RemoteAccess};
+use eframe::egui::{self, Color32, ComboBox, RichText};
+use sdroxide_types::{Command, Region, RemoteAccess};
 
 use crate::app::SdroxideApp;
 use crate::app::persist::band_plan_path;
@@ -186,6 +186,76 @@ impl SdroxideApp {
             .size(10.5)
             .color(crate::theme::gray(140)),
         );
+    }
+
+    /// The SWR guard: arm it, and set the ratio it stops transmitting at.
+    ///
+    /// Reads the live values out of the broadcast TX state rather than off
+    /// disk, so a remote client shows the radio's setting and not its own
+    /// machine's `config.toml`, which would be a different antenna entirely.
+    /// The command is sent only on an actual change, since a `DragValue` reports
+    /// its value every frame it is dragged and each one would be a config write.
+    pub(in crate::app) fn settings_swr_guard(
+        &self,
+        ui: &mut egui::Ui,
+        cmds: &mut Vec<Command>,
+    ) {
+        ui.label(RichText::new("SWR guard").strong());
+        ui.add_space(4.0);
+
+        let mut enabled = self.state.tx.swr_guard;
+        // The engine clamps this too; matching the range here keeps the widget
+        // from offering a value that would come back changed.
+        let mut limit = self.state.tx.swr_limit.clamp(1.1, 10.0);
+
+        ui.horizontal(|ui| {
+            if ui.checkbox(&mut enabled, "Stop transmitting on high SWR").changed() {
+                cmds.push(Command::SetSwrGuard { enabled, limit });
+            }
+        });
+        ui.add_enabled_ui(enabled, |ui| {
+            ui.horizontal(|ui| {
+                ui.label("Trip at");
+                let r = ui.add(
+                    egui::DragValue::new(&mut limit)
+                        .speed(0.1)
+                        .range(1.1..=10.0)
+                        .fixed_decimals(1)
+                        .suffix(":1"),
+                );
+                // `drag_stopped` and `lost_focus`, not `changed`: one command
+                // per settled value rather than one per frame of the drag.
+                if (r.drag_stopped() || r.lost_focus()) && limit != self.state.tx.swr_limit {
+                    cmds.push(Command::SetSwrGuard { enabled, limit });
+                }
+            });
+        });
+
+        ui.add_space(6.0);
+        ui.label(
+            RichText::new(
+                "Reads the SWR the radio itself measures while transmitting, and if it stays at \
+                 or above this figure, stops the transmission and locks transmit out until you \
+                 acknowledge it. Meant for the antenna that is not connected, the feeder that has \
+                 failed, or the switch left on the wrong port. It needs a rig that reports SWR \
+                 over CAT; on one that does not, it never fires. It ignores the first fraction of \
+                 a second of each transmission and anything under 5 W, because the reading is not \
+                 trustworthy until power has risen. Acknowledging does not fix anything: if the \
+                 fault is still there, the next transmission is stopped too.",
+            )
+            .size(10.5)
+            .color(crate::theme::gray(140)),
+        );
+        if let Some(swr) = self.state.tx.swr_tripped {
+            ui.add_space(4.0);
+            ui.label(
+                RichText::new(format!(
+                    "⚠ Currently tripped at {swr:.1}:1 — transmit is locked out."
+                ))
+                .size(11.0)
+                .color(Color32::from_rgb(255, 190, 70)),
+            );
+        }
     }
 
     /// The user's own speakers / microphone (applied live).

--- a/crates/sdroxide-ui/src/app/settings/mod.rs
+++ b/crates/sdroxide-ui/src/app/settings/mod.rs
@@ -1297,6 +1297,11 @@ impl SdroxideApp {
                 ui.add_space(10.0);
                 ui.separator();
                 ui.add_space(6.0);
+                self.settings_swr_guard(ui, cmds);
+
+                ui.add_space(10.0);
+                ui.separator();
+                ui.add_space(6.0);
                 self.settings_user_audio(ui, io.audio_pick);
                 // The radio's own sound card is only used by the CAT / Audio
                 // interface; every other backend carries its audio in-band.

--- a/src/gui_main.rs
+++ b/src/gui_main.rs
@@ -50,6 +50,8 @@ fn build_controller(
         initial_mode: boot.initial_mode,
         initial_antenna: boot.initial_antenna,
         tx_ham_only,
+        swr_guard: settings.swr_guard,
+        swr_limit: settings.swr_limit,
         reopen: boot.reopen,
         // This engine is one of the operator's radios: remember where they
         // leave it, in its own scope.

--- a/src/local_controller.rs
+++ b/src/local_controller.rs
@@ -89,6 +89,19 @@ impl LocalController {
 
 impl RadioController for LocalController {
     fn send(&mut self, cmd: Command) {
+        // The SWR guard is a station setting, not a session one: an operator
+        // who raises the limit for a dummy load expects it still raised
+        // tomorrow. Persisted on the way past, the same way the audio device
+        // selection is, and only for a LOCAL radio — a remote session's
+        // config.toml is on the client machine, which is the wrong one.
+        if let Command::SetSwrGuard { enabled, limit } = cmd {
+            let mut s = sdroxide_config::Settings::load();
+            s.swr_guard = enabled;
+            s.swr_limit = limit;
+            if let Err(e) = s.save() {
+                warn!("saving SWR guard setting: {e}");
+            }
+        }
         let _ = self.cmd_tx.send(cmd);
     }
 

--- a/src/server_main.rs
+++ b/src/server_main.rs
@@ -48,6 +48,13 @@ pub fn run(
                 initial_mode: boot.initial_mode,
                 initial_antenna: boot.initial_antenna,
                 tx_ham_only,
+                // The SWR guard matters MORE headless, not less: there is no
+                // operator watching the meter, so an unattended beacon or a
+                // remote client would otherwise keep transmitting into a fault
+                // indefinitely. The latch is cleared by a connected client
+                // acknowledging it.
+                swr_guard: settings.swr_guard,
+                swr_limit: settings.swr_limit,
                 // A headless server is typically started before the rig it
                 // talks to; the engine uses this to attach as soon as the
                 // radio is there.


### PR DESCRIPTION
sdroxide already reads the SWR the rig reports, shows it on the meter, announces it by speech and pushes it to TCI clients — but nothing ever acts on it. This adds the missing half: an optional guard that stops the transmission when the SWR is bad, and stays stopped until the operator says they have looked at it.

It is modelled on the equivalent feature in WSJT-X, which is where the request came from.

### What it does

While transmitting, the meter loop compares the rig's reported SWR against a limit. At or above it, the transmitter is unkeyed, transmit is latched out, and a persistent notice tells the operator to check the antenna. The latch clears only via `Command::ClearSwrTrip`, surfaced in the notice banner as an explicit button, so a fault cannot be dismissed into silence — if the antenna is still bad, the next over is stopped too.

`swr_guard` (on) and `swr_limit` (2.5:1) live in `config.toml` next to `tx_ham_only`, and both are editable in Settings → General.

**It is inert on any rig that does not report SWR**, so it costs nothing to leave enabled.

### Three decisions worth explaining

**Forward power is optional.** The first version required both an SWR and a forward-power reading before it would act. The CI-V driver sends `TxTelemetry { fwd_w: None, swr: Some(v) }`, so on every Icom that branch could never fire and the guard was dead code. It is now used only to reject a reading taken at essentially no power.

**There is no meaningful power floor.** The first version ignored readings below 5 W, to filter the key-up transient. That is self-defeating: a rig with SWR protection folds its power back *because* the SWR is bad — an IC-7300 dropped to 3 W into 7.5:1 — so any floor high enough to filter a transient is also high enough to gate out the emergency. Discarding the transient is a question of time, not power, so it is now done by time: SWR is ignored for the first six meter samples of each over (~0.2 s), and the trip needs six consecutive over-limit samples after that.

**The trip unkeys via `Command::SetPtt(false)`, not `deny_tx()`.** That helper only sets state flags, on its documented assumption that every deny happens before the transmitter keys — true of the rails in `sync_tx_state`, false here, where the rig is on the air. This follows the route the TCI starvation unkey already uses.

`TxState` gains `swr_guard`, `swr_limit` and `swr_tripped` so remote clients can show the setting and offer the acknowledgement, rather than each client reading a `config.toml` that may be on a different machine — the same reasoning that keeps the IARU region in the broadcast state. The engine clamps the limit to 1.1–10.0 so a client editing the field before the first state arrives cannot arm a threshold that refuses every transmission.

### Testing

`crates/sdroxide-radio/tests/swr_guard.rs`, six tests, all passing. They drive the real engine with a stand-in rig whose reported telemetry the test dictates, covering: the Icom shape (SWR present, forward power absent), a folded-back 3 W at 7.5:1, a good 1.3:1 left alone, a disarmed guard, a rig reporting no SWR, and a reading taken at genuinely 0 W. The first also asserts that the transmitter actually stops and that the next key-up is refused.

Also tested on air on an IC-7300 into a genuine 7.5:1: transmission stopped and the warning appeared.

One note in case it shows up in CI: `tests/scanner.rs::an_impossible_scan_is_refused_with_a_reason` fails for me, and it fails identically on an unmodified `main`, so it is not from this branch.

Happy to change any of the defaults, the wording, or where the settings live.
