### PR TITLE
Add a Test button for each logging service's credentials

### DIFF
--- a/crates/sdroxide-net/src/event.rs
+++ b/crates/sdroxide-net/src/event.rs
@@ -16,6 +16,10 @@ pub enum NetEvent {
     Callsign(CallsignInfo),
     /// One QSO/target upload result.
     Upload(UploadResult),
+    /// The outcome of checking one service's stored credentials. Distinct
+    /// from [`NetEvent::Upload`] because nothing was logged: this is an
+    /// answer about the account, not about a QSO.
+    LoginTest(sdroxide_types::LoginTestResult),
     /// Parsed confirmation records downloaded from LoTW/eQSL.
     Confirmations(Vec<QsoRecord>),
     /// WSPR reception reports fetched from WSPRnet — normally reports of *our*

--- a/crates/sdroxide-net/src/manager.rs
+++ b/crates/sdroxide-net/src/manager.rs
@@ -295,6 +295,35 @@ impl SpotManager {
         });
     }
 
+    /// Check one service's stored credentials; the result arrives via `poll`.
+    ///
+    /// On its own thread like every other network job, because these talk to
+    /// servers that can take seconds to answer and the UI thread is drawing a
+    /// waterfall. Read-only throughout: see [`crate::upload::test_login`].
+    ///
+    /// Tests the APPLIED config. The settings dialog therefore sends its edits
+    /// with [`sdroxide_types::Command::SetNetworkConfig`] immediately before
+    /// asking for a test, so what is checked is what is on screen: testing the
+    /// applied config alone would answer about the old password whenever
+    /// someone pasted a new one and pressed Test before Apply, which is exactly
+    /// when they would press it.
+    pub fn test_login(&self, target: sdroxide_types::LoginTarget) {
+        let cfg = self.cfg.clone();
+        let my_call = self.op_call.clone();
+        let tx = self.event_tx.clone();
+        std::thread::spawn(move || {
+            let (ok, message) = match crate::upload::test_login(&cfg, &my_call, target) {
+                Ok(m) => (true, m),
+                Err(e) => (false, e),
+            };
+            let _ = tx.send(NetEvent::LoginTest(sdroxide_types::LoginTestResult {
+                target,
+                ok,
+                message,
+            }));
+        });
+    }
+
     /// Download QSL confirmations; results arrive via `poll`.
     pub fn sync_confirmations(&self) {
         let cfg = self.cfg.clone();

--- a/crates/sdroxide-net/src/upload.rs
+++ b/crates/sdroxide-net/src/upload.rs
@@ -3,7 +3,7 @@
 //! (it requires TQSL signing) — the UI exports ADIF for the operator to sign;
 //! but confirmations can still be downloaded here to drive award tracking.
 
-use sdroxide_types::{NetworkConfig, QsoRecord, UploadTarget};
+use sdroxide_types::{LoginTarget, NetworkConfig, QsoRecord, UploadTarget};
 
 use crate::http;
 
@@ -101,6 +101,157 @@ fn upload_clublog(cfg: &NetworkConfig, my_call: &str, adif: &str) -> Result<Stri
     } else {
         Ok("Club Log: accepted".into())
     }
