### PR TITLE
Hold the FT8 transmit frequency, and vet what actually radiates

### DIFF
--- a/crates/sdroxide-digi/src/controller.rs
+++ b/crates/sdroxide-digi/src/controller.rs
@@ -264,8 +264,24 @@ impl DigiController {
     /// one legitimate move into it — following the Fox once it has answered us —
     /// goes through [`tune_audio_hz`](Self::tune_audio_hz) instead.
     pub fn set_audio_hz(&mut self, hz: f32) {
+        // Held means held, whoever is asking. This is the operator's own route
+        // (a click on a decode or the waterfall, the offset box, a key binding)
+        // *and* the follow-the-DX branch of `start_qso`, so one check covers
+        // both the deliberate move and the automatic one.
+        if self.tx_held() {
+            return;
+        }
         let hz = if self.is_hound() { hz.max(sdroxide_types::FOX_ZONE_MAX_HZ) } else { hz };
         self.tune_audio_hz(hz);
+    }
+
+    /// True when the operator has pinned the transmit tone.
+    ///
+    /// Deliberately not overridable by a modifier key the way WSJT-X's Hold Tx
+    /// Freq is: the case this exists for is a licence edge, where a move made by
+    /// accident is an out-of-band transmission and not merely bad manners.
+    fn tx_held(&self) -> bool {
+        self.qso.status(false).config.hold_tx_freq
     }
 
     fn is_hound(&self) -> bool {
@@ -310,7 +326,9 @@ impl DigiController {
         // Where to answer from. Moving onto the DX's own frequency is the
         // obvious choice and the wrong one — see `pick_tx_freq`. A Hound is
         // exempt twice over: its calling frequency is the operator's, and the
-        // Fox's own half of the band is out of bounds.
+        // Fox's own half of the band is out of bounds. Both branches below are
+        // no-ops under `hold_tx_freq`, which is checked inside each of them
+        // rather than here, so every other caller is covered by the same gate.
         if !self.is_hound() {
             if self.qso.status(false).config.auto_tx_freq {
                 self.pick_tx_freq();
@@ -336,7 +354,9 @@ impl DigiController {
     fn pick_tx_freq(&mut self) {
         let cfg_ok = {
             let s = self.qso.status(false);
-            s.config.auto_tx_freq && s.config.dxped_mode == sdroxide_types::DxpedMode::Normal
+            !s.config.hold_tx_freq
+                && s.config.auto_tx_freq
+                && s.config.dxped_mode == sdroxide_types::DxpedMode::Normal
         };
         if !cfg_ok {
             return;
@@ -816,6 +836,60 @@ mod tests {
         c.set_config(DigiConfig { auto_tx_freq: false, ..cfg() });
         c.start_qso("K1ABC".into(), None, -10, 800.0, false);
         assert_eq!(c.audio_hz(), 800.0);
+    }
+
+    #[test]
+    fn holding_the_transmit_frequency_stops_every_mover() {
+        // The case this exists for: UK 60 m, where the allocation ends 1 kHz
+        // above a 5357 kHz dial and either automatic mover walks out of it.
+        let mut c = DigiController::new(
+            Mode::Ft8,
+            DigiConfig { hold_tx_freq: true, ..cfg() },
+            12_000.0,
+        );
+        // Placed by the sequencer's own route, which is what the operator's
+        // click becomes once the hold is lifted.
+        c.tune_audio_hz(820.0);
+
+        // 1. The operator's own set is refused while held — no modifier-key
+        //    escape, unlike WSJT-X's Hold Tx Freq.
+        c.set_audio_hz(2400.0);
+        assert_eq!(c.audio_hz(), 820.0, "an operator click moved a held frequency");
+
+        // 2. Answering a station does not follow it, with Auto TX FRQ either way.
+        c.start_qso("W9XYZ".into(), None, -10, 2400.0, false);
+        assert_eq!(c.audio_hz(), 820.0, "answering moved a held frequency");
+        c.set_config(DigiConfig { hold_tx_freq: true, auto_tx_freq: false, ..cfg() });
+        c.start_qso("K1ABC".into(), None, -10, 2400.0, false);
+        assert_eq!(c.audio_hz(), 820.0, "follow-the-DX moved a held frequency");
+
+        // 3. Calling CQ does not hunt for a clear slot. `pick_tx_freq` would
+        //    otherwise roam 400..2600 Hz, most of which is out of band here.
+        c.set_config(DigiConfig { hold_tx_freq: true, ..cfg() });
+        c.call_cq();
+        assert_eq!(c.audio_hz(), 820.0, "calling CQ moved a held frequency");
+
+        // Lifting it hands control back, and the operator's click lands.
+        c.set_config(DigiConfig { hold_tx_freq: false, ..cfg() });
+        c.set_audio_hz(2400.0);
+        assert_eq!(c.audio_hz(), 2400.0, "lifting the hold did not release the frequency");
+    }
+
+    #[test]
+    fn a_held_hound_still_follows_the_fox() {
+        use sdroxide_types::DxpedMode;
+        // The one move a hold does not block: a Fox that has answered us owns
+        // the frequency the contact finishes on, and it is not ours to pin.
+        let mut c = DigiController::new(
+            Mode::Ft8,
+            DigiConfig { hold_tx_freq: true, dxped_mode: DxpedMode::Hound, ..cfg() },
+            12_000.0,
+        );
+        c.tune_audio_hz(1800.0);
+        c.start_qso("DX1FOX".into(), None, -10, 700.0, false);
+        assert_eq!(c.audio_hz(), 1800.0, "calling frequency should be held");
+        c.tune_audio_hz(700.0);
+        assert_eq!(c.audio_hz(), 700.0, "the Fox's QSY is exempt");
     }
 
     #[test]

--- a/crates/sdroxide-digi/src/controller.rs
+++ b/crates/sdroxide-digi/src/controller.rs
@@ -157,9 +157,13 @@ pub struct BurstPlayer {
     pub pos: usize,
 }
 
-/// The stretch of the passband [`clearest_tx_hz`] will choose from, and the
-/// grid it searches on. Kept inside the usual SSB filter with room for the
+/// The widest stretch of the passband [`clearest_tx_hz`] will choose from, and
+/// the grid it searches on. Kept inside the usual SSB filter with room for the
 /// ~50 Hz signal at either edge.
+///
+/// The band plan narrows this further where it has an opinion, so these are the
+/// outer bounds rather than the range actually searched. See
+/// [`DigiController::emission_permitted`].
 const TX_PICK_MIN_HZ: f32 = 400.0;
 const TX_PICK_MAX_HZ: f32 = 2600.0;
 const TX_PICK_STEP_HZ: f32 = 10.0;
@@ -176,9 +180,11 @@ const CLEAR_ENOUGH_HZ: f32 = 120.0;
 /// the spot furthest from all of them; among spots that are equally clear, the
 /// one nearest `current`, so the transmit marker doesn't wander across the band
 /// between contacts for no reason.
-fn clearest_tx_hz(busy: &[f32], current: f32) -> f32 {
+fn clearest_tx_hz(busy: &[f32], current: f32, permitted: impl Fn(f32) -> bool) -> f32 {
     let steps = ((TX_PICK_MAX_HZ - TX_PICK_MIN_HZ) / TX_PICK_STEP_HZ) as i32;
-    let candidates = || (0..=steps).map(|i| TX_PICK_MIN_HZ + i as f32 * TX_PICK_STEP_HZ);
+    let candidates = || {
+        (0..=steps).map(|i| TX_PICK_MIN_HZ + i as f32 * TX_PICK_STEP_HZ).filter(|&hz| permitted(hz))
+    };
     let clearance = |hz: f32| {
         busy.iter().map(|b| (b - hz).abs()).fold(f32::INFINITY, f32::min).min(CLEAR_ENOUGH_HZ)
     };
@@ -369,8 +375,42 @@ impl DigiController {
             })
             .map(|(_, hz)| *hz)
             .collect();
-        let hz = clearest_tx_hz(&busy, self.audio_hz);
+        let hz = clearest_tx_hz(&busy, self.audio_hz, |hz| self.emission_permitted(hz));
         self.tune_audio_hz(hz);
+    }
+
+    /// Would a signal at this offset sit inside the band plan's segment?
+    ///
+    /// The same question the engine's transmit lockout asks at key-down, asked
+    /// early so the automatic chooser stops picking slots that would then be
+    /// refused. Without it the two disagree in the one case that matters: on a
+    /// UK 60 m dial of 5357 kHz the allocation ends at 5358.0, so everything
+    /// above 950 Hz is out of band, while the chooser hunts to 2600 Hz and has
+    /// no idea. The operator gets a transmit lockout instead of a contact, and
+    /// nothing on screen says which of the two settings caused it.
+    ///
+    /// So Auto TX FRQ becomes usable where a licence is narrower than the mode's
+    /// habits, rather than being a thing to be avoided there. Hold TX is
+    /// unaffected and is still the way to pin an exact figure.
+    ///
+    /// Fails OPEN on the same rule as the lockout: unless the dial itself is
+    /// inside a listed segment, no opinion is offered. A band plan with a gap in
+    /// it must not silently strand the chooser with nowhere to go, and a mode
+    /// with no stated bandwidth is not one this can reason about.
+    ///
+    /// The dial here is the RECEIVE dial, which is the one the controller is
+    /// given. Under split or XIT the transmitted dial differs and this can
+    /// therefore approve a slot the lockout then refuses, which is exactly
+    /// today's behaviour and no worse. It cannot go the other way and approve
+    /// something that radiates out of band, because the lockout still has the
+    /// final say at key-down.
+    fn emission_permitted(&self, offset_hz: f32) -> bool {
+        let Some(bw) = self.mode().occupied_bw_hz() else { return true };
+        if sdroxide_types::segment_kind_at(self.dial_hz).is_none() {
+            return true;
+        }
+        let lo = self.dial_hz + f64::from(offset_hz);
+        sdroxide_types::span_within_segment(lo, lo + f64::from(bw))
     }
 
     /// Pick which message goes out next (the operator's Tx1–Tx6).
@@ -809,19 +849,42 @@ mod tests {
     }
 
     #[test]
+    fn the_chooser_stays_inside_what_the_band_plan_allows() {
+        // UK 60 m in the shape the chooser sees it: on a 5357 kHz dial the
+        // allocation ends at 5358.0, so an FT8 signal may start no higher than
+        // 950 Hz, while the search runs to 2600. The real predicate reads the
+        // band plan; here it is handed in directly, so this pins the CHOOSER
+        // and does not depend on which bandplan.json happens to be installed,
+        // nor touch the process-wide plan that other tests are reading.
+        let ceiling = 950.0;
+
+        // Crowded right up to the edge of what is legal. The quiet space above
+        // is the obvious choice and the illegal one.
+        let busy: Vec<f32> = (0..8).map(|i| 420.0 + i as f32 * 60.0).collect();
+        let hz = clearest_tx_hz(&busy, 1500.0, |hz| hz <= ceiling);
+        assert!(hz <= ceiling, "picked {hz} Hz, which is past the band edge");
+        assert!(hz >= TX_PICK_MIN_HZ, "picked {hz} Hz, below the search floor");
+
+        // Nothing legal anywhere: it stays put rather than jumping to an
+        // arbitrary edge. Declining to choose is the safe answer, and the
+        // transmit lockout is still there to refuse what it was already on.
+        assert_eq!(clearest_tx_hz(&[], 700.0, |_| false), 700.0);
+    }
+
+    #[test]
     fn the_transmit_frequency_goes_where_our_own_period_is_quiet() {
         // A crowded stretch below 1200 Hz and a clear one above it.
         let busy: Vec<f32> = (0..12).map(|i| 500.0 + i as f32 * 60.0).collect();
-        let hz = clearest_tx_hz(&busy, 1500.0);
+        let hz = clearest_tx_hz(&busy, 1500.0, |_| true);
         assert!(hz > 1220.0, "picked {hz} Hz, inside the crowd");
         assert!(busy.iter().all(|b| (b - hz).abs() >= 60.0), "picked {hz} Hz, on top of a station");
 
         // With the band empty it stays where it already is rather than
         // wandering off to an arbitrary edge.
-        assert_eq!(clearest_tx_hz(&[], 1500.0), 1500.0);
+        assert_eq!(clearest_tx_hz(&[], 1500.0, |_| true), 1500.0);
         // One station in the middle: it moves clear, but no further than it has
         // to — a spot 120 Hz away is as good as one 900 Hz away.
-        let hz = clearest_tx_hz(&[1500.0], 1500.0);
+        let hz = clearest_tx_hz(&[1500.0], 1500.0, |_| true);
         assert!((hz - 1500.0).abs() >= CLEAR_ENOUGH_HZ, "{hz} is still on top of them");
         assert!(
             (hz - 1500.0).abs() <= CLEAR_ENOUGH_HZ + TX_PICK_STEP_HZ,

--- a/crates/sdroxide-digi/src/controller.rs
+++ b/crates/sdroxide-digi/src/controller.rs
@@ -661,6 +661,12 @@ impl DigiController {
 }
 
 impl crate::DigiEngine for DigiController {
+    /// Straight to `tune_audio_hz`, deliberately bypassing the hold that
+    /// [`set_audio_hz`](DigiController::set_audio_hz) enforces. See the trait
+    /// method for why a band change is the exception.
+    fn restore_audio_hz(&mut self, hz: f32) {
+        self.tune_audio_hz(hz);
+    }
     fn mode(&self) -> Mode {
         DigiController::mode(self)
     }
@@ -873,6 +879,32 @@ mod tests {
         c.set_config(DigiConfig { hold_tx_freq: false, ..cfg() });
         c.set_audio_hz(2400.0);
         assert_eq!(c.audio_hz(), 2400.0, "lifting the hold did not release the frequency");
+    }
+
+    #[test]
+    fn a_band_change_reaches_a_held_frequency() {
+        use crate::DigiEngine as _;
+        // The second exception, and the reason it is one: a hold pins the tone
+        // against everything that would move it by itself, but a change of band
+        // is the operator's own act, and what comes back is a figure they set
+        // on that band themselves. Holding through it would carry 60 m's
+        // sub-1 kHz figure onto 20 m, or 20 m's 1500 onto 60 m, where it cannot
+        // legally go.
+        let mut c = DigiController::new(
+            Mode::Ft8,
+            DigiConfig { hold_tx_freq: true, ..cfg() },
+            12_000.0,
+        );
+        c.tune_audio_hz(820.0);
+
+        // The ordinary route is still refused, so the hold is genuinely on and
+        // the restore below is not passing for the trivial reason.
+        c.set_audio_hz(1500.0);
+        assert_eq!(c.audio_hz(), 820.0, "an operator click moved a held frequency");
+
+        // The band-memory route goes through it.
+        c.restore_audio_hz(1500.0);
+        assert_eq!(c.audio_hz(), 1500.0, "a band change did not reach a held frequency");
     }
 
     #[test]

--- a/crates/sdroxide-digi/src/lib.rs
+++ b/crates/sdroxide-digi/src/lib.rs
@@ -78,6 +78,20 @@ pub trait DigiEngine: Send {
     fn abort_tx(&mut self);
     fn set_config(&mut self, cfg: DigiConfig);
     fn set_audio_hz(&mut self, hz: f32);
+    /// Put the transmit tone back where the operator last left it on this band.
+    ///
+    /// Separate from [`set_audio_hz`](Self::set_audio_hz) because it is the one
+    /// move Hold TX does not block. Hold exists to stop the tone drifting on its
+    /// own; changing band is the operator's own act, and the figure being
+    /// restored is one they chose there themselves. Holding through a band
+    /// change would instead carry a licence-edge figure onto a band that does
+    /// not want it, or 1500 Hz onto one that cannot have it.
+    ///
+    /// Defaults to the ordinary route, so a mode with no hold of its own, and
+    /// no per-band memory, needs no implementation.
+    fn restore_audio_hz(&mut self, hz: f32) {
+        self.set_audio_hz(hz);
+    }
     fn audio_hz(&self) -> f32;
     fn status(&self) -> DigiStatus;
 

--- a/crates/sdroxide-proto/src/lib.rs
+++ b/crates/sdroxide-proto/src/lib.rs
@@ -385,7 +385,14 @@ use sdroxide_types::{
 /// client can survive: postcard is positional and every field after it shifts.
 /// `#[serde(default)]` covers the config file on disk, not the wire. The engine
 /// gained `Settings.tx_guard_offset`, but that is local and not on the wire.
-pub const PROTO_VERSION: u16 = 66;
+///
+/// **67** — the transmit tone is remembered per band. `DigiConfig` gained
+/// `tx_audio_hz`, a map from `Band` to the offset last chosen there, and the
+/// same reasoning as 66 applies unchanged: it sits inside `DigiStatus`,
+/// postcard is positional, and a v66 client reading a v67 status runs into the
+/// wrong field. `#[serde(default)]` again covers the config file and not the
+/// wire. The engine's `digi_tx_band` is local state and is not sent.
+pub const PROTO_VERSION: u16 = 67;
 const VERSION_BYTE: u8 = 0x12;
 
 #[derive(Debug, thiserror::Error)]

--- a/crates/sdroxide-proto/src/lib.rs
+++ b/crates/sdroxide-proto/src/lib.rs
@@ -379,7 +379,13 @@ use sdroxide_types::{
 /// the new block on the end stops at the wrong byte, and the LimeRFE settings
 /// it cannot decode are the ones that decide whether an amplifier is switched
 /// into the transmit path.
-pub const PROTO_VERSION: u16 = 65;
+///
+/// **66** — the transmit tone can be held. `DigiConfig` gained `hold_tx_freq`,
+/// and `DigiConfig` travels inside `DigiStatus`, so this is not an append a v65
+/// client can survive: postcard is positional and every field after it shifts.
+/// `#[serde(default)]` covers the config file on disk, not the wire. The engine
+/// gained `Settings.tx_guard_offset`, but that is local and not on the wire.
+pub const PROTO_VERSION: u16 = 66;
 const VERSION_BYTE: u8 = 0x12;
 
 #[derive(Debug, thiserror::Error)]

--- a/crates/sdroxide-radio/src/engine.rs
+++ b/crates/sdroxide-radio/src/engine.rs
@@ -8044,6 +8044,51 @@ impl Engine {
                      --oob-tx, if you are licensed to transmit here)",
                 );
             }
+            // The dial is not what goes out. A digital mode transmits at the
+            // dial PLUS its audio offset, so every check above — this radio's
+            // range, the amateur-band rail — has been vetting a frequency we do
+            // not radiate. On most bands the gap does not matter, because the
+            // conventional dial sits kilohertz below the edge. Where a licence
+            // is narrower than the band plan it matters entirely.
+            //
+            // UK 60 m is the case that earned it: on a 5357 kHz dial the
+            // allocation ends at 5358.0, an audio offset over 1 kHz is out of
+            // band, and `Band::containing` says 60 m throughout because the
+            // built-in table carries the WRC-15 allocation (5351.5–5366.5) that
+            // most of Region 1 actually has.
+            //
+            // So this is checked against the SUB-SEGMENTS rather than the band
+            // edges, because `bandplan.json` holds one range per band and eleven
+            // would be needed. An operator whose licence is narrower says so by
+            // narrowing the segments in that file; nothing here is UK-specific.
+            //
+            // It fails OPEN where the table says nothing: unless the dial is
+            // inside a listed segment, no opinion is offered. A band plan with a
+            // gap in it must not become a transmit lockout for the operator who
+            // is legitimately in that gap.
+            if self.tx_ham_only
+                && let Some(d) = self.digi.as_ref()
+                && let Some(bw) = d.mode().occupied_bw_hz()
+                && sdroxide_types::segment_kind_at(txf).is_some()
+            {
+                // Upper sideband, and the offset is the signal's LOWEST tone —
+                // the figure the waterfall shows and the one WSJT-X's Tx Freq
+                // means — so the emission runs from there up by its bandwidth.
+                let lo = txf + f64::from(d.audio_hz());
+                let hi = lo + f64::from(bw);
+                if !sdroxide_types::span_within_segment(lo, hi) {
+                    return self.deny_tx(&format!(
+                        "{:.3} kHz dial + {:.0} Hz offset puts {} from {:.3} to {:.3} kHz, which \
+                         leaves the band plan's segment — lower the transmit offset, or widen \
+                         the segment in bandplan.json if your licence allows it",
+                        txf / 1e3,
+                        d.audio_hz(),
+                        d.mode().label(),
+                        lo / 1e3,
+                        hi / 1e3,
+                    ));
+                }
+            }
             // Assert the app's current mode and power levels to the rig before
             // keying, so a CAT/TCI rig transmits in the right modulation at the
             // right drive even when the operator hasn't touched those controls

--- a/crates/sdroxide-radio/src/engine.rs
+++ b/crates/sdroxide-radio/src/engine.rs
@@ -4560,6 +4560,7 @@ impl Engine {
 
             // Digital modes (FT8/FT4).
             SetDigiConfig(c) => {
+                let c = keep_engine_owned(c, &self.digi_config);
                 self.digi_config = c.clone();
                 if let Some(d) = self.digi.as_mut() {
                     d.set_config(c);
@@ -9246,6 +9247,52 @@ fn encode_png_gray(gray: &[u8], w: u16, h: u16) -> Option<Vec<u8>> {
     let mut buf = std::io::Cursor::new(Vec::new());
     image::DynamicImage::ImageLuma8(img).write_to(&mut buf, image::ImageFormat::Png).ok()?;
     Some(buf.into_inner())
+}
+
+/// Replace the fields of an incoming [`DigiConfig`] that the engine owns rather
+/// than the client, leaving every genuine setting as sent.
+///
+/// Only `tx_audio_hz` so far, the per-band transmit offsets. They ride in
+/// `DigiConfig` because that is what reaches the config file, not because a
+/// client has any business setting them, and the panel seeds its editable copy
+/// from the first status and owns it from then on. So an incoming map is always
+/// a stale snapshot, and taking it discards every offset learned since that
+/// client started.
+///
+/// Found the hard way, minutes after the offsets went in. 60 m's was set,
+/// recorded and saved; ticking Hold TX a moment later sent a copy seeded before
+/// it existed, and the empty map went over the good file. Nothing reported a
+/// fault, because the write succeeded. A merge here cannot be defeated by a
+/// client that means no harm, where asking clients to send the map back
+/// faithfully could be defeated by any of them.
+fn keep_engine_owned(mut incoming: DigiConfig, current: &DigiConfig) -> DigiConfig {
+    incoming.tx_audio_hz = current.tx_audio_hz.clone();
+    incoming
+}
+
+#[cfg(test)]
+mod digi_config_tests {
+    use super::*;
+
+    #[test]
+    fn a_client_config_cannot_wipe_the_band_offsets() {
+        use sdroxide_types::Band;
+        // What the engine has learned: an offset the operator set on 60 m.
+        let mut current = DigiConfig::default();
+        current.tx_audio_hz.insert(Band::M60, 370.0);
+
+        // What a panel sends when a chip is toggled: its own copy, seeded
+        // before that offset existed, carrying an empty map and one real edit.
+        let incoming = DigiConfig { hold_tx_freq: true, ..DigiConfig::default() };
+
+        let merged = keep_engine_owned(incoming, &current);
+        assert_eq!(
+            merged.tx_audio_hz.get(&Band::M60).copied(),
+            Some(370.0),
+            "a chip toggle wiped the band offsets"
+        );
+        assert!(merged.hold_tx_freq, "and the edit the client actually made was lost");
+    }
 }
 
 #[cfg(test)]

--- a/crates/sdroxide-radio/src/engine.rs
+++ b/crates/sdroxide-radio/src/engine.rs
@@ -1336,6 +1336,12 @@ struct Engine {
     /// only while a digital mode is active.
     digi: Option<Box<dyn DigiEngine>>,
     digi_config: DigiConfig,
+    /// The band the running controller's transmit offset belongs to, so a move
+    /// to another one can be noticed. `None` means "not yet applied", which is
+    /// how a fresh controller asks for its band's stored offset: startup and a
+    /// mode change both go through the same path as a retune that way, rather
+    /// than each needing its own hook.
+    digi_tx_band: Option<sdroxide_types::Band>,
     /// True while the current TX burst is driven by the digi engine.
     digi_tx: bool,
     /// WSPR band hopping has been stood down because the operator moved the
@@ -1937,6 +1943,7 @@ fn engine_thread(
         audio_nr_level: NrLevel::Off,
         digi: None,
         digi_config,
+        digi_tx_band: None,
         digi_tx: false,
         hop_suspended: false,
         voice: VoiceKeyer::load(),
@@ -3354,6 +3361,32 @@ impl Engine {
 
     /// Tick the FT8/FT4 controller and apply its actions (emit events, key/
     /// unkey PTT). Owned actions avoid a `&mut self.digi` / `&mut self` clash.
+    /// Apply the transmit offset stored for the band the dial is on, when that
+    /// band has changed since the last one applied.
+    ///
+    /// Called from the poll rather than hooked onto the places that assign
+    /// `state.band`, of which there are four: two retune paths, a region change
+    /// and a band-plan reload, the last two moving the band under a dial that
+    /// never moved. One check at a known point covers all four and cannot be
+    /// forgotten by a fifth.
+    ///
+    /// A band with nothing stored is left alone rather than reset to 1500. The
+    /// operator is mid-session on a frequency they chose, and the memory has
+    /// nothing better to offer than what is already there.
+    fn follow_band_tx_offset(&mut self) {
+        let band = self.state.band;
+        if self.digi_tx_band == Some(band) {
+            return;
+        }
+        self.digi_tx_band = Some(band);
+        let Some(hz) = self.digi_config.tx_audio_hz.get(&band).copied() else { return };
+        if let Some(d) = self.digi.as_mut() {
+            // `restore_audio_hz`, not `set_audio_hz`: this is the one move that
+            // goes through a hold. See the trait method.
+            d.restore_audio_hz(hz);
+        }
+    }
+
     fn poll_digi(&mut self) {
         // A message the radio was keying itself has run its length: it is off
         // the air, so the station interlock goes back. Not while an ordinary
@@ -3366,6 +3399,7 @@ impl Engine {
                 self.release_tx_gate();
             }
         }
+        self.follow_band_tx_offset();
         let Some(digi) = self.digi.as_mut() else { return };
         let dial = self.state.rx_freq_hz();
         let actions = digi.poll(SystemTime::now(), dial);
@@ -3621,6 +3655,11 @@ impl Engine {
         // session a port whose other end has gone.
         self.packet_port = None;
         self.digi = Some(self.make_digi(mode, tap_rate));
+        // The new controller starts at the mode's default 1500 Hz whatever the
+        // last one was on, so the band's stored offset has to be applied again.
+        // Clearing this leaves that to `follow_band_tx_offset` on the next poll
+        // rather than repeating it here.
+        self.digi_tx_band = None;
         if mode == Mode::Cw {
             self.source.set_cw_wpm(self.digi_config.cw_wpm);
         }
@@ -4549,6 +4588,29 @@ impl Engine {
                     d.set_audio_hz(hz);
                 }
                 self.sync_cw_filter();
+                // Remembered against the band, and only here: this arm is the
+                // operator's own route (the offset box, the nudge chips, a click
+                // on a decode or the waterfall). The automatic movers never
+                // reach it, which is intended — the quietest slot this over is
+                // not a preference, and saving it would overwrite the figure
+                // that was chosen on purpose.
+                //
+                // Read back from the controller rather than stored as asked,
+                // because `hz` is a request: a hold refuses it outright and the
+                // Fox zone floors it, so the value on the air is the only one
+                // worth restoring later.
+                if let Some(actual) = self.digi.as_ref().map(|d| d.audio_hz()) {
+                    let band = self.state.band;
+                    if self.digi_config.tx_audio_hz.insert(band, actual) != Some(actual) {
+                        // Saved on every change, as every other setting here is.
+                        // The nudge chips can write repeatedly, which is a few
+                        // hundred bytes of JSON either way; the alternative is a
+                        // debounce that loses the last move on a crash.
+                        if let Err(e) = sdroxide_config::save_digi_config(&self.digi_config) {
+                            warn!("saving digi config: {e}");
+                        }
+                    }
+                }
             }
             DigiCallCq => {
                 if let Some(d) = self.digi.as_mut() {

--- a/crates/sdroxide-types/src/band_segments.rs
+++ b/crates/sdroxide-types/src/band_segments.rs
@@ -251,12 +251,41 @@ pub fn segment_kind_at(hz: f64) -> Option<SegmentKind> {
 /// 5358.0; the exclusive test would refuse it, and the operator who did the
 /// arithmetic correctly would be the one told no.
 ///
-/// A span straddling two adjacent segments is NOT accepted, even where they
-/// touch. Segments divide a band by usage as well as by legality, and the case
-/// this exists for is the licence edge, where the neighbour is not another
-/// segment but a gap.
+/// Touching segments are MERGED first, so a span crossing from one into the next
+/// is accepted where they meet. This asks a question about legality, not about
+/// band-plan etiquette: a signal reaching out of the digital sub-segment and
+/// into the phone one is in poor taste and is not out of band, and this is
+/// consulted by the transmit lockout, which must refuse only the latter.
+///
+/// Region 1's 160 m is the case that forced it. The plan runs 1.838–1.843 Digi
+/// and 1.843–2.000 Phone, so an FT8 signal on the conventional 1.840 dial leaves
+/// the digital segment at a 2950 Hz offset. Without the merge every offset above
+/// that was refused, on a band edge that is not one: 550 Hz of the mode's normal
+/// range, denied because two rows in a table happen to meet there.
+///
+/// A real GAP still stops it, which is the whole point. The UK's 60 m is eleven
+/// discrete slivers, and 5.358–5.362 is not an allocation at all, so a signal
+/// running past 5358.0 is not merged into anything and is correctly refused.
 pub fn span_within_segment_in(lo: f64, hi: f64, region: Region) -> bool {
-    segments_in(region).iter().any(|s| lo >= s.lo && hi <= s.hi)
+    let segs = segments_in(region);
+    // `segments_in` is sorted by lower edge and non-overlapping (the loader
+    // sorts it and complains about overlaps), so one pass finds the run.
+    let mut i = 0;
+    while i < segs.len() {
+        let start = segs[i].lo;
+        let mut end = segs[i].hi;
+        // Extend while the next segment begins exactly where this run ends.
+        // Sub-hertz slack because the edges come from MHz in `bandplan.json`.
+        while i + 1 < segs.len() && (segs[i + 1].lo - end).abs() < 0.5 {
+            i += 1;
+            end = segs[i].hi;
+        }
+        if lo >= start && hi <= end {
+            return true;
+        }
+        i += 1;
+    }
+    false
 }
 
 /// True when `lo..=hi` fits inside one sub-segment of the station's region.
@@ -762,6 +791,45 @@ mod tests {
         assert_eq!(segment_kind_at_in(7_074_000.0, Region::R1), Some(Digi));
         // Outside any HF ham segment.
         assert_eq!(segment_kind_at_in(15_000_000.0, Region::R1), None);
+    }
+
+    /// An emission has width, so the transmit lockout asks about a span rather
+    /// than a point. Two things have to hold at once, and they pull opposite
+    /// ways: a signal must be free to cross where the band plan merely changes
+    /// its mind about usage, and must be stopped where the allocation stops.
+    #[test]
+    fn a_span_may_cross_a_usage_boundary_but_not_a_gap() {
+        // Region 1's 160 m: Digi ends and Phone begins at 1.843, and nothing
+        // about that is a band edge. FT8 on the conventional 1.840 dial reaches
+        // past it at any offset over 2950 Hz, and refusing that would deny
+        // 550 Hz of the mode's normal range on a boundary that is not one.
+        let dial = 1_840_000.0;
+        let ft8 = 50.0;
+        for off in [200.0, 2950.0, 3000.0, 3500.0] {
+            assert!(
+                span_within_segment_in(dial + off, dial + off + ft8, Region::R1),
+                "160 m FT8 at {off} Hz should be allowed; it is inside the band throughout"
+            );
+        }
+        // Above the band itself is still refused. 2.000 is where Region 1's
+        // 160 m ends, and nothing is merged past it.
+        assert!(!span_within_segment_in(1_999_990.0, 2_000_050.0, Region::R1));
+
+        // The built-in Region 1 60 m is one all-modes block, so a signal
+        // anywhere inside it is fine. This is what a UK operator narrows by
+        // hand, and the narrowing is what the lockout then enforces; the
+        // built-in tables are the IARU allocation, not any one licence.
+        assert!(span_within_segment_in(5_357_950.0, 5_358_000.0, Region::R1));
+
+        // A gap is not merged away, which is the half that matters. Region 1
+        // has nothing between 2.000 and 3.500, so a span reaching into it is
+        // refused however close the neighbours are.
+        assert!(!span_within_segment_in(3_499_950.0, 3_500_050.0, Region::R1));
+
+        // The upper bound is inclusive: a transmission finishing exactly on a
+        // segment's top edge is permitted. Refusing it would fail the operator
+        // who did the arithmetic correctly.
+        assert!(span_within_segment_in(1_842_000.0, 1_843_000.0, Region::R1));
     }
 
     /// The places the three plans genuinely disagree — the point of the

--- a/crates/sdroxide-types/src/band_segments.rs
+++ b/crates/sdroxide-types/src/band_segments.rs
@@ -239,6 +239,31 @@ pub fn segment_kind_at(hz: f64) -> Option<SegmentKind> {
     segment_kind_at_in(hz, crate::region())
 }
 
+/// True when the whole span `lo..=hi` fits inside one sub-segment of `region`'s
+/// band plan.
+///
+/// Unlike [`segment_kind_at_in`], which asks about a point, this asks about an
+/// emission: a signal has width, and the question at a band edge is whether all
+/// of it is inside, not whether its carrier is.
+///
+/// The upper bound is INCLUSIVE, deliberately, where `segment_kind_at_in`'s is
+/// not. A segment ending at 5358.0 kHz permits a transmission reaching exactly
+/// 5358.0; the exclusive test would refuse it, and the operator who did the
+/// arithmetic correctly would be the one told no.
+///
+/// A span straddling two adjacent segments is NOT accepted, even where they
+/// touch. Segments divide a band by usage as well as by legality, and the case
+/// this exists for is the licence edge, where the neighbour is not another
+/// segment but a gap.
+pub fn span_within_segment_in(lo: f64, hi: f64, region: Region) -> bool {
+    segments_in(region).iter().any(|s| lo >= s.lo && hi <= s.hi)
+}
+
+/// True when `lo..=hi` fits inside one sub-segment of the station's region.
+pub fn span_within_segment(lo: f64, hi: f64) -> bool {
+    span_within_segment_in(lo, hi, crate::region())
+}
+
 /// True if `hz` falls in a CW sub-segment.
 pub fn is_cw_segment(hz: f64) -> bool {
     segment_kind_at(hz) == Some(SegmentKind::Cw)

--- a/crates/sdroxide-types/src/digi.rs
+++ b/crates/sdroxide-types/src/digi.rs
@@ -1732,6 +1732,34 @@ mod tests {
     use super::*;
 
     #[test]
+    fn a_band_keyed_offset_survives_the_config_file() {
+        // The failure this guards compiles perfectly and only shows at runtime:
+        // serde_json requires map keys to be strings, so a key type that
+        // serialises as anything else would make `save_digi_config` fail at the
+        // moment the operator sets an offset, leaving a log line and no saved
+        // figure. `Band` is a unit-variant enum and serialises as its name, and
+        // this pins that rather than trusting it.
+        let mut cfg = DigiConfig { my_call: "G4MQL".into(), ..DigiConfig::default() };
+        cfg.tx_audio_hz.insert(crate::Band::M60, 370.0);
+        cfg.tx_audio_hz.insert(crate::Band::M20, 1500.0);
+        let text = serde_json::to_string(&cfg).expect("a band-keyed map must serialise");
+        assert!(text.contains(r#""M60":370.0"#), "60 m's offset is not in the file: {text}");
+
+        let back: DigiConfig = serde_json::from_str(&text).expect("and must load again");
+        assert_eq!(back.tx_audio_hz.get(&crate::Band::M60).copied(), Some(370.0));
+        assert_eq!(back.tx_audio_hz.get(&crate::Band::M20).copied(), Some(1500.0));
+
+        // And a `digi.json` written before this field existed still loads, which
+        // is what `#[serde(default)]` is there for. Anything else would greet an
+        // operator with a config reset to defaults on the first run after an
+        // update, callsign included.
+        let old = r#"{"my_call":"G4MQL","my_grid":"IO81VS"}"#;
+        let loaded: DigiConfig = serde_json::from_str(old).expect("an old config must still load");
+        assert_eq!(loaded.my_call, "G4MQL");
+        assert!(loaded.tx_audio_hz.is_empty(), "a band with no entry must have none");
+    }
+
+    #[test]
     fn report_formatting() {
         assert_eq!(fmt_report(-13), "-13");
         assert_eq!(fmt_report(2), "+02");

--- a/crates/sdroxide-types/src/digi.rs
+++ b/crates/sdroxide-types/src/digi.rs
@@ -897,10 +897,32 @@ pub struct DigiConfig {
     /// tells us nothing about who is transmitting there when *we* do — and the
     /// station that is will not hear a word. With this on, the engine picks the
     /// quietest spot in the period we are about to transmit in, from the
-    /// stations it has actually decoded there. Turn it off to hold a frequency
-    /// by hand. Ignored in DXpedition mode, where both roles have their
-    /// frequencies decided for them.
+    /// stations it has actually decoded there. Ignored in DXpedition mode, where
+    /// both roles have their frequencies decided for them.
+    ///
+    /// Turning it OFF does not hold the frequency: it selects the other mover,
+    /// answering on the frequency of the station being called. To hold, see
+    /// [`hold_tx_freq`](Self::hold_tx_freq).
     pub auto_tx_freq: bool,
+    /// FT8/FT4: never move the transmit tone by itself, whatever else asks.
+    ///
+    /// The third state the pair above cannot express. `auto_tx_freq` chooses
+    /// *which* automatic mover runs, not whether one does: on, the engine hunts
+    /// the quietest slot between 400 and 2600 Hz; off, it jumps onto whichever
+    /// station is being answered. Both are wrong where the licence, and not the
+    /// band plan, sets the ceiling.
+    ///
+    /// The case that earned it is UK 60 m. On a 5357 kHz dial the allocation
+    /// ends at 5358.0, so the transmit tone must stay under 1 kHz, and either
+    /// mover will walk out of the band unprompted between one over and the next.
+    ///
+    /// With this on nothing moves the tone: not answering a station, not the
+    /// call queue walking on, not calling CQ, not a click on a decode or on the
+    /// waterfall. Turn it off to move, then on again. The one exception is a
+    /// Hound following the Fox that answered it, which is the DXpedition's
+    /// frequency to give and not ours to hold.
+    #[serde(default)]
+    pub hold_tx_freq: bool,
     /// FT8: which side of a DXpedition pile-up to operate (see [`DxpedMode`]).
     /// Ignored in every other mode.
     pub dxped_mode: DxpedMode,
@@ -1202,6 +1224,7 @@ impl Default for DigiConfig {
             sstv_tx_ppm: 0.0,
             rf_paint_speed: 0.25,
             auto_tx_freq: true,
+            hold_tx_freq: false,
             dxped_mode: DxpedMode::Normal,
             fox_slots: 3,
             rade_mute_analog: false,

--- a/crates/sdroxide-types/src/digi.rs
+++ b/crates/sdroxide-types/src/digi.rs
@@ -918,11 +918,39 @@ pub struct DigiConfig {
     ///
     /// With this on nothing moves the tone: not answering a station, not the
     /// call queue walking on, not calling CQ, not a click on a decode or on the
-    /// waterfall. Turn it off to move, then on again. The one exception is a
-    /// Hound following the Fox that answered it, which is the DXpedition's
-    /// frequency to give and not ours to hold.
+    /// waterfall. Turn it off to move, then on again.
+    ///
+    /// Two exceptions, both of them moves the operator has effectively asked
+    /// for. A Hound follows the Fox that answered it, which is the
+    /// DXpedition's frequency to give and not ours to hold. And a change of
+    /// band restores that band's own entry in
+    /// [`tx_audio_hz`](Self::tx_audio_hz), because holding through a band
+    /// change is what carries a licence-edge figure onto a band that does not
+    /// want it.
     #[serde(default)]
     pub hold_tx_freq: bool,
+    /// FT8/FT4: the transmit tone offset last chosen on each band, in Hz.
+    ///
+    /// Per band and not one figure for the station, because the constraint that
+    /// makes an offset worth remembering belongs to the band rather than to the
+    /// operator. UK 60 m holds the tone under 1 kHz; carrying that figure onto
+    /// 20 m would sit us at the bottom of the passband for no reason, and
+    /// carrying 20 m's usual 1500 back onto 60 m is out of band. WSJT-X
+    /// remembers this by MODE instead, which does not help here: the edge is a
+    /// property of where the dial is, not of what is being sent.
+    ///
+    /// Only the operator's own moves are recorded. An automatic hop (the
+    /// quietest-slot hunt, or answering a station where it transmits) is the
+    /// engine's choice for one over and not a preference to restore next time.
+    ///
+    /// A band with no entry starts at the mode's usual 1500 Hz.
+    ///
+    /// `HashMap` rather than `BTreeMap` because [`Band`](crate::Band) has no
+    /// `Ord` and should not gain one: its declaration order is a postcard wire
+    /// index with later bands appended out of place, so a derived ordering
+    /// would read as frequency order without being it.
+    #[serde(default)]
+    pub tx_audio_hz: std::collections::HashMap<crate::Band, f32>,
     /// FT8: which side of a DXpedition pile-up to operate (see [`DxpedMode`]).
     /// Ignored in every other mode.
     pub dxped_mode: DxpedMode,
@@ -1225,6 +1253,7 @@ impl Default for DigiConfig {
             rf_paint_speed: 0.25,
             auto_tx_freq: true,
             hold_tx_freq: false,
+            tx_audio_hz: std::collections::HashMap::new(),
             dxped_mode: DxpedMode::Normal,
             fox_slots: 3,
             rade_mute_analog: false,

--- a/crates/sdroxide-types/src/lib.rs
+++ b/crates/sdroxide-types/src/lib.rs
@@ -69,7 +69,8 @@ pub use band_segments::{
     WSPR_DIALS, digi_channels, digi_channels_for, digi_channels_in, digi_channels_in_region,
     is_auto_digi, is_cw_segment, is_digi_segment, is_psk_segment, is_psk_segment_in,
     is_rtty_segment, is_rtty_segment_in, psk_ranges, psk_ranges_in, rtty_ranges, rtty_ranges_in,
-    segment_kind_at, segment_kind_at_in, segments, segments_in, sstv_dials_in,
+    segment_kind_at, segment_kind_at_in, segments, segments_in, span_within_segment,
+    span_within_segment_in, sstv_dials_in,
 };
 pub use bandplan::{BandPlan, BandPlanError, RegionPlan, band_plan, set_band_plan};
 pub use broadcast::{BroadcastStation, BroadcastStations};

--- a/crates/sdroxide-types/src/mode.rs
+++ b/crates/sdroxide-types/src/mode.rs
@@ -228,6 +228,33 @@ impl Mode {
         matches!(self, Mode::Ft8 | Mode::Ft4 | Mode::Ft2 | Mode::Js8)
     }
 
+    /// How much spectrum this mode's signal occupies, in Hz, for the modes whose
+    /// answer is a property of the waveform rather than of a filter setting.
+    ///
+    /// `None` means "ask something else": SSB and NFM are as wide as the filter
+    /// the operator chose, and CW as wide as the fist sending it.
+    ///
+    /// Used by the transmit lockout, which needs to know how far above the
+    /// carrier the emission actually reaches. The figures are tones times tone
+    /// spacing: FT8 is 8 × 6.25, FT4 is 4 × 20.833, FT2 is 4 × 41.667 (see
+    /// `Ft2::TONE_SPACING_HZ`), WSPR is 4 × 1.4648.
+    ///
+    /// JS8 is given its WIDEST speed, Turbo's 160 Hz, because a `Mode` does not
+    /// know which speed is set — [`crate::Js8Speed::bandwidth_hz`] does, and is
+    /// the figure to prefer wherever the speed is in hand. Erring wide is the
+    /// right direction for a band-edge check and the wrong one for a display,
+    /// so do not reuse this for drawing.
+    pub fn occupied_bw_hz(self) -> Option<f32> {
+        match self {
+            Mode::Ft8 => Some(50.0),
+            Mode::Ft4 => Some(83.3),
+            Mode::Ft2 => Some(166.7),
+            Mode::Js8 => Some(crate::Js8Speed::Turbo.bandwidth_hz()),
+            Mode::Wspr => Some(6.0),
+            _ => None,
+        }
+    }
+
     /// True for WSPR. Its own controller and panel: it is slotted like FT8, but
     /// there is no QSO to sequence and what it decodes is a list of paths rather
     /// than a conversation.

--- a/crates/sdroxide-ui/src/app/frame.rs
+++ b/crates/sdroxide-ui/src/app/frame.rs
@@ -445,6 +445,12 @@ impl eframe::App for SdroxideApp {
                                 .as_ref()
                                 .map(|s| s.config.auto_tx_freq)
                                 .unwrap_or(true),
+                        mode.is_slotted()
+                            && self
+                                .digi_status
+                                .as_ref()
+                                .map(|s| s.config.hold_tx_freq)
+                                .unwrap_or(false),
                         &markers,
                         &ft8_spots,
                         &ft8_alpha,
@@ -589,6 +595,11 @@ impl eframe::App for SdroxideApp {
                         &mut self.trace_cache,
                         cw_pitch,
                         sdroxide_types::DxpedMode::Normal,
+                        false,
+                        // This waterfall is drawn for the non-slotted modes, so
+                        // there is no held FT8 transmit tone for a click to
+                        // disturb. The engine's own gate is the authority in any
+                        // case; this only decides whether the UI bothers asking.
                         false,
                         &[],
                         &cw_spots,

--- a/crates/sdroxide-ui/src/app/mod.rs
+++ b/crates/sdroxide-ui/src/app/mod.rs
@@ -323,6 +323,13 @@ pub struct SdroxideApp {
     /// by the round-tripped status echo. Seeded once from the first status.
     digi_cfg_edit: sdroxide_types::DigiConfig,
     digi_cfg_seeded: bool,
+    /// The FT8/FT4 transmit-offset box, as typed. Kept as text rather than a
+    /// number so a half-finished figure survives between frames: parsing every
+    /// keystroke would rewrite "8" to 200 before the 2 was pressed.
+    ///
+    /// Refreshed from the engine only while the box is NOT focused, so the
+    /// operator's typing is never overwritten by the value they are replacing.
+    digi_tx_hz_edit: String,
     /// SSTV image-mode panel state (gallery, TX slots, message, textures).
     sstv: SstvUi,
     /// RF Paint (Spectrum Painting) panel state (text/image + previews).
@@ -915,6 +922,7 @@ impl SdroxideApp {
             fsq_rx_images: Vec::new(),
             fsq_img_inbox: std::sync::Arc::new(std::sync::Mutex::new(None)),
             digi_cfg_seeded: false,
+            digi_tx_hz_edit: String::new(),
             digi_preview: None,
             map_view: Default::default(),
             band_conditions: None,

--- a/crates/sdroxide-ui/src/app/panels/decodes.rs
+++ b/crates/sdroxide-ui/src/app/panels/decodes.rs
@@ -190,6 +190,19 @@ impl SdroxideApp {
                 // whole range below it is the operator's to choose from, and a
                 // number printed in a tooltip is a number everyone sits on.
                 let our_hz = self.digi_status.as_ref().map(|s| s.audio_hz).unwrap_or(1500.0);
+                // The nudges land on round figures rather than stepping a flat
+                // 10 Hz, because a flat step preserves the last digit of
+                // wherever the tone happens to be sitting. A tone left at 373 by
+                // an automatic move or a waterfall click can then reach 363 and
+                // 383 and never 370 at all, however many times it is pressed.
+                // Reported from the station the day the box landed, having been
+                // tried: "it would not give me exact 370 so its 373".
+                //
+                // Nothing is lost by it. The step is unchanged where the tone is
+                // already round, and an exact figure of any kind still comes
+                // from the box beneath.
+                let step_down = ((our_hz / 10.0).ceil() - 1.0) * 10.0;
+                let step_up = ((our_hz / 10.0).floor() + 1.0) * 10.0;
                 // The three of them are one column, nudges above and typed
                 // figure below, rather than four items loose in the wrapping
                 // row. Loose, they sat side by side on a wide panel and broke
@@ -209,14 +222,10 @@ impl SdroxideApp {
                     ui.horizontal(|ui| {
                         ui.label(RichText::new("TX").size(11.0).color(crate::theme::gray(140)));
                         if crate::chrome::chip_enabled(ui, !held, false, "−").clicked() {
-                            cmds.push(Command::SetDigiAudioFreq(
-                                (our_hz - 10.0).clamp(200.0, 3500.0),
-                            ));
+                            cmds.push(Command::SetDigiAudioFreq(step_down.clamp(200.0, 3500.0)));
                         }
                         if crate::chrome::chip_enabled(ui, !held, false, "+").clicked() {
-                            cmds.push(Command::SetDigiAudioFreq(
-                                (our_hz + 10.0).clamp(200.0, 3500.0),
-                            ));
+                            cmds.push(Command::SetDigiAudioFreq(step_up.clamp(200.0, 3500.0)));
                         }
                     });
                     // The readout and the entry are the same widget: two of them

--- a/crates/sdroxide-ui/src/app/panels/decodes.rs
+++ b/crates/sdroxide-ui/src/app/panels/decodes.rs
@@ -187,44 +187,105 @@ impl SdroxideApp {
                 // whole range below it is the operator's to choose from, and a
                 // number printed in a tooltip is a number everyone sits on.
                 let our_hz = self.digi_status.as_ref().map(|s| s.audio_hz).unwrap_or(1500.0);
-                // Each control gated on its own rather than the group being
-                // wrapped in an `add_enabled_ui`, for the wrapping reason above.
-                ui.label(RichText::new("TX").size(11.0).color(crate::theme::gray(140)));
-                if crate::chrome::chip_enabled(ui, !held, false, "−").clicked() {
-                    cmds.push(Command::SetDigiAudioFreq((our_hz - 10.0).clamp(200.0, 3500.0)));
-                }
-                if crate::chrome::chip_enabled(ui, !held, false, "+").clicked() {
-                    cmds.push(Command::SetDigiAudioFreq((our_hz + 10.0).clamp(200.0, 3500.0)));
-                }
-                // The readout and the entry are the same widget: two of them
-                // would be two things to disagree with each other.
+                // The three of them are one column, nudges above and typed
+                // figure below, rather than four items loose in the wrapping
+                // row. Loose, they sat side by side on a wide panel and broke
+                // apart on a narrow one, so where the box appeared depended on
+                // the panel width and it could be separated from the chips that
+                // move the same number. As a column it is placed as a single
+                // item: the whole group wraps or none of it does.
                 //
-                // Speed 0 so it is a box you type in and not a slider a stray
-                // drag can push off a licence edge.
-                //
-                // Committed on LOST FOCUS (Enter, or clicking away) rather than
-                // on `changed()`, because a DragValue in text mode reparses as
-                // you type: `changed()` would fire on "8", then "82", then
-                // "820", sending three transmit-frequency changes for one
-                // figure, the first two of them wrong. And NO `.range()`, for
-                // the same reason — it clamps the value while the text is still
-                // half-typed, so the box fights the operator and "820" becomes
-                // "200" the moment the 8 is pressed. Clamped here instead, once,
-                // when the number is finished.
-                let mut typed = our_hz;
-                let resp = ui
-                    .add_enabled(
-                        !held,
-                        egui::DragValue::new(&mut typed).speed(0.0).fixed_decimals(0).suffix(" Hz"),
-                    )
-                    .on_hover_text(
-                        "Type the transmit offset in Hz, then press Enter. Where your licence \
-                         is narrower than the band plan the whole range below the edge is \
-                         yours to pick from, so nothing is suggested here.",
-                    );
-                if resp.lost_focus() && (typed - our_hz).abs() >= 0.5 {
-                    cmds.push(Command::SetDigiAudioFreq(typed.clamp(200.0, 3500.0)));
-                }
+                // Each control is still gated on its own rather than the column
+                // being wrapped in an `add_enabled_ui`. The rule about a child
+                // `Ui` not wrapping inside a `horizontal_wrapped` is what this
+                // column relies on, not an exception to it: the inner rows are
+                // meant to keep their shape. An enabling wrapper would be a
+                // second child for a different purpose, and greying out is what
+                // `chip_enabled` is for.
+                ui.vertical(|ui| {
+                    ui.horizontal(|ui| {
+                        ui.label(RichText::new("TX").size(11.0).color(crate::theme::gray(140)));
+                        if crate::chrome::chip_enabled(ui, !held, false, "−").clicked() {
+                            cmds.push(Command::SetDigiAudioFreq(
+                                (our_hz - 10.0).clamp(200.0, 3500.0),
+                            ));
+                        }
+                        if crate::chrome::chip_enabled(ui, !held, false, "+").clicked() {
+                            cmds.push(Command::SetDigiAudioFreq(
+                                (our_hz + 10.0).clamp(200.0, 3500.0),
+                            ));
+                        }
+                    });
+                    // The readout and the entry are the same widget: two of them
+                    // would be two things to disagree with each other.
+                    //
+                    // A `TextEdit` rather than the `DragValue` this started as.
+                    // Speed 0 stopped a drag from changing anything, but it did not
+                    // stop egui *advertising* one: the pointer still turned into the
+                    // horizontal resize arrows on hover, so the box offered a
+                    // gesture that had been deliberately killed. A text box promises
+                    // only what it delivers, and its caret says "type here" without
+                    // a tooltip having to say it.
+                    //
+                    // The buffer is refreshed from the engine only while the box is
+                    // NOT focused, and that is what makes typing survive at all: the
+                    // offset arrives afresh in every status frame, so reseeding on
+                    // top of a half-typed figure would rewrite it under the
+                    // operator's hands.
+                    //
+                    // Committed on LOST FOCUS (Enter, or clicking away) rather than
+                    // on every change, because the text is reparsed as it is typed:
+                    // committing on change would send "8", then "82", then "820" —
+                    // three transmit-frequency changes for one figure, the first two
+                    // of them wrong, and on 60 m the first two are the ones inside
+                    // the band. Clamped once, when the number is finished, rather
+                    // than continuously, which would fight the operator and turn
+                    // "820" into "200" the moment the 8 was pressed.
+                    //
+                    // Anything unparsable is simply not sent, and the box puts
+                    // itself right on the next unfocused frame from the engine's own
+                    // value. There is no error state to explain or dismiss.
+                    let tx_hz_id = ui.id().with("digi_tx_hz");
+                    if !ui.memory(|m| m.has_focus(tx_hz_id)) {
+                        let shown = format!("{our_hz:.0}");
+                        if self.digi_tx_hz_edit != shown {
+                            self.digi_tx_hz_edit = shown;
+                        }
+                    }
+                    let resp = ui
+                        .horizontal(|ui| {
+                            let r = ui
+                                .add_enabled(
+                                    !held,
+                                    egui::TextEdit::singleline(&mut self.digi_tx_hz_edit)
+                                        .id(tx_hz_id)
+                                        .desired_width(40.0),
+                                )
+                                .on_hover_text(
+                                    "Type the transmit offset in Hz, then press Enter. Where \
+                                     your licence is narrower than the band plan the whole \
+                                     range below the edge is yours to pick from, so nothing \
+                                     is suggested here.",
+                                );
+                            // The unit rides beside the box rather than inside
+                            // it. As a suffix it would be text sitting in the
+                            // buffer the operator is typing into, to be worked
+                            // around on every edit and parsed back off again.
+                            ui.label(
+                                RichText::new("Hz").size(11.0).color(crate::theme::gray(140)),
+                            );
+                            r
+                        })
+                        .inner;
+                    if resp.lost_focus() {
+                        if let Ok(v) = self.digi_tx_hz_edit.trim().parse::<f32>() {
+                            let v = v.clamp(200.0, 3500.0);
+                            if (v - our_hz).abs() >= 0.5 {
+                                cmds.push(Command::SetDigiAudioFreq(v));
+                            }
+                        }
+                    }
+                });
             }
             ui.add_space(8.0);
             // The same control the keyboard-mode panels carry, but it cannot be

--- a/crates/sdroxide-ui/src/app/panels/decodes.rs
+++ b/crates/sdroxide-ui/src/app/panels/decodes.rs
@@ -164,7 +164,10 @@ impl SdroxideApp {
                     .on_hover_text(
                         "Pin the transmit tone where it is. Nothing moves it: not answering a \
                          station, not the call queue, not calling CQ, not a click on a decode \
-                         or on the waterfall. Turn it off to move, then on again.\n\nFor where \
+                         or on the waterfall. Turn it off to move, then on again.\n\nChanging \
+                         band is the one exception, and it is your own act: the offset you last \
+                         set on the new band comes back with it, so a 60 m figure is not carried \
+                         onto 20 m and 20 m's is not carried onto 60 m.\n\nFor where \
                          the licence is narrower than the band plan — on a UK 60 m dial of \
                          5357 kHz the allocation ends at 5358.0, so the tone has to stay under \
                          1000 Hz, and either automatic mover will walk out of the band between \

--- a/crates/sdroxide-ui/src/app/panels/decodes.rs
+++ b/crates/sdroxide-ui/src/app/panels/decodes.rs
@@ -135,18 +135,95 @@ impl SdroxideApp {
             // than in the setup window because it decides what clicking a
             // decode in this list does.
             if self.digi_cfg_seeded {
+                let held = self.digi_cfg_edit.hold_tx_freq;
                 let auto = self.digi_cfg_edit.auto_tx_freq;
-                if crate::chrome::chip(ui, auto, "Auto TX FRQ")
-                    .on_hover_text(
+                // Greyed while held, because held wins: leaving it live would
+                // offer a choice between two movers neither of which can run.
+                // `chip_enabled`, not a bare `add_enabled_ui`: this row is
+                // `horizontal_wrapped`, and a child Ui inside one does not wrap.
+                let auto_chip = crate::chrome::chip_enabled(ui, !held, auto && !held, "Auto TX FRQ")
+                    .on_hover_text(if held {
+                        "Overridden by Hold TX. Lift the hold to choose which way the transmit \
+                         frequency moves."
+                    } else {
                         "Pick our transmit frequency automatically: the quietest spot in the \
                          period we transmit in, rather than the frequency of whoever we are \
                          answering — they transmit in the other period, so theirs says nothing \
-                         about who is there when we key. Off holds the frequency you set.",
+                         about who is there when we key. Off does NOT hold the frequency: it \
+                         answers on the frequency of the station being called. To hold, use \
+                         Hold TX."
+                    });
+                if auto_chip.clicked() {
+                    self.digi_cfg_edit.auto_tx_freq = !auto;
+                    cmds.push(Command::SetDigiConfig(self.digi_cfg_edit.clone()));
+                }
+                // The third state neither setting above can express: don't move
+                // at all. For the licence edges, where the band plan is wider
+                // than what we are allowed to key into.
+                if crate::chrome::chip(ui, held, "Hold TX")
+                    .on_hover_text(
+                        "Pin the transmit tone where it is. Nothing moves it: not answering a \
+                         station, not the call queue, not calling CQ, not a click on a decode \
+                         or on the waterfall. Turn it off to move, then on again.\n\nFor where \
+                         the licence is narrower than the band plan — on a UK 60 m dial of \
+                         5357 kHz the allocation ends at 5358.0, so the tone has to stay under \
+                         1000 Hz, and either automatic mover will walk out of the band between \
+                         one over and the next.",
                     )
                     .clicked()
                 {
-                    self.digi_cfg_edit.auto_tx_freq = !auto;
+                    self.digi_cfg_edit.hold_tx_freq = !held;
                     cmds.push(Command::SetDigiConfig(self.digi_cfg_edit.clone()));
+                }
+                // Our own transmit offset: readout, ±10 Hz, and a box to type
+                // it into. FT8 and FT4 were the only slotted modes without one
+                // — JS8, FSQ, CW and the text modem all have the nudge pair —
+                // so the offset could be placed only by clicking the waterfall,
+                // which is not a way to land on an exact figure. A hold is only
+                // as good as the ability to set what is being held.
+                //
+                // No suggested value anywhere here, deliberately. Where the
+                // ceiling is the licence's rather than the band plan's, the
+                // whole range below it is the operator's to choose from, and a
+                // number printed in a tooltip is a number everyone sits on.
+                let our_hz = self.digi_status.as_ref().map(|s| s.audio_hz).unwrap_or(1500.0);
+                // Each control gated on its own rather than the group being
+                // wrapped in an `add_enabled_ui`, for the wrapping reason above.
+                ui.label(RichText::new("TX").size(11.0).color(crate::theme::gray(140)));
+                if crate::chrome::chip_enabled(ui, !held, false, "−").clicked() {
+                    cmds.push(Command::SetDigiAudioFreq((our_hz - 10.0).clamp(200.0, 3500.0)));
+                }
+                if crate::chrome::chip_enabled(ui, !held, false, "+").clicked() {
+                    cmds.push(Command::SetDigiAudioFreq((our_hz + 10.0).clamp(200.0, 3500.0)));
+                }
+                // The readout and the entry are the same widget: two of them
+                // would be two things to disagree with each other.
+                //
+                // Speed 0 so it is a box you type in and not a slider a stray
+                // drag can push off a licence edge.
+                //
+                // Committed on LOST FOCUS (Enter, or clicking away) rather than
+                // on `changed()`, because a DragValue in text mode reparses as
+                // you type: `changed()` would fire on "8", then "82", then
+                // "820", sending three transmit-frequency changes for one
+                // figure, the first two of them wrong. And NO `.range()`, for
+                // the same reason — it clamps the value while the text is still
+                // half-typed, so the box fights the operator and "820" becomes
+                // "200" the moment the 8 is pressed. Clamped here instead, once,
+                // when the number is finished.
+                let mut typed = our_hz;
+                let resp = ui
+                    .add_enabled(
+                        !held,
+                        egui::DragValue::new(&mut typed).speed(0.0).fixed_decimals(0).suffix(" Hz"),
+                    )
+                    .on_hover_text(
+                        "Type the transmit offset in Hz, then press Enter. Where your licence \
+                         is narrower than the band plan the whole range below the edge is \
+                         yours to pick from, so nothing is suggested here.",
+                    );
+                if resp.lost_focus() && (typed - our_hz).abs() >= 0.5 {
+                    cmds.push(Command::SetDigiAudioFreq(typed.clamp(200.0, 3500.0)));
                 }
             }
             ui.add_space(8.0);
@@ -188,6 +265,8 @@ impl SdroxideApp {
         // the same question of the same radio.
         let tx_ok = self.tx_capable();
         let auto_tx_freq = self.digi_status.as_ref().map(|s| s.config.auto_tx_freq).unwrap_or(true);
+        let hold_tx_freq =
+            self.digi_status.as_ref().map(|s| s.config.hold_tx_freq).unwrap_or(false);
         let sort = self.digi_sort;
         let desc = self.digi_sort_desc;
         // Turn parity needs the mode's slot length (FT8 15 s, FT4 7.5 s). JS8's
@@ -692,8 +771,11 @@ impl SdroxideApp {
                     } else if row.clicked() {
                         // Moving our transmit onto theirs is exactly what Auto
                         // TX FRQ exists to avoid, so with it on a click only
-                        // previews the station.
-                        if !auto_tx_freq {
+                        // previews the station. Hold TX suppresses it too: the
+                        // engine would refuse the command anyway, and sending
+                        // one it drops on the floor is how a UI comes to
+                        // disagree with the radio.
+                        if !auto_tx_freq && !hold_tx_freq {
                             cmds.push(Command::SetDigiAudioFreq(d.audio_hz));
                         }
                         // Preview this station's location (if it sent a grid).

--- a/crates/sdroxide-ui/src/app/panels/setup.rs
+++ b/crates/sdroxide-ui/src/app/panels/setup.rs
@@ -283,7 +283,21 @@ impl SdroxideApp {
                         .on_hover_text(
                             "Choose the transmit frequency automatically: the quietest spot in \
                              the period you transmit in, rather than the frequency of the \
-                             station you are answering. Off holds whatever you set by hand.",
+                             station you are answering. Off does NOT hold it — it answers on \
+                             the frequency of the station being called. To hold, use Hold TX.",
+                        )
+                        .changed();
+                    ui.end_row();
+                    ui.label("Hold TX frequency");
+                    changed |= ui
+                        .checkbox(&mut cfg.hold_tx_freq, "")
+                        .on_hover_text(
+                            "Pin the transmit tone where it is. Nothing moves it: not \
+                             answering a station, not the call queue, not calling CQ, not a \
+                             click on a decode or the waterfall. Overrides Auto TX frequency. \
+                             For where your licence is narrower than the band plan — on a UK \
+                             60 m dial of 5357 kHz the allocation ends at 5358.0, so the tone \
+                             must stay under 1000 Hz.",
                         )
                         .changed();
                     ui.end_row();

--- a/crates/sdroxide-ui/src/app/panels/setup.rs
+++ b/crates/sdroxide-ui/src/app/panels/setup.rs
@@ -295,9 +295,10 @@ impl SdroxideApp {
                             "Pin the transmit tone where it is. Nothing moves it: not \
                              answering a station, not the call queue, not calling CQ, not a \
                              click on a decode or the waterfall. Overrides Auto TX frequency. \
-                             For where your licence is narrower than the band plan — on a UK \
-                             60 m dial of 5357 kHz the allocation ends at 5358.0, so the tone \
-                             must stay under 1000 Hz.",
+                             Changing band is the one exception: the offset you last set on \
+                             the new band comes back with it. For where your licence is \
+                             narrower than the band plan — on a UK 60 m dial of 5357 kHz the \
+                             allocation ends at 5358.0, so the tone must stay under 1000 Hz.",
                         )
                         .changed();
                     ui.end_row();

--- a/crates/sdroxide-ui/src/widgets/spectrum_view.rs
+++ b/crates/sdroxide-ui/src/widgets/spectrum_view.rs
@@ -807,6 +807,11 @@ pub fn show_ext(
     // FT8/FT4: the engine is choosing the transmit frequency, so clicking a
     // station label must not drag it onto that station.
     auto_tx_freq: bool,
+    // FT8/FT4: the operator has pinned the transmit tone, so NO click moves it
+    // — a station label or bare waterfall alike. The engine refuses the command
+    // regardless; suppressing it here keeps the UI from asking for something it
+    // has been told cannot happen.
+    hold_tx_freq: bool,
     // Extra audio-offset tuning lines (Hz relative to the dial), e.g. the RTTY
     // mark/space pair. Drawn as thin amber lines to aid exact tuning.
     markers: &[f32],
@@ -1282,7 +1287,7 @@ pub fn show_ext(
                         // the period opposite ours, so their frequency says
                         // nothing about who is there when we key. With it on the
                         // label is a label; with it off it tunes, as before.
-                        if !auto_tx_freq {
+                        if !auto_tx_freq && !hold_tx_freq {
                             let audio = (spot_hz - state.rx_freq_hz()) as f32;
                             cmds.push(Command::SetDigiAudioFreq(audio.clamp(200.0, 3500.0)));
                         }
@@ -1319,8 +1324,11 @@ pub fn show_ext(
                             }
                         }
                     }
-                } else if click_sets_offset {
-                    // Digital mode: set the audio TX offset, not the VFO.
+                } else if click_sets_offset && !hold_tx_freq {
+                    // Digital mode: set the audio TX offset, not the VFO. Held
+                    // means held even for a deliberate click on clear water:
+                    // the case this exists for is a licence edge, where a slip
+                    // is an out-of-band transmission.
                     let audio = (view.x_to_freq(pos.x, &rect) - state.rx_freq_hz()) as f32;
                     cmds.push(Command::SetDigiAudioFreq(audio.clamp(200.0, 3500.0)));
                 } else {


### PR DESCRIPTION
Auto TX FRQ is not a switch for whether the transmit tone moves. It chooses which of two movers runs: on, the engine hunts the quietest slot between 400 and 2600 Hz; off, it jumps onto whichever station is being answered. Neither holds anything, so there was no way to pin the tone at all, and three places said otherwise: the chip tooltip, the setup checkbox and the config doc comment all claimed turning Auto off held the frequency you set. All three are corrected here.

That is harmless on the bands the mode was designed around, where the conventional dial sits kilohertz below the edge. It is not harmless where a licence is narrower than the band plan. UK 60 m is the case: on a 5357 kHz dial the allocation ends at 5358.0, so the tone has to stay under 1 kHz, and either mover walks out of the band unprompted between one over and the next.

**The hold.** `DigiConfig` gains `hold_tx_freq`, gating `DigiController::set_audio_hz` and `pick_tx_freq`, which between them cover the operator's own click, the follow-the-DX branch of `start_qso`, and the automatic choice for a reply or a CQ. The one exception is a Hound following the Fox that answered it, which goes through `tune_audio_hz` and is the DXpedition's frequency to give rather than ours to pin. There is deliberately no modifier-key escape: WSJT-X lets Ctrl or Shift override `cbHoldTxFreq`, which is right when the hold is about etiquette on a crowded band, but here it is about a band edge, where a move made by accident is an out-of-band transmission.

**The transmit lockout, which could not have caught any of this.** It tested `state.tx_freq_hz()`, the dial, and a digital mode radiates at the dial plus its audio offset. At 5357 with 1500 Hz it saw 5357.0, passed it, and 5358.5 went out. It now vets the emission: dial, plus offset, plus the mode's occupied bandwidth from `Mode::occupied_bw_hz`. JS8 is given its widest speed there, because a `Mode` does not know which speed is set and erring wide is the right direction for a band edge. The check runs against sub-segments rather than band edges, because `bandplan.json` holds one range per band and UK 60 m needs eleven. Nothing here is UK-specific: an operator whose licence is narrower says so by narrowing the segments in that file. It fails open where the table says nothing, and the upper bound is inclusive, so a transmission reaching exactly 5358.0 is permitted rather than refused on a rounding convention.

A later commit relaxes the span check so an emission may cross a usage boundary but not a gap. Region 1's 160 m is why: the plan runs 1.838-1.843 Digi and 1.843-2.000 Phone, so FT8 on the conventional 1.840 dial left the digital segment at a 2950 Hz offset and everything above that was refused, on a boundary that is not a band edge at all.

**Also here.** FT8 and FT4 gain a transmit offset readout, a plus and minus 10 Hz pair and a box to type a figure into. They were the only slotted modes without one, so the offset could be placed only by clicking the waterfall, and a hold is only as good as the ability to set what is being held. No figure is suggested anywhere in the UI, because a number in a tooltip is a number everyone sits on. The offset is then remembered per band rather than per station, and pinned to the config file so a client config cannot wipe it.

**Protocol bumped to 67**, in two steps. 66 for `hold_tx_freq` and 67 for the per-band `tx_audio_hz` map. `DigiConfig` travels inside `DigiStatus` and postcard is positional, so neither is an append an older client survives, and `#[serde(default)]` covers the config file on disk rather than the wire. Rebased onto current main today, so these sit above the LimeSDR bump at 65.

**Testing.** Two tests drive all four movers against a held frequency (operator set, answering with Auto on and with it off, calling CQ) and prove the Hound exception survives; one more proves the band-memory route is refused while held for a non-trivial reason. `cargo check --release --no-default-features` and `cargo test --release --no-default-features --no-run` are both clean on the rebased branch.
