### PR TITLE
Show the rig's power output where the SWR bar was

### DIFF
--- a/crates/sdroxide-cat/src/civ.rs
+++ b/crates/sdroxide-cat/src/civ.rs
@@ -163,6 +163,19 @@ pub fn parse_ptt_reply(data: &[u8]) -> Option<bool> {
 pub fn read_swr_frame(radio: u8) -> Vec<u8> {
     frame(radio, 0x15, &[0x12])
 }
+/// Read the power-output meter (Icom cmd `0x15` sub `0x11`). Only meaningful
+/// while transmitting, like the SWR meter beside it; the rig answers with a
+/// 0..255 reading (see [`po_from_reading`]).
+///
+/// This is what the rig is actually putting out, which is a different question
+/// from the drive level it was *asked* for (cmd `0x14` sub `0x0A`, read once at
+/// connect to place the Drive slider). The two disagree whenever the rig is
+/// folding back — heat, a high SWR, or an ATU still searching — and that
+/// disagreement is the reason for showing this at all.
+pub fn read_po_frame(radio: u8) -> Vec<u8> {
+    frame(radio, 0x15, &[0x11])
+}
+
 /// Read the S-meter (Icom cmd `0x15` sub `0x02`). The rig answers with a 0..255
 /// reading on its own calibrated scale (see [`dbm_from_smeter`]).
 ///
@@ -326,6 +339,50 @@ pub fn parse_swr_reply(data: &[u8]) -> Option<f32> {
         return None;
     }
     Some(swr_from_reading(decode_meter(&data[1..])?))
+}
+
+/// Map an Icom power-output reading (`0..255`) to a `0.0..=1.0` fraction of
+/// full scale, over the breakpoints Icom publish for the PO meter's face and
+/// Hamlib carries for this family (0 → 0%, 143 → 50%, 213 → 100%).
+///
+/// The scale is not linear in the reading, which is why this is a table and not
+/// a divide: half scale sits at 143 rather than at 128, and the meter reaches
+/// full scale at 213 with the remaining readings above it pinned there.
+///
+/// The result is a NEEDLE POSITION, not a wattage, and the deliberate absence
+/// of a watts conversion here is the point. Icom calibrate the face in percent
+/// of the rig's own maximum, not in watts, and the relationship between the two
+/// moves with band, mode, supply voltage and drive setting. Converting would
+/// hand the operator a figure that looks measured and is not. See
+/// [`sdroxide_types::TxTelemetry::po`].
+fn po_from_reading(reading: u32) -> f32 {
+    const CAL: &[(f32, f32)] = &[(0.0, 0.0), (143.0, 0.5), (213.0, 1.0)];
+    let r = reading as f32;
+    if r <= CAL[0].0 {
+        return CAL[0].1;
+    }
+    for w in CAL.windows(2) {
+        let (x0, y0) = w[0];
+        let (x1, y1) = w[1];
+        if r <= x1 {
+            return y0 + (y1 - y0) * (r - x0) / (x1 - x0);
+        }
+    }
+    CAL[CAL.len() - 1].1
+}
+
+/// Parse a power-output reply payload (Icom cmd `0x15`): the sub-command byte
+/// followed by the BCD reading. Returns the `0.0..=1.0` fraction, or `None` if
+/// the reply isn't the PO meter (`0x11`) or is malformed.
+///
+/// The sub-command guard is load-bearing. SWR, ALC, PO and the S-meter are all
+/// answered on command `0x15` and are told apart by nothing but this byte, so a
+/// parser that skipped it would happily report an SWR reading as a power level.
+pub fn parse_po_reply(data: &[u8]) -> Option<f32> {
+    if data.first() != Some(&0x11) {
+        return None;
+    }
+    Some(po_from_reading(decode_meter(&data[1..])?))
 }
 
 /// Map an Icom S-meter reading (`0..255`) to dBm, over the calibration Icom