+}
+
+/// Check one service's stored credentials, without logging anything.
+///
+/// ⛔ NOTHING HERE MAY WRITE. A credential check that inserted a dummy QSO to
+/// see whether the login worked would put a fictional contact in the operator's
+/// permanent log and, for the services that forward to LoTW or an award
+/// programme, somewhere it cannot be withdrawn from. Every branch below uses
+/// the cheapest READ endpoint the service publishes, and the upload endpoints
+/// above are deliberately not reachable from here.
+///
+/// The message on success is what the operator sees next to the button, so it
+/// says something they can check against — the account or callsign the service
+/// answered for, where the service gives one.
+pub fn test_login(
+    cfg: &NetworkConfig,
+    my_call: &str,
+    target: LoginTarget,
+) -> Result<String, String> {
+    match target {
+        LoginTarget::Eqsl => test_eqsl(cfg),
+        LoginTarget::QrzLogbook => test_qrz(cfg),
+        LoginTarget::ClubLog => test_clublog(cfg, my_call),
+        LoginTarget::Lotw => test_lotw(cfg),
+    }
+}
+
+fn test_eqsl(cfg: &NetworkConfig) -> Result<String, String> {
+    if cfg.eqsl.user.trim().is_empty() || cfg.eqsl.password.trim().is_empty() {
+        return Err("username/password not set".into());
+    }
+    // The inbox download, asked for a date nothing can be newer than: the
+    // question is whether the login is accepted, not what is in the inbox, and
+    // this keeps eQSL from building an ADIF file to answer it.
+    let url = format!(
+        "https://www.eqsl.cc/qslcard/DownloadInBox.cfm?UserName={}&Password={}&RcvdSince=20991231",
+        urlencode(cfg.eqsl.user.trim()),
+        urlencode(cfg.eqsl.password.trim())
+    );
+    let page = http::get(&url)?;
+    let text = strip_html(&page);
+    let low = text.to_ascii_lowercase();
+    // Every rule below is taken from what eQSL actually returned on 17 August
+    // 2026, for a good login, a good login with nothing to fetch, and a
+    // deliberately wrong password. Guessing at this is how the first version
+    // managed to be wrong in both directions at once: eQSL says
+    // "Error: No such Username/Password found", which contains neither "invalid"
+    // nor "not found", and its empty-inbox answer is "You have no log entries",
+    // which contains neither "no qso" nor a ".adi" link.
+    if low.contains("no such username/password") || low.contains("error:") {
+        let line = text
+            .lines()
+            .map(str::trim)
+            .find(|l| l.to_ascii_lowercase().contains("error") || l.to_ascii_lowercase().contains("no such"))
+            .unwrap_or("login rejected");
+        return Err(line.trim_start_matches("Error:").trim().chars().take(120).collect());
+    }
+    if low.contains("no log entries") || low.contains("has been built") || page.to_ascii_lowercase().contains(".adi") {
+        return Ok(format!("signed in as {}", cfg.eqsl.user.trim()));
+    }
+    Err("unexpected reply; check the username and password".into())
+}
+
+fn test_qrz(cfg: &NetworkConfig) -> Result<String, String> {
+    if cfg.qrz_logbook_key.trim().is_empty() {
+        return Err("API key not set".into());
+    }
+    // STATUS reports the logbook's own details and inserts nothing. This is the
+    // one service of the four with an endpoint meant for exactly this.
+    let body = http::post_form(
+        "https://logbook.qrz.com/api",
+        &[("KEY", cfg.qrz_logbook_key.trim()), ("ACTION", "STATUS")],
+    )?;
+    let kv = parse_kv(&body);
+    let get = |k: &str| kv.iter().find(|(a, _)| a == k).map(|(_, v)| v.clone());
+    match get("RESULT").as_deref() {
+        Some("OK") => {
+            let call = get("CALLSIGN").unwrap_or_else(|| "logbook".into());
+            match get("COUNT") {
+                Some(n) => Ok(format!("{call}, {n} QSOs")),
+                None => Ok(call),
+            }
+        }
+        _ => Err(get("REASON")
+            .or_else(|| get("STATUS"))
+            .unwrap_or_else(|| "key rejected".into())
+            .chars()
+            .take(120)
+            .collect()),
+    }
+}
+
+/// Club Log needs BOTH an account password and an API key, and the upload uses
+/// both, so a check that proved only one would pass while uploads still failed.
+/// They have separate read endpoints, so both are exercised.
+fn test_clublog(cfg: &NetworkConfig, my_call: &str) -> Result<String, String> {
+    if cfg.clublog.user.trim().is_empty() || cfg.clublog.password.trim().is_empty() {
+        return Err("email/password not set".into());
+    }
+    let call = my_call.trim();
+    if call.is_empty() {
+        return Err("station callsign not set".into());
+    }
+    // The OQRS ADIF download. `type=dxqsl` asks for OQRS requests rather than
+    // the whole log, so this stays small on a station with fifty thousand QSOs,
+    // and POST is required rather than GET.
+    //
+    // ⚠️ THIS CHECKS THE ACCOUNT, NOT THE API KEY, and the upload needs both.
+    // The documented key check is `GET /dxcc?call=&api=&full=1`, which returned
+    // 403 Forbidden on every attempt here on 17 August 2026, with and without a
+    // User-Agent, while the account call below succeeded from the same host
+    // seconds later. Rather than report a guess about the key, the message says
+    // which half was actually checked.
+    let body = http::post_form(
+        "https://clublog.org/getadif.php",
+        &[
+            ("email", cfg.clublog.user.trim()),
+            ("password", cfg.clublog.password.trim()),
+            ("call", call),
+            ("type", "dxqsl"),
+        ],
+    )?;
+    // A positive marker, not an error-word search: Club Log's own success text
+    // is prose, and a rule that hunts for "error" in prose eventually finds one.
+    if body.to_ascii_lowercase().contains("club log") {
+        return Ok(format!("{call}: account accepted (API key not checked)"));
+    }
+    Err(body.trim().chars().take(120).collect())
+}
+
+fn test_lotw(cfg: &NetworkConfig) -> Result<String, String> {
+    if cfg.lotw.user.trim().is_empty() || cfg.lotw.password.trim().is_empty() {
+        return Err("login not set".into());
+    }
+    // The same report the confirmation sync uses, bounded to a date that cannot
+    // return records, so this costs ARRL almost nothing to answer.
+    let url = format!(
+        "https://lotw.arrl.org/lotwuser/lotwreport.adi?login={}&password={}&qso_query=1&qso_qsl=yes&qso_qslsince=2099-12-31",
+        urlencode(cfg.lotw.user.trim()),
+        urlencode(cfg.lotw.password.trim())
+    );
+    let body = http::get(&url)?;
+    // A rejected login is an HTML page; an accepted one is ADIF, whose header
+    // ends in <eoh> even when no records follow.
+    if body.to_ascii_lowercase().contains("username/password") || body.contains("<!DOCTYPE") {
+        return Err("login rejected (LoTW returned its log-on page)".into());
+    }
+    if body.to_ascii_lowercase().contains("<eoh>") {
+        return Ok(format!("signed in as {}", cfg.lotw.user.trim()));
+    }
+    Err("unexpected reply; check the login and password".into())
 }
 
 /// Download QSL confirmations from LoTW and eQSL, returning parsed confirmation

--- a/crates/sdroxide-radio/src/engine.rs
+++ b/crates/sdroxide-radio/src/engine.rs
@@ -4157,6 +4157,7 @@ impl Engine {
 
             // Network cockpit (no RadioState change → return before the State
             // emit below).
+            TestLogin(target) => self.spots.test_login(target),
             SetNetworkConfig(cfg) => {
                 if let Err(e) = sdroxide_config::save_network_config(&cfg) {
                     warn!("saving network config: {e}");
@@ -5778,6 +5779,7 @@ impl Engine {
                 sdroxide_net::NetEvent::Status(s) => RadioEvent::NetStatus(s),
                 sdroxide_net::NetEvent::Callsign(c) => RadioEvent::CallsignResult(c),
                 sdroxide_net::NetEvent::Upload(r) => RadioEvent::Upload(r),
+                sdroxide_net::NetEvent::LoginTest(r) => RadioEvent::LoginTest(r),
                 sdroxide_net::NetEvent::Confirmations(r) => RadioEvent::Confirmations(r),
                 sdroxide_net::NetEvent::WsprSpots(s) => RadioEvent::WsprSpots(s),
                 sdroxide_net::NetEvent::PropPaths(p) => RadioEvent::PropPaths(p),

--- a/crates/sdroxide-server/src/lib.rs
+++ b/crates/sdroxide-server/src/lib.rs
@@ -743,6 +743,12 @@ fn handle_event(shared: &Shared, ev: RadioEvent) {
             // solar relay already carries what it adds up to. See
             // `RadioEvent::PropPaths`.
             RadioEvent::PropPaths(_) => None,
+            // Not forwarded, and the UI hides the buttons on a remote engine to
+            // match. The answer names the account the service recognised, which
+            // is the station owner's business rather than every connected
+            // client's, and it is only ever asked for from the machine the
+            // credentials live on. Same treatment as `RadioEvent::Notice`.
+            RadioEvent::LoginTest(_) => None,
         }
     };
     // The satellite half of the station config also drives this machine's own

--- a/crates/sdroxide-types/src/callsign.rs
+++ b/crates/sdroxide-types/src/callsign.rs
@@ -76,6 +76,43 @@ impl UploadTarget {
         [UploadTarget::Eqsl, UploadTarget::QrzLogbook, UploadTarget::ClubLog];
 }
 
+/// A service whose stored credentials can be checked without logging a QSO.
+///
+/// Deliberately a separate enum from [`UploadTarget`] rather than an extension
+/// of it. LoTW is testable but is not an upload target (its upload needs TQSL
+/// signing), and the two lists would drift apart the moment a download-only
+/// service was added.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub enum LoginTarget {
+    Eqsl,
+    QrzLogbook,
+    ClubLog,
+    Lotw,
+}
+
+impl LoginTarget {
+    pub fn label(self) -> &'static str {
+        match self {
+            LoginTarget::Eqsl => "eQSL",
+            LoginTarget::QrzLogbook => "QRZ Logbook",
+            LoginTarget::ClubLog => "Club Log",
+            LoginTarget::Lotw => "LoTW",
+        }
+    }
+
+    pub const ALL: [LoginTarget; 4] =
+        [LoginTarget::Eqsl, LoginTarget::QrzLogbook, LoginTarget::ClubLog, LoginTarget::Lotw];
+}
+
+/// The outcome of checking one service's stored credentials.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct LoginTestResult {
+    pub target: LoginTarget,
+    pub ok: bool,
+    /// What the service said, or why the check could not be made.
+    pub message: String,
+}
+
 /// The outcome of an upload attempt for one QSO to one target.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct UploadResult {