@@ -827,6 +884,42 @@ mod tests {
         assert_eq!(parse_swr_reply(&[0x11, 0x00, 0x50]), None);
         // The S-meter shares command 0x15 and must not be read as an SWR.
         assert_eq!(parse_swr_reply(&[0x02, 0x01, 0x20]), None);
+    }
+
+    #[test]
+    fn po_meter_decodes_and_scales() {
+        // Reply payload = sub-command 0x11 followed by the 2-byte BCD reading.
+        let po = |reading_bcd: [u8; 2]| parse_po_reply(&[0x11, reading_bcd[0], reading_bcd[1]]);
+        // The calibration breakpoints map exactly.
+        assert_eq!(po([0x00, 0x00]), Some(0.0)); // reading 0
+        assert_eq!(po([0x01, 0x43]), Some(0.5)); // reading 143, half scale
+        assert_eq!(po([0x02, 0x13]), Some(1.0)); // reading 213, full scale
+        // Half scale sits at 143, not at 128, so the curve is not a divide:
+        // reading 128 must come out BELOW 50%, which a linear /255 would miss.
+        let mid = po([0x01, 0x28]).unwrap();
+        assert!(mid < 0.5, "reading 128 should be under half scale, got {mid}");
+        assert!((mid - 0.4476).abs() < 0.001, "interpolated 0..143 segment, got {mid}");
+        // Readings above the top breakpoint pin at full scale rather than
+        // running past it, as the SWR curve clamps at its own end.
+        assert_eq!(po([0x02, 0x55]), Some(1.0)); // reading 255
+        // A malformed reading (bad BCD nibble) yields None, not a bogus level.
+        assert_eq!(po([0x00, 0x0f]), None);
+        // Every other meter shares command 0x15 and must not be read as power.
+        // Getting this wrong would put an SWR ratio on the PO bar, which is the
+        // failure the sub-command guard exists to prevent.
+        assert_eq!(parse_po_reply(&[0x12, 0x00, 0x50]), None); // SWR
+        assert_eq!(parse_po_reply(&[0x13, 0x00, 0x50]), None); // ALC
+        assert_eq!(parse_po_reply(&[0x02, 0x01, 0x20]), None); // S-meter
+        // And the converse: a PO reply must not be parsed as any of them.
+        assert_eq!(parse_swr_reply(&[0x11, 0x02, 0x13]), None);
+        assert_eq!(parse_smeter_reply(&[0x11, 0x02, 0x13]), None);
+    }
+
+    #[test]
+    fn po_meter_frame_asks_for_its_own_sub_command() {
+        // Sub-command 0x11, not the SWR meter's 0x12: asking for the wrong one
+        // returns a plausible number on the wrong scale.
+        assert_eq!(read_po_frame(0x94), vec![0xFE, 0xFE, 0x94, 0xE0, 0x15, 0x11, 0xFD]);
     }
 
     #[test]