--- a/crates/sdroxide-types/src/command.rs
+++ b/crates/sdroxide-types/src/command.rs
@@ -1,7 +1,8 @@
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    AgcMode, Band, DigiConfig, Direction, ImageKind, Mode, NetworkConfig, NrLevel, QsoStep,
+    AgcMode, Band, DigiConfig, Direction, ImageKind, LoginTarget, Mode, NetworkConfig, NrLevel,
+    QsoStep,
     RadioConfig, RigctldConfig, RotatorConfig, RxId, SatConfig, SatLockConfig, SkimmerSettings,
     SpectrumConfig, SstvMode, TciServerConfig, TxEqState, UploadTarget, Vfo, WsjtxConfig,
 };
@@ -256,6 +257,12 @@ pub enum Command {
     /// Apply (and persist) the network-feature configuration: (re)connect the
     /// DX cluster, (dis)arm the POTA/SOTA/PSK feeds, and store credentials.
     SetNetworkConfig(NetworkConfig),
+    /// Check one logging service's credentials, without logging anything.
+    ///
+    /// Tests the APPLIED network config, so a dialog with unsaved edits sends
+    /// [`Command::SetNetworkConfig`] immediately before this one. The answer
+    /// comes back as [`crate::RadioEvent::LoginTest`].
+    TestLogin(LoginTarget),
     /// The operator's current dial frequency, so band-scoped feeds (PSK
     /// Reporter) can query the right slice. Sent by the engine on VFO change.
     SpotDialHint(f64),

--- a/crates/sdroxide-types/src/controller.rs
+++ b/crates/sdroxide-types/src/controller.rs
@@ -27,6 +27,9 @@ pub enum RadioEvent {
     /// audio input was unavailable or a mono card was selected for IQ). `None`
     /// clears it. Native-local only — not forwarded to remote clients.
     Notice(Option<String>),
+    /// The outcome of a credential check asked for by
+    /// [`crate::Command::TestLogin`]. Nothing was logged to produce it.
+    LoginTest(crate::LoginTestResult),
     /// FT8/FT4 decodes from one receive slot.
     Ft8Decodes(Vec<Decode>),
     /// FT8/FT4 engine status change.

--- a/crates/sdroxide-types/src/lib.rs
+++ b/crates/sdroxide-types/src/lib.rs
@@ -71,7 +71,9 @@ pub use band_segments::{
 };
 pub use bandplan::{BandPlan, BandPlanError, RegionPlan, band_plan, set_band_plan};
 pub use broadcast::{BroadcastStation, BroadcastStations};
-pub use callsign::{CallsignInfo, UploadResult, UploadTarget};
+pub use callsign::{
+    CallsignInfo, LoginTarget, LoginTestResult, UploadResult, UploadTarget,
+};
 pub use caps::{DeviceCaps, Direction, GainElement};
 pub use command::Command;
 pub use contacts::FsqContact;

--- a/crates/sdroxide-ui/src/app/frame.rs
+++ b/crates/sdroxide-ui/src/app/frame.rs
@@ -693,6 +693,14 @@ impl eframe::App for SdroxideApp {
         }
 
         for c in cmds {
+            // Marked here rather than at the button, because the settings panel
+            // holds borrows of `self` while it draws and cannot take a mutable
+            // one. This is the point where the command is definitely going out,
+            // which is the honest moment to call the check "in flight" anyway.
+            if let Command::TestLogin(t) = &c {
+                self.login_tests_pending.insert(*t);
+                self.login_tests.remove(t);
+            }
             self.ctrl.send(c);
         }
 
@@ -833,6 +841,15 @@ impl SdroxideApp {
                         self.speech.announcer.on_error(&e, now);
                     }
                     self.error = Some(e);
+                }
+                RadioEvent::LoginTest(r) => {
+                    self.login_tests_pending.remove(&r.target);
+                    self.push_net_log(format!(
+                        "{}: {}",
+                        r.target.label(),
+                        if r.ok { format!("ok, {}", r.message) } else { r.message.clone() }
+                    ));
+                    self.login_tests.insert(r.target, r);
                 }
                 RadioEvent::Notice(n) => {
                     if self.focused {

--- a/crates/sdroxide-ui/src/app/mod.rs
+++ b/crates/sdroxide-ui/src/app/mod.rs
@@ -481,6 +481,12 @@ pub struct SdroxideApp {
     net_rbn_cmds: String,
     /// Rolling upload/lookup result log for the spots window (newest first).
     net_log: Vec<String>,
+    /// Latest credential-check result per logging service, and which checks are
+    /// still in flight. Not persisted: an answer from an hour ago says nothing
+    /// about the password typed since, and a stale green tick is worse than no
+    /// tick at all.
+    login_tests: std::collections::HashMap<sdroxide_types::LoginTarget, sdroxide_types::LoginTestResult>,
+    login_tests_pending: std::collections::HashSet<sdroxide_types::LoginTarget>,
     /// Inbox for an ADIF file chosen via the native "Import" dialog (a picker
     /// thread writes; the UI drains it each frame).
     adif_import_inbox: Arc<Mutex<Option<String>>>,
@@ -935,6 +941,8 @@ impl SdroxideApp {
             net_cluster_cmds: String::new(),
             net_rbn_cmds: String::new(),
             net_log: Vec::new(),
+            login_tests: std::collections::HashMap::new(),
+            login_tests_pending: std::collections::HashSet::new(),
             adif_import_inbox: Arc::new(Mutex::new(None)),
             pending_lookups: Vec::new(),
             callsign_cache: Default::default(),

--- a/crates/sdroxide-ui/src/app/settings/mod.rs
+++ b/crates/sdroxide-ui/src/app/settings/mod.rs
@@ -26,7 +26,7 @@ pub(in crate::app) mod tle;
 pub(in crate::app) mod ui_tab;
 
 use eframe::egui::{self, Color32, ComboBox, RichText};
-use sdroxide_types::{Command, LookupProvider, NetworkConfig};
+use sdroxide_types::{Command, LoginTarget, LookupProvider, NetworkConfig};
 
 use self::controls::settings_controls_tab;
 use self::general::{device_combo, region_combo, remote_access_settings};
@@ -2212,9 +2212,20 @@ impl SdroxideApp {
                     ui.checkbox(&mut io.net_edit.auto_upload_clublog, "Club Log");
                 });
 
+                // Only where the engine is in this process: the result is not
+                // sent to remote clients, so a button there would spin for ever.
+                if !self.ctrl.engine_is_remote() {
+                    self.login_test_row(ui, cmds, io.net_edit, LoginTarget::Eqsl);
+                    self.login_test_row(ui, cmds, io.net_edit, LoginTarget::QrzLogbook);
+                    self.login_test_row(ui, cmds, io.net_edit, LoginTarget::ClubLog);
+                }
+
                 net_heading(ui, "Confirmations (download)");
                 net_row(ui, "LoTW user", &mut io.net_edit.lotw.user, 140.0);
                 net_secret(ui, "LoTW pass", &mut io.net_edit.lotw.password, 140.0);
+                if !self.ctrl.engine_is_remote() {
+                    self.login_test_row(ui, cmds, io.net_edit, LoginTarget::Lotw);
+                }
                 ui.label(
                     RichText::new(
                         "LoTW upload uses TQSL — export ADIF from the logbook and sign it. \

--- a/crates/sdroxide-ui/src/app/settings/net.rs
+++ b/crates/sdroxide-ui/src/app/settings/net.rs
@@ -249,3 +249,56 @@ pub(in crate::app) fn broadcast_stations_settings(
         .weak(),
     );
 }
+
+impl crate::app::SdroxideApp {
+    /// One "Test" button and its answer, for a logging service's credentials.
+    ///
+    /// The point of it: today the first sign that a password is wrong is a QSO
+    /// that failed to upload, hours after the contact. This asks the service
+    /// directly, before anything depends on the answer.
+    ///
+    /// ⛔ It sends the EDITED config first. The engine tests what it has
+    /// applied, so without that a freshly pasted key would be checked against
+    /// the old one, and the operator would be told their new credentials were
+    /// wrong when they had simply not been saved yet. Pressing Test therefore
+    /// also applies the network settings, which is what someone pressing it
+    /// means, and the label says so.
+    ///
+    /// Nothing is cached between sessions: a green tick from an hour ago says
+    /// nothing about the password typed since.
+    pub(in crate::app) fn login_test_row(
+        &self,
+        ui: &mut egui::Ui,
+        cmds: &mut Vec<sdroxide_types::Command>,
+        edited: &sdroxide_types::NetworkConfig,
+        target: sdroxide_types::LoginTarget,
+    ) {
+        ui.horizontal(|ui| {
+            let pending = self.login_tests_pending.contains(&target);
+            let btn = ui.add_enabled(
+                !pending,
+                egui::Button::new(RichText::new(format!("Test {}", target.label())).size(11.0)),
+            );
+            if btn
+                .on_hover_text(
+                    "Ask the service whether these credentials work. Applies the settings above \
+                     first, and logs nothing: it only reads.",
+                )
+                .clicked()
+            {
+                cmds.push(sdroxide_types::Command::SetNetworkConfig(edited.clone()));
+                cmds.push(sdroxide_types::Command::TestLogin(target));
+            }
+            if pending {
+                ui.label(RichText::new("checking…").size(11.0).weak());
+            } else if let Some(r) = self.login_tests.get(&target) {
+                let (mark, colour) = if r.ok {
+                    ("✔", crate::theme::GREEN())
+                } else {
+                    ("✖", Color32::from_rgb(255, 120, 120))
+                };
+                ui.label(RichText::new(format!("{mark} {}", r.message)).size(11.0).color(colour));
+            }
+        });
+    }
+}


### PR DESCRIPTION
Today the first sign that an eQSL password or a QRZ key is wrong is a QSO that failed to upload, hours after the contact. This adds a Test button beside each set of credentials in Settings, so the answer is available before anything depends on it.

Covers eQSL, QRZ Logbook, Club Log and LoTW.

### Nothing here writes

A credential check that inserted a dummy QSO to see whether the login worked would put a fictional contact in the operator's permanent log, and for the services that feed award programmes, somewhere it cannot easily be withdrawn from. Every branch uses the cheapest read endpoint the service publishes, and the upload functions are not reachable from `test_login`.

### The reply rules came from the services, not from the docs

This is the part I would want a reviewer to check hardest, so it is worth saying how it was arrived at. Every rule below is taken from what the service actually returned on 17 August 2026, verified for correct *and* wrong credentials wherever that could be done without risking a lockout.

- **eQSL** rejects with `Error: No such Username/Password found`, and reports an empty inbox as `You have no log entries`. My first version guessed at "invalid" / "not found" / "no qso" and was wrong in both directions at once: it would have passed a rejection and failed a good empty account. Verified both ways.
- **QRZ Logbook** has a `STATUS` action, which is the only endpoint of the four intended for exactly this. Verified against a real key and a bogus one (`invalid api key`).
- **Club Log**'s account is checked with `POST getadif.php` and `type=dxqsl`, so the whole log is not downloaded to answer the question.
- **LoTW** answers a bad login with its log-on page rather than an error, which is why the check looks for ADIF rather than for an error string. Worth knowing: LoTW logins are case-sensitive, and the username is the callsign in upper case, so a login that looks right can still be refused with nothing on the page saying why. That is precisely the kind of thing this button exists to surface.

### One gap, stated rather than hidden

**Club Log's API key is not checked, only the account.** The upload needs both. The documented key endpoint, `GET /dxcc?call=&api=&full=1`, returned `403 Forbidden` on every attempt here, with and without a User-Agent, seconds after the account call succeeded from the same host with the same key present in config. Rather than report a guess, the success message says `account accepted (API key not checked)`.

If there is a supported way to validate a key, I would happily add it and make that message unconditional.

### Smaller decisions

Pressing Test sends `SetNetworkConfig` first. Without that, a freshly pasted key would be checked against the previously applied one and reported wrong when it was merely unsaved, which is exactly when someone presses Test.

Results are not cached between sessions: a green tick from an hour ago says nothing about the password typed since.

The result is not forwarded to remote clients and the buttons are hidden there, matching how `RadioEvent::Notice` is handled, since the answer names the account the service recognised.

### Testing

Built and run on Linux/aarch64 against real eQSL, QRZ, Club Log and LoTW accounts. No automated tests: these hit live third-party services, and I did not want to add a suite that either needs credentials in CI or mocks the very reply formats that were the hard part. Happy to add tests over a fake HTTP layer if you would prefer them.

One unrelated note in case it appears in CI: `tests/scanner.rs::an_impossible_scan_is_refused_with_a_reason` fails for me, and fails identically on an unmodified `main`, so it is not from this branch.