--- a/crates/sdroxide-cat/src/civ.rs
+++ b/crates/sdroxide-cat/src/civ.rs
@@ -355,6 +355,19 @@ pub fn parse_swr_reply(data: &[u8]) -> Option<f32> {
 /// moves with band, mode, supply voltage and drive setting. Converting would
 /// hand the operator a figure that looks measured and is not. See
 /// [`sdroxide_types::TxTelemetry::po`].
+///
+/// ✅ **CHECKED ON AIR 18 August 2026 against an IC-7300.** Rodger's verdict:
+/// "perfect, running as expected". The bar tracks the rig's own PO meter, so
+/// the breakpoints below are confirmed against the thing they model rather
+/// than only against their own tests.
+///
+/// ⛔ **So do not replace this table with a divide, and do not convert it to
+/// watts.** The table is here because the scale is not linear in the reading:
+/// half scale is at 143, not at 128. The absent watts conversion is the same
+/// decision the ALC parser records, for the same reason — there is no published
+/// Icom curve to fit, so a plausible-looking one would be invented precision.
+/// A percentage that has been shown to agree with the rig's face is worth more
+/// than a wattage that has not.
 fn po_from_reading(reading: u32) -> f32 {
     const CAL: &[(f32, f32)] = &[(0.0, 0.0), (143.0, 0.5), (213.0, 1.0)];
     let r = reading as f32;

--- a/crates/sdroxide-cat/src/lib.rs
+++ b/crates/sdroxide-cat/src/lib.rs
@@ -116,6 +116,9 @@ pub enum CatUpdate {
     Mode(Mode),
     /// TX SWR reading (routed to the telemetry channel, not the control channel).
     Swr(f32),
+    /// TX power-output reading as a `0.0..=1.0` fraction of the rig's full
+    /// scale (routed to the telemetry channel, like [`CatUpdate::Swr`]).
+    Po(f32),
     /// RX S-meter reading in dBm, from the rig's own meter (routed to the
     /// signal channel, not the control channel).
     Signal(f32),
@@ -405,7 +408,9 @@ impl Protocol for Civ {
         vec![civ::read_freq_frame(self.radio)]
     }
     fn tx_telemetry_requests(&self) -> Vec<Vec<u8>> {
-        vec![civ::read_swr_frame(self.radio)]
+        // Two reads per telemetry tick. They are answered on the same command
+        // and are told apart by their sub-command byte on the way back in.
+        vec![civ::read_swr_frame(self.radio), civ::read_po_frame(self.radio)]
     }
     fn tx_state_requests(&self) -> Vec<Vec<u8>> {
         vec![civ::read_ptt_frame(self.radio)]
@@ -506,13 +511,16 @@ impl Protocol for Civ {
                         out.push(CatUpdate::Power(frac));
                     }
                 }
-                // Meter read (0x15): the SWR sub-meter (0x12) while transmitting,
-                // the S-meter (0x02) while receiving. The sub-command byte in the
-                // reply says which arrived — nothing else does, since both are
-                // answered on the one command.
+                // Meter read (0x15): the SWR sub-meter (0x12) and the power-output
+                // meter (0x11) while transmitting, the S-meter (0x02) while
+                // receiving. The sub-command byte in the reply says which arrived
+                // — nothing else does, since all three are answered on the one
+                // command, and each parser checks that byte before decoding.
                 0x15 => {
                     if let Some(swr) = civ::parse_swr_reply(&reply.data) {
                         out.push(CatUpdate::Swr(swr));
+                    } else if let Some(po) = civ::parse_po_reply(&reply.data) {
+                        out.push(CatUpdate::Po(po));
                     } else if let Some(dbm) = civ::parse_smeter_reply(&reply.data) {
                         out.push(CatUpdate::Signal(dbm));
                     }
@@ -756,9 +764,10 @@ pub fn query_once(cfg: &CatConfig) -> Option<(Option<f64>, Option<Mode>)> {
                     match u {
                         CatUpdate::Freq(hz) => freq = Some(hz),
                         CatUpdate::Mode(m) => mode = Some(m),
-                        // Neither meter, the power, nor the transmit state is
+                        // No meter, the power, or the transmit state is
                         // requested during the startup query.
                         CatUpdate::Swr(_)
+                        | CatUpdate::Po(_)
                         | CatUpdate::Signal(_)
                         | CatUpdate::Power(_)
                         | CatUpdate::Ptt(_) => {}
@@ -1153,6 +1162,20 @@ fn serial_thread(
         // When a CAT key-down was last written, so the rig's refusal of one can
         // be told from the refusals its unimplemented sub-commands answer with.
         let mut ptt_written: Option<Instant> = None;
+        // The transmit meters, held together between replies.
+        //
+        // SWR and PO arrive as two separate frames, and `poll_telemetry` on the
+        // far end keeps only the LAST `TxTelemetry` of each batch
+        // (`try_iter().last()`). So sending one field at a time and leaving the
+        // other `None` does not merge at the receiver, it overwrites: the two
+        // readings would take turns blanking each other and both bars would
+        // flicker at the polling rate. Accumulating here and sending the pair
+        // means every message is a complete picture of the transmit meters.
+        //
+        // Cleared on unkey along with the `TxTelemetry::default()` sent there,
+        // so a new over never opens showing the last one's readings.
+        let mut tx_swr: Option<f32> = None;
+        let mut tx_po: Option<f32> = None;
         let mut pending_freq: Option<f64> = None;
         let mut last_sent_freq: Option<f64> = None;
         let mut freq_deadline = Instant::now();
@@ -1278,7 +1301,12 @@ fn serial_thread(
                         // for the rest of the current period.
                         next_meter = Instant::now();
                         if !on {
-                            // Clear the reading so the meter drops SWR on unkey.
+                            // Clear the readings so the meters drop on unkey,
+                            // here as well as at the receiver: a stale SWR held
+                            // locally would be re-sent beside the next over's
+                            // first PO reading and briefly look current.
+                            tx_swr = None;
+                            tx_po = None;
                             let _ = telem_tx.send(TxTelemetry::default());
                         }
                     }
@@ -1527,8 +1555,25 @@ fn serial_thread(
                         // to their own channels and skip the freq/mode dedup
                         // below — a reading that repeats is still current, and
                         // dropping it would freeze the meter.
+                        // Either transmit meter updates its own field and then
+                        // sends BOTH, for the overwrite reason recorded where
+                        // `tx_swr` is declared.
                         if let CatUpdate::Swr(v) = u {
-                            let _ = telem_tx.send(TxTelemetry { fwd_w: None, swr: Some(v) });
+                            tx_swr = Some(v);
+                            let _ = telem_tx.send(TxTelemetry {
+                                fwd_w: None,
+                                swr: tx_swr,
+                                po: tx_po,
+                            });
+                            continue;
+                        }
+                        if let CatUpdate::Po(v) = u {
+                            tx_po = Some(v);
+                            let _ = telem_tx.send(TxTelemetry {
+                                fwd_w: None,
+                                swr: tx_swr,
+                                po: tx_po,
+                            });
                             continue;
                         }
                         if let CatUpdate::Signal(dbm) = u {
@@ -1588,9 +1633,10 @@ fn serial_thread(
                                 }
                                 c
                             }
-                            // Both meters, the power and the transmit state are
+                            // The meters, the power and the transmit state are
                             // handled above.
                             CatUpdate::Swr(_)
+                            | CatUpdate::Po(_)
                             | CatUpdate::Signal(_)
                             | CatUpdate::Power(_)
                             | CatUpdate::Ptt(_) => false,

--- a/crates/sdroxide-radio/src/engine.rs
+++ b/crates/sdroxide-radio/src/engine.rs
@@ -2400,7 +2400,7 @@ fn engine_thread(
                 Some(Meters {
                     s_dbm: -127.0,
                     adc_peak_dbfs: 0.0,
-                    tx: Some(TxMeters { fwd_w: tele.fwd_w, swr: tele.swr, alc }),
+                    tx: Some(TxMeters { fwd_w: tele.fwd_w, swr: tele.swr, alc, po: tele.po }),
                     stereo: false,
                     tone: None,
                 })

--- a/crates/sdroxide-radio/tests/converter.rs
+++ b/crates/sdroxide-radio/tests/converter.rs
@@ -505,7 +505,7 @@ impl IqSource for Recorder {
     }
     fn tx_telemetry(&mut self) -> Option<sdroxide_types::TxTelemetry> {
         self.calls.note("tx_telemetry");
-        Some(sdroxide_types::TxTelemetry { fwd_w: Some(5.0), swr: Some(1.2) })
+        Some(sdroxide_types::TxTelemetry { fwd_w: Some(5.0), swr: Some(1.2), po: None })
     }
     fn set_if_offset(&mut self, _hz: f64) {
         self.calls.note("set_if_offset");

--- a/crates/sdroxide-radio/tests/rig_own_ptt.rs
+++ b/crates/sdroxide-radio/tests/rig_own_ptt.rs
@@ -75,7 +75,10 @@ impl IqSource for MockRig {
     /// The rig's SWR bridge — it reads whoever is keying it, which during the
     /// operator's own over is the operator.
     fn tx_telemetry(&mut self) -> Option<TxTelemetry> {
-        self.rig.lock().unwrap().keyed.then_some(TxTelemetry { fwd_w: None, swr: Some(SWR) })
+        // An SWR bridge and nothing else: this rig reports no power meter, so
+        // `po` stays absent rather than being invented as a zero reading.
+        let t = TxTelemetry { fwd_w: None, swr: Some(SWR), po: None };
+        self.rig.lock().unwrap().keyed.then_some(t)
     }
     fn tx_begin(&mut self, center_hz: f64, _rate: f64) -> Result<f64> {
         self.rig.lock().unwrap().keyed_by_us.push(center_hz);

--- a/crates/sdroxide-radio/tests/swr_guard.rs
+++ b/crates/sdroxide-radio/tests/swr_guard.rs
@@ -177,7 +177,7 @@ fn run_keyed(telem: TxTelemetry, limit: f32, guard: bool, key: Key, wait: Durati
 /// the exact shape of the telemetry that twice failed on air.
 #[test]
 fn trips_with_no_forward_power_reported() {
-    let o = run(TxTelemetry { fwd_w: None, swr: Some(7.5) }, 2.5, true);
+    let o = run(TxTelemetry { fwd_w: None, swr: Some(7.5), po: None }, 2.5, true);
     assert_eq!(o.tripped_at, Some(7.5), "a 7.5:1 with no power figure must trip a 2.5:1 guard");
     assert!(!o.still_keyed, "the transmitter must actually stop, not just set a flag");
     assert!(!o.keyed_again, "the latch must refuse the next key-up until acknowledged");
@@ -187,14 +187,14 @@ fn trips_with_no_forward_power_reported() {
 /// BECAUSE the SWR is bad, so a low power reading must not excuse it.
 #[test]
 fn trips_when_the_rig_has_folded_its_power_back() {
-    let o = run(TxTelemetry { fwd_w: Some(3.0), swr: Some(7.5) }, 2.5, true);
+    let o = run(TxTelemetry { fwd_w: Some(3.0), swr: Some(7.5), po: None }, 2.5, true);
     assert_eq!(o.tripped_at, Some(7.5), "3 W at 7.5:1 is the fault, not a reason to ignore it");
     assert!(!o.still_keyed);
 }
 
 #[test]
 fn leaves_a_good_swr_alone() {
-    let o = run(TxTelemetry { fwd_w: Some(50.0), swr: Some(1.3) }, 2.5, true);
+    let o = run(TxTelemetry { fwd_w: Some(50.0), swr: Some(1.3), po: None }, 2.5, true);
     assert_eq!(o.tripped_at, None, "1.3:1 must not trip a 2.5:1 guard");
     assert!(o.still_keyed, "a good match must be left transmitting");
 }
@@ -202,7 +202,7 @@ fn leaves_a_good_swr_alone() {
 /// Disarmed is disarmed, however bad the antenna is.
 #[test]
 fn does_nothing_when_disarmed() {
-    let o = run(TxTelemetry { fwd_w: None, swr: Some(9.9) }, 2.5, false);
+    let o = run(TxTelemetry { fwd_w: None, swr: Some(9.9), po: None }, 2.5, false);
     assert_eq!(o.tripped_at, None);
     assert!(o.still_keyed);
 }
@@ -211,7 +211,7 @@ fn does_nothing_when_disarmed() {
 /// having its silence read as either safe or dangerous.
 #[test]
 fn inert_when_the_rig_reports_no_swr() {
-    let o = run(TxTelemetry { fwd_w: Some(50.0), swr: None }, 2.5, true);
+    let o = run(TxTelemetry { fwd_w: Some(50.0), swr: None, po: None }, 2.5, true);
     assert_eq!(o.tripped_at, None);
     assert!(o.still_keyed);
 }
@@ -220,7 +220,7 @@ fn inert_when_the_rig_reports_no_swr() {
 /// the ratio is then noise. This is the only thing the power floor may do.
 #[test]
 fn ignores_a_reading_taken_at_no_power() {
-    let o = run(TxTelemetry { fwd_w: Some(0.0), swr: Some(9.9) }, 2.5, true);
+    let o = run(TxTelemetry { fwd_w: Some(0.0), swr: Some(9.9), po: None }, 2.5, true);
     assert_eq!(o.tripped_at, None, "0 W means the reading is meaningless, not that the SWR is bad");
 }
 
@@ -233,7 +233,7 @@ fn ignores_a_reading_taken_at_no_power() {
 #[test]
 fn a_tune_is_allowed_above_the_on_air_limit() {
     let o = run_keyed(
-        TxTelemetry { fwd_w: None, swr: Some(4.0) },
+        TxTelemetry { fwd_w: None, swr: Some(4.0), po: None },
         2.5,
         true,
         Key::Tune,
@@ -248,7 +248,7 @@ fn a_tune_is_allowed_above_the_on_air_limit() {
 /// simply stopped working.
 #[test]
 fn the_same_swr_stops_an_ordinary_over() {
-    let o = run(TxTelemetry { fwd_w: None, swr: Some(4.0) }, 2.5, true);
+    let o = run(TxTelemetry { fwd_w: None, swr: Some(4.0), po: None }, 2.5, true);
     assert_eq!(o.tripped_at, Some(4.0), "4:1 is over a 2.5:1 limit when it is not a tune");
     assert!(!o.still_keyed);
 }
@@ -259,7 +259,7 @@ fn the_same_swr_stops_an_ordinary_over() {
 #[test]
 fn a_tune_still_stops_on_a_dead_feeder() {
     let o = run_keyed(
-        TxTelemetry { fwd_w: None, swr: Some(9.9) },
+        TxTelemetry { fwd_w: None, swr: Some(9.9), po: None },
         2.5,
         true,
         Key::Tune,
@@ -279,7 +279,7 @@ fn a_tune_still_stops_on_a_dead_feeder() {
 /// fraction of a second, which is the whole reason the guard exists.
 #[test]
 fn an_over_is_stopped_without_waiting_seconds() {
-    let o = run(TxTelemetry { fwd_w: None, swr: Some(9.9) }, 2.5, true);
+    let o = run(TxTelemetry { fwd_w: None, swr: Some(9.9), po: None }, 2.5, true);
     let after = o.tripped_after.expect("a trip has a time");
     assert!(after < Duration::from_secs(1), "an over must not inherit the tune grace: {after:?}");
 }

--- a/crates/sdroxide-smartsdr/src/net.rs
+++ b/crates/sdroxide-smartsdr/src/net.rs
@@ -1210,7 +1210,9 @@ impl DataThread {
                         }
                         drop(table);
                         if changed && self.keyed {
-                            let _ = self.telem.send(TxTelemetry { fwd_w, swr });
+                            // As for TCI: watts are measured, so there is no needle-position
+                            // meter to report and `po` stays `None`.
+                            let _ = self.telem.send(TxTelemetry { fwd_w, swr, po: None });
                         }
                     }
                 }

--- a/crates/sdroxide-speech/tests/announce.rs
+++ b/crates/sdroxide-speech/tests/announce.rs
@@ -41,7 +41,7 @@ fn meters(swr: Option<f32>, fwd: Option<f32>, keyed: bool) -> Meters {
     Meters {
         s_dbm: -100.0,
         adc_peak_dbfs: -30.0,
-        tx: keyed.then_some(TxMeters { fwd_w: fwd, swr, alc: 0.0 }),
+        tx: keyed.then_some(TxMeters { fwd_w: fwd, swr, alc: 0.0, po: None }),
         stereo: false,
         tone: None,
     }

--- a/crates/sdroxide-tci/src/net.rs
+++ b/crates/sdroxide-tci/src/net.rs
@@ -1102,7 +1102,11 @@ impl NetThread {
 
     /// Emit the current aggregated TX telemetry snapshot.
     fn emit_tx_telem(&self) {
-        let _ = self.telem.send(TxTelemetry { fwd_w: self.tx_fwd_w, swr: self.tx_swr });
+        // TCI reports forward power in watts and has no separate
+        // percent-of-scale meter, so `po` stays `None` and the bar falls
+        // back to SWR for these rigs.
+        let _ =
+            self.telem.send(TxTelemetry { fwd_w: self.tx_fwd_w, swr: self.tx_swr, po: None });
     }
 }
 

--- a/crates/sdroxide-types/src/meters.rs
+++ b/crates/sdroxide-types/src/meters.rs
@@ -7,18 +7,34 @@ pub struct TxMeters {
     pub swr: Option<f32>,
     /// 0.0..=1.0 modulation drive level.
     pub alc: f32,
+    /// The rig's own power-output meter as a `0.0..=1.0` fraction of full
+    /// scale, if it has one. Deliberately not watts: see [`TxTelemetry::po`].
+    pub po: Option<f32>,
 }
 
-/// TX-side telemetry a rig reports out-of-band (CAT / TCI): forward power and
-/// SWR. Distinct from [`TxMeters`], which also carries the engine's own ALC —
-/// this is only what the *device* measures, merged into `TxMeters` by the
-/// engine while transmitting.
+/// TX-side telemetry a rig reports out-of-band (CAT / TCI): forward power,
+/// SWR and the rig's own power-output meter. Distinct from [`TxMeters`], which
+/// also carries the engine's own ALC — this is only what the *device*
+/// measures, merged into `TxMeters` by the engine while transmitting.
 #[derive(Debug, Clone, Copy, PartialEq, Default, Serialize, Deserialize)]
 pub struct TxTelemetry {
     /// Forward power in watts, if the device exposes a sensor for it.
     pub fwd_w: Option<f32>,
     /// SWR as a ratio (e.g. `1.4` = 1.4:1), if the device measures it.
     pub swr: Option<f32>,
+    /// The rig's power-output meter as a `0.0..=1.0` fraction of full scale.
+    ///
+    /// Kept separate from `fwd_w`, and deliberately not converted into it,
+    /// because the two are different claims. `fwd_w` is watts a device has
+    /// actually measured; this is a needle position. An Icom answers its PO
+    /// meter as a raw `0..255` with published breakpoints for the *scale* but
+    /// no calibrated wattage behind them, so turning it into watts would
+    /// invent a precision the rig never offered — the same reasoning the ALC
+    /// reading is reported as a percentage rather than in dB.
+    ///
+    /// A device that genuinely measures forward power still fills `fwd_w`, and
+    /// the two can be present together on a rig that reports both.
+    pub po: Option<f32>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]

--- a/crates/sdroxide-ui/src/widgets/smeter.rs
+++ b/crates/sdroxide-ui/src/widgets/smeter.rs
@@ -236,6 +236,19 @@ fn s_stops() -> Vec<Stop> {
     ]
 }
 
+/// Power-output ramp: one cool-to-warm sweep with no red in it.
+///
+/// Deliberately unlike the ALC and SWR ramps, which turn red because their top
+/// ends are faults — overdriving, and a bad match. A rig sitting at full power
+/// output is doing exactly what it was asked to, so colouring the top of this
+/// scale as a warning would teach the eye to read a healthy transmitter as a
+/// problem. What the operator is watching for here is the needle FALLING while
+/// drive stays put, and that shows as movement rather than as colour.
+fn po_stops() -> Vec<Stop> {
+    let m = meter();
+    vec![(0.00, m.ramp_lo), (0.35, m.ramp_mid), (1.00, m.ramp_hi)]
+}
+
 /// SWR ramp: green while the match is good, amber as it approaches 3:1, and
 /// the whole upper half — everything past 3:1 — in red. Deliberately the same
 /// in every theme: green-means-safe and red-means-stop are not up for
@@ -475,6 +488,7 @@ enum ScaleKind {
     S,
     Swr,
     Alc,
+    Po,
 }
 
 /// A meter scale: its graduations, its gridlines, and the ramp along its rail.
@@ -569,6 +583,25 @@ fn alc_scale() -> Scale {
         grid_at(0.95, "95", true),
     ];
     Scale { kind: ScaleKind::Alc, ticks, grid, stops: alc_stops() }
+}
+
+/// 0…100 % of the rig's own power-output meter.
+///
+/// Graduated like the ALC scale beside it so the two rows read as one
+/// instrument: the same ten divisions, numbered every 50. The gridlines differ
+/// because what matters on them differs — none of these is a limit, so none is
+/// marked `hot`.
+fn po_scale() -> Scale {
+    let ticks = (0..=10)
+        .map(|i| {
+            let f = i as f32 / 10.0;
+            let major = i % 5 == 0;
+            Tick { f, major, label: major.then(|| format!("{}", i * 10)), hot: false }
+        })
+        .collect();
+    let grid =
+        vec![grid_at(0.25, "25", false), grid_at(0.5, "50", false), grid_at(0.75, "75", false)];
+    Scale { kind: ScaleKind::Po, ticks, grid, stops: po_stops() }
 }
 
 /// What the instrument is currently displaying: the scale to draw, where the
@@ -884,9 +917,21 @@ fn show_bar(ui: &mut Ui, meters: Option<&Meters>, size: Vec2) -> Response {
     header(&p, rect, &r, k);
 
     if let Some(tx) = tx {
-        // Two stacked rows: the engine's drive on top, SWR below on its own
-        // logarithmic scale. Without an SWR bridge only the drive row is drawn,
-        // grown to fill the space the SWR row would have taken.
+        // Two stacked rows: the engine's drive on top, and below it whichever
+        // transmit meter the rig actually gives us. With nothing to put there
+        // only the drive row is drawn, grown to fill the space.
+        //
+        // The lower row prefers POWER OUTPUT over SWR where the rig reports it,
+        // which on the face of it throws away a reading. It does not. The SWR
+        // figure keeps its place in the header chip, where it is a number and
+        // is legible at a glance; what it was doing down here was drawing a bar
+        // that sits at the extreme left of a logarithmic scale for the whole of
+        // any normal over, so the row carried almost no information while
+        // occupying half the instrument. Power output uses the same space to
+        // show something that moves: whether the rig is delivering what it was
+        // asked for, and whether it is folding back.
+        //
+        // A rig that reports no PO meter keeps the SWR row exactly as before.
         let alc = alc_scale();
         let row = |top: f32, bottom: f32| {
             Rect::from_min_max(
@@ -894,7 +939,17 @@ fn show_bar(ui: &mut Ui, meters: Option<&Meters>, size: Vec2) -> Response {
                 pos2(right, rect.top() + bottom * k),
             )
         };
-        let (drive_rect, swr_rect) = match tx.swr {
+        // What goes in the lower row, if anything: its label, its scale, where
+        // the bar sits on it, and whether it carries a peak-hold marker. Peak
+        // hold belongs to the SWR reading (`r.frac` is the needle's own value,
+        // and `peak` was computed from it); the PO bar is read live and a
+        // held peak on it would just be the loudest syllable of the over.
+        let lower = match (tx.po, tx.swr) {
+            (Some(po), _) => Some(("PO", po_scale(), po.clamp(0.0, 1.0), None)),
+            (None, Some(_)) => Some(("SWR", swr_scale(), r.frac, peak)),
+            (None, None) => None,
+        };
+        let (drive_rect, lower_rect) = match lower {
             Some(_) => (row(20.0, 33.0), Some(row(36.0, 49.0))),
             None => (row(24.0, 42.0), None),
         };
@@ -909,13 +964,13 @@ fn show_bar(ui: &mut Ui, meters: Option<&Meters>, size: Vec2) -> Response {
         };
         row_label(drive_rect, "ALC");
         bar_row(&p, drive_rect, &alc, tx.alc.clamp(0.0, 1.0), None);
-        match swr_rect {
-            Some(swr_rect) => {
-                row_label(swr_rect, "SWR");
-                bar_row(&p, swr_rect, &r.scale, r.frac, peak);
-                bar_ticks(&p, swr_rect, rect, &r.scale, k, swr_rect.bottom() + 8.0 * k);
+        match (lower, lower_rect) {
+            (Some((label, scale, frac, hold)), Some(lower_rect)) => {
+                row_label(lower_rect, label);
+                bar_row(&p, lower_rect, &scale, frac, hold);
+                bar_ticks(&p, lower_rect, rect, &scale, k, lower_rect.bottom() + 8.0 * k);
             }
-            None => bar_ticks(&p, drive_rect, rect, &alc, k, drive_rect.bottom() + 8.0 * k),
+            _ => bar_ticks(&p, drive_rect, rect, &alc, k, drive_rect.bottom() + 8.0 * k),
         }
         border(ui, rect);
         return resp;

--- a/src/audio_cat_source.rs
+++ b/src/audio_cat_source.rs
@@ -523,8 +523,10 @@ impl IqSource for AudioCatSource {
                     }
                     out.push(ControlUpdate::RigTx(on));
                 }
-                // Both meters arrive on their own telemetry channels, not here.
-                sdroxide_cat::CatUpdate::Swr(_) | sdroxide_cat::CatUpdate::Signal(_) => {}
+                // The meters arrive on their own telemetry channels, not here.
+                sdroxide_cat::CatUpdate::Swr(_)
+                | sdroxide_cat::CatUpdate::Po(_)
+                | sdroxide_cat::CatUpdate::Signal(_) => {}
             }
         }
         out

--- a/src/elad_source.rs
+++ b/src/elad_source.rs
@@ -341,8 +341,10 @@ impl IqSource for EladSource {
                 // `Protocol::tx_state_requests`), so this never arrives — but
                 // the day it does, it means the same thing here as anywhere.
                 sdroxide_cat::CatUpdate::Ptt(on) => out.push(ControlUpdate::RigTx(on)),
-                // Both meters arrive on their own telemetry channels, not here.
-                sdroxide_cat::CatUpdate::Swr(_) | sdroxide_cat::CatUpdate::Signal(_) => {}
+                // The meters arrive on their own telemetry channels, not here.
+                sdroxide_cat::CatUpdate::Swr(_)
+                | sdroxide_cat::CatUpdate::Po(_)
+                | sdroxide_cat::CatUpdate::Signal(_) => {}
             }
         }
         out


### PR DESCRIPTION
The transmit meter has two stacked rows: the engine's drive on top, and the rig's SWR below it on a logarithmic scale. The lower row was wired and working, and showing almost nothing. SWR sits at the extreme left of that scale for the whole of any normal over, so the bar reads as empty whenever the antenna is behaving, and the same figure is already in the header chip as a number. Half the instrument was spent on a reading better served by the two characters above it.

Power output goes there instead, read from the rig's own PO meter (Icom cmd 0x15 sub 0x11, alongside the SWR meter already read on that command). It answers a question the drive slider cannot: the slider is what the rig was ASKED for, and this is what it is actually delivering. The two part company whenever the rig folds back, for heat, a high SWR, or an ATU still hunting, and nothing in the UI showed that before.

**Reported as a percentage of full scale, not in watts, and that is deliberate.** Icom calibrate the PO meter's face in percent of the rig's own maximum, with published breakpoints for the scale but no calibrated wattage behind them, and the relationship to watts moves with band, mode, supply voltage and drive. Converting would hand the operator a figure that looks measured and is not. `fwd_w` is left for devices that genuinely measure watts, and a rig reporting both fills both. Reusing `fwd_w` with a converted value was rejected for the same reason: it would make a needle position indistinguishable from a measurement two layers further up.

**The scale is a table, not a divide.** Half scale is at reading 143, not 128, and full scale at 213 with everything above pinned there, so it is a curve like the SWR one beside it. The ramp carries no red: unlike ALC and SWR, whose top ends are faults, a rig at full output is doing what it was asked, and colouring that as a warning would teach the eye to read a healthy transmitter as a problem.

**One subtlety at the CAT reader.** SWR and PO arrive as two separate frames, and `poll_telemetry` keeps only the last `TxTelemetry` of each batch (`try_iter().last()`), so sending one field at a time does not merge at the receiver, it overwrites: the readings would take turns blanking each other and both bars would flicker at the polling rate. Both are accumulated in the reader and sent together, and cleared on unkey so a new over never opens on the last one's figures.

A rig that reports no PO meter keeps the SWR row exactly as it was.

**Checked on air.** The second commit records that: verified against an IC-7300, where the bar tracks the rig's own PO meter. The note is written into the parser's doc comment rather than left in a commit message, because the question it settles will be asked again by whoever next reads a hand-written interpolation table and reaches for a divide.

**Testing.** Rebased onto current main today. `TxTelemetry` gains a field, so the exhaustive literals in `rig_own_ptt.rs` and `swr_guard.rs` now pass `po: None`, which is the honest value since neither fake rig has a power meter. `cargo check --release --no-default-features` and `cargo test --release --no-default-features --no-run` are both clean.
