### PR TITLE
Read the rig's ALC meter, and tell it apart from our own

### DIFF
--- a/crates/sdroxide-cat/src/civ.rs
+++ b/crates/sdroxide-cat/src/civ.rs
@@ -163,6 +163,16 @@ pub fn parse_ptt_reply(data: &[u8]) -> Option<bool> {
 pub fn read_swr_frame(radio: u8) -> Vec<u8> {
     frame(radio, 0x15, &[0x12])
 }
+/// Read the ALC meter (Icom cmd `0x15` sub `0x13`). Only meaningful while
+/// transmitting, like the SWR meter beside it.
+///
+/// ALC is the rig telling us how hard its own automatic level control is
+/// working, which is the number that says whether the audio being fed to it is
+/// too hot. Nothing on this side can compute it: the drive level SDRoxide
+/// measures is what it SENDS, and ALC is what the rig does about it.
+pub fn read_alc_frame(radio: u8) -> Vec<u8> {
+    frame(radio, 0x15, &[0x13])
+}
 /// Read the S-meter (Icom cmd `0x15` sub `0x02`). The rig answers with a 0..255
 /// reading on its own calibrated scale (see [`dbm_from_smeter`]).
 ///
@@ -326,6 +336,24 @@ pub fn parse_swr_reply(data: &[u8]) -> Option<f32> {
         return None;
     }
     Some(swr_from_reading(decode_meter(&data[1..])?))
+}
+
+/// Parse an ALC-meter reply payload (Icom cmd `0x15`): the sub-command byte
+/// followed by the BCD reading. Returns 0.0..=1.0, or `None` if the reply is not
+/// the ALC meter (`0x13`) or is malformed.
+///
+/// ⚠️ **The scale is a straight 0..255 fraction, and that is a decision rather
+/// than a calibration.** Icom publishes a curve for the S-meter and the standard
+/// breakpoints for SWR, but nothing for ALC: the manual says only that the meter
+/// should stay within the ALC zone. So this reports the raw reading as a
+/// fraction of full scale and does not pretend to a precision it has not got.
+/// Read it as "how far along its own meter the rig says it is", which is what
+/// the operator is looking at on the rig's face anyway.
+pub fn parse_alc_reply(data: &[u8]) -> Option<f32> {
+    if data.first() != Some(&0x13) {
+        return None;
+    }
+    Some((decode_meter(&data[1..])? as f32 / 255.0).clamp(0.0, 1.0))
 }
 
 /// Map an Icom S-meter reading (`0..255`) to dBm, over the calibration Icom
@@ -827,6 +855,30 @@ mod tests {
         assert_eq!(parse_swr_reply(&[0x11, 0x00, 0x50]), None);
         // The S-meter shares command 0x15 and must not be read as an SWR.
         assert_eq!(parse_swr_reply(&[0x02, 0x01, 0x20]), None);
+    }
+
+    #[test]
+    fn the_alc_meter_is_read_and_parsed_on_its_own_sub_command() {
+        // The frame asks for sub-command 0x13, not the SWR meter's 0x12. Getting
+        // this wrong would return an SWR reading dressed as ALC, which is the
+        // kind of error that looks plausible on screen.
+        let f = read_alc_frame(0x94);
+        assert_eq!(f[f.len() - 3..f.len() - 1], [0x15, 0x13], "wrong meter requested");
+
+        // Raw 0..255 as a fraction of full scale: see the parser's note on why
+        // there is no calibration curve here.
+        let alc = |bcd: [u8; 2]| parse_alc_reply(&[0x13, bcd[0], bcd[1]]);
+        assert_eq!(alc([0x00, 0x00]), Some(0.0));
+        assert_eq!(alc([0x02, 0x55]), Some(1.0));
+        assert!((alc([0x01, 0x28]).unwrap() - 0.5).abs() < 0.01, "midscale");
+
+        // ⛔ The three TX/RX meters all answer on command 0x15 and are told
+        // apart ONLY by the sub-command byte, so each parser must refuse the
+        // others. Without this an ALC reply would fall through to the SWR
+        // parser and be reported as an SWR ratio, which the guard acts on.
+        assert_eq!(parse_alc_reply(&[0x12, 0x00, 0x48]), None, "took an SWR reply");
+        assert_eq!(parse_alc_reply(&[0x02, 0x01, 0x20]), None, "took an S-meter reply");
+        assert_eq!(parse_swr_reply(&[0x13, 0x01, 0x28]), None, "SWR parser took an ALC reply");
     }
 
     #[test]

--- a/crates/sdroxide-cat/src/civ.rs
+++ b/crates/sdroxide-cat/src/civ.rs
@@ -349,6 +349,16 @@ pub fn parse_swr_reply(data: &[u8]) -> Option<f32> {
 /// fraction of full scale and does not pretend to a precision it has not got.
 /// Read it as "how far along its own meter the rig says it is", which is what
 /// the operator is looking at on the rig's face anyway.
+///
+/// ✅ **CHECKED ON AIR 18 August 2026 against an IC-7300 and found good enough.**
+/// Rodger's verdict, and it settles the open question this comment used to
+/// carry: the percentage agrees with the rig's own meter and reads much as
+/// WSJT-X 3.2.0's does beside its SWR figure. **It is a GUIDE and is meant to
+/// be one** — his words, "if I really am looking for adjusting I would go to the
+/// rig". ⛔ **So do not fit a calibration curve here.** There is no published
+/// Icom curve to fit it to, a plausible-looking one would be invented precision,
+/// and the raw fraction has now been shown to track the rig closely enough for
+/// the job it does.
 pub fn parse_alc_reply(data: &[u8]) -> Option<f32> {
     if data.first() != Some(&0x13) {
         return None;

--- a/crates/sdroxide-cat/src/lib.rs
+++ b/crates/sdroxide-cat/src/lib.rs
@@ -116,6 +116,10 @@ pub enum CatUpdate {
     Mode(Mode),
     /// TX SWR reading (routed to the telemetry channel, not the control channel).
     Swr(f32),
+    /// TX ALC reading, 0.0..=1.0 of the rig's own meter. Routed alongside
+    /// [`CatUpdate::Swr`]. Distinct from the engine's own drive measurement,
+    /// which is what SDRoxide SENDS rather than what the rig does about it.
+    Alc(f32),
     /// RX S-meter reading in dBm, from the rig's own meter (routed to the
     /// signal channel, not the control channel).
     Signal(f32),
@@ -405,7 +409,7 @@ impl Protocol for Civ {
         vec![civ::read_freq_frame(self.radio)]
     }
     fn tx_telemetry_requests(&self) -> Vec<Vec<u8>> {
-        vec![civ::read_swr_frame(self.radio)]
+        vec![civ::read_swr_frame(self.radio), civ::read_alc_frame(self.radio)]
     }
     fn tx_state_requests(&self) -> Vec<Vec<u8>> {
         vec![civ::read_ptt_frame(self.radio)]
@@ -506,13 +510,16 @@ impl Protocol for Civ {
                         out.push(CatUpdate::Power(frac));
                     }
                 }
-                // Meter read (0x15): the SWR sub-meter (0x12) while transmitting,
-                // the S-meter (0x02) while receiving. The sub-command byte in the
-                // reply says which arrived — nothing else does, since both are
-                // answered on the one command.
+                // Meter read (0x15): while transmitting the SWR sub-meter (0x12)
+                // and the ALC one (0x13); while receiving the S-meter (0x02).
+                // The sub-command byte in the reply says which arrived — nothing
+                // else does, since all three are answered on the one command,
+                // which is why each parser checks it and returns None otherwise.
                 0x15 => {
                     if let Some(swr) = civ::parse_swr_reply(&reply.data) {
                         out.push(CatUpdate::Swr(swr));
+                    } else if let Some(alc) = civ::parse_alc_reply(&reply.data) {
+                        out.push(CatUpdate::Alc(alc));
                     } else if let Some(dbm) = civ::parse_smeter_reply(&reply.data) {
                         out.push(CatUpdate::Signal(dbm));
                     }
@@ -756,9 +763,10 @@ pub fn query_once(cfg: &CatConfig) -> Option<(Option<f64>, Option<Mode>)> {
                     match u {
                         CatUpdate::Freq(hz) => freq = Some(hz),
                         CatUpdate::Mode(m) => mode = Some(m),
-                        // Neither meter, the power, nor the transmit state is
+                        // No meter, the power, or the transmit state is
                         // requested during the startup query.
                         CatUpdate::Swr(_)
+                        | CatUpdate::Alc(_)
                         | CatUpdate::Signal(_)
                         | CatUpdate::Power(_)
                         | CatUpdate::Ptt(_) => {}
@@ -1044,6 +1052,10 @@ fn serial_thread(
     // process rather than per connection: `protocol` — and so what it has
     // learned about this rig — outlives a reconnect.
     let mut announced_push = false;
+    // The latest of each TX meter, because they arrive in separate replies and
+    // the consumer keeps only the last message sent. See the send site.
+    let mut last_swr: Option<f32> = None;
+    let mut last_alc: Option<f32> = None;
     // What mode to command the rig into for a given app mode. FT8/FT4 use the
     // separate `digi_mode` setting; every other mode obeys `mode_control`
     // (CAT = mirror the selected mode to the rig; Radio = don't touch it).
@@ -1278,7 +1290,11 @@ fn serial_thread(
                         // for the rest of the current period.
                         next_meter = Instant::now();
                         if !on {
-                            // Clear the reading so the meter drops SWR on unkey.
+                            // Clear the readings so the meters drop on unkey.
+                            // Both held values go too, or the next over would
+                            // open carrying the last one from the previous one.
+                            last_swr = None;
+                            last_alc = None;
                             let _ = telem_tx.send(TxTelemetry::default());
                         }
                     }
@@ -1527,8 +1543,25 @@ fn serial_thread(
                         // to their own channels and skip the freq/mode dedup
                         // below — a reading that repeats is still current, and
                         // dropping it would freeze the meter.
+                        // ⛔ SWR and ALC arrive as SEPARATE replies, and the
+                        // consumer keeps only the LAST message
+                        // (`poll_telemetry` is `try_iter().last()`). So sending
+                        // one field at a time would make each reading blank the
+                        // other, and the casualty would be the SWR guard: it
+                        // reads `None` as "the rig has not said anything yet"
+                        // and would sit at that forever, never tripping. Both
+                        // are therefore held here and sent together, so every
+                        // message carries the latest of each.
                         if let CatUpdate::Swr(v) = u {
-                            let _ = telem_tx.send(TxTelemetry { fwd_w: None, swr: Some(v) });
+                            last_swr = Some(v);
+                            let _ =
+                                telem_tx.send(TxTelemetry { fwd_w: None, swr: last_swr, alc: last_alc });
+                            continue;
+                        }
+                        if let CatUpdate::Alc(v) = u {
+                            last_alc = Some(v);
+                            let _ =
+                                telem_tx.send(TxTelemetry { fwd_w: None, swr: last_swr, alc: last_alc });
                             continue;
                         }
                         if let CatUpdate::Signal(dbm) = u {
@@ -1588,9 +1621,10 @@ fn serial_thread(
                                 }
                                 c
                             }
-                            // Both meters, the power and the transmit state are
+                            // The meters, the power and the transmit state are
                             // handled above.
                             CatUpdate::Swr(_)
+                            | CatUpdate::Alc(_)
                             | CatUpdate::Signal(_)
                             | CatUpdate::Power(_)
                             | CatUpdate::Ptt(_) => false,

--- a/crates/sdroxide-radio/src/engine.rs
+++ b/crates/sdroxide-radio/src/engine.rs
@@ -2288,11 +2288,19 @@ fn engine_thread(
             // but only an over *we* key is one the guard may unkey, which is
             // why the rails below stay on `tx_active` alone.
             let meters = if engine.tx_active || engine.rig_tx {
-                let alc = engine.tx.as_ref().map(|t| t.alc_peak).unwrap_or(0.0);
                 // CAT/TCI rigs report real forward power / SWR; HackRF and other
                 // IQ sources have no such sensor and leave both `None` (the meter
                 // then falls back to showing drive-side ALC).
                 let tele = engine.source.tx_telemetry().unwrap_or_default();
+                // The rig's own ALC where it reports one, our modulator's peak
+                // otherwise. They are different measurements and the rig's is
+                // the one that answers the operator's question: `alc_peak` is
+                // what SDRoxide SENDS, and ALC is what the rig does about it.
+                // On a CAT rig driving an external radio our figure says
+                // nothing useful about whether the audio is too hot for it.
+                let alc = tele
+                    .alc
+                    .unwrap_or_else(|| engine.tx.as_ref().map(|t| t.alc_peak).unwrap_or(0.0));
                 // Clients that asked for `tx_sensors` get the same figures.
                 if let Some(srv) = engine.tci_srv.as_ref() {
                     srv.push_telemetry(tele);

--- a/crates/sdroxide-radio/tests/converter.rs
+++ b/crates/sdroxide-radio/tests/converter.rs
@@ -505,7 +505,7 @@ impl IqSource for Recorder {
     }
     fn tx_telemetry(&mut self) -> Option<sdroxide_types::TxTelemetry> {
         self.calls.note("tx_telemetry");
-        Some(sdroxide_types::TxTelemetry { fwd_w: Some(5.0), swr: Some(1.2) })
+        Some(sdroxide_types::TxTelemetry { fwd_w: Some(5.0), swr: Some(1.2), alc: None })
     }
     fn set_if_offset(&mut self, _hz: f64) {
         self.calls.note("set_if_offset");

--- a/crates/sdroxide-radio/tests/rig_own_ptt.rs
+++ b/crates/sdroxide-radio/tests/rig_own_ptt.rs
@@ -75,7 +75,10 @@ impl IqSource for MockRig {
     /// The rig's SWR bridge — it reads whoever is keying it, which during the
     /// operator's own over is the operator.
     fn tx_telemetry(&mut self) -> Option<TxTelemetry> {
-        self.rig.lock().unwrap().keyed.then_some(TxTelemetry { fwd_w: None, swr: Some(SWR) })
+        // An SWR bridge and nothing else: this rig reports no ALC meter, so
+        // `alc` stays absent rather than being invented as a zero reading.
+        let t = TxTelemetry { fwd_w: None, swr: Some(SWR), alc: None };
+        self.rig.lock().unwrap().keyed.then_some(t)
     }
     fn tx_begin(&mut self, center_hz: f64, _rate: f64) -> Result<f64> {
         self.rig.lock().unwrap().keyed_by_us.push(center_hz);

--- a/crates/sdroxide-radio/tests/swr_guard.rs
+++ b/crates/sdroxide-radio/tests/swr_guard.rs
@@ -177,7 +177,7 @@ fn run_keyed(telem: TxTelemetry, limit: f32, guard: bool, key: Key, wait: Durati
 /// the exact shape of the telemetry that twice failed on air.
 #[test]
 fn trips_with_no_forward_power_reported() {
-    let o = run(TxTelemetry { fwd_w: None, swr: Some(7.5) }, 2.5, true);
+    let o = run(TxTelemetry { fwd_w: None, swr: Some(7.5), alc: None }, 2.5, true);
     assert_eq!(o.tripped_at, Some(7.5), "a 7.5:1 with no power figure must trip a 2.5:1 guard");
     assert!(!o.still_keyed, "the transmitter must actually stop, not just set a flag");
     assert!(!o.keyed_again, "the latch must refuse the next key-up until acknowledged");
@@ -187,14 +187,14 @@ fn trips_with_no_forward_power_reported() {
 /// BECAUSE the SWR is bad, so a low power reading must not excuse it.
 #[test]
 fn trips_when_the_rig_has_folded_its_power_back() {
-    let o = run(TxTelemetry { fwd_w: Some(3.0), swr: Some(7.5) }, 2.5, true);
+    let o = run(TxTelemetry { fwd_w: Some(3.0), swr: Some(7.5), alc: None }, 2.5, true);
     assert_eq!(o.tripped_at, Some(7.5), "3 W at 7.5:1 is the fault, not a reason to ignore it");
     assert!(!o.still_keyed);
 }
 
 #[test]
 fn leaves_a_good_swr_alone() {
-    let o = run(TxTelemetry { fwd_w: Some(50.0), swr: Some(1.3) }, 2.5, true);
+    let o = run(TxTelemetry { fwd_w: Some(50.0), swr: Some(1.3), alc: None }, 2.5, true);
     assert_eq!(o.tripped_at, None, "1.3:1 must not trip a 2.5:1 guard");
     assert!(o.still_keyed, "a good match must be left transmitting");
 }
@@ -202,7 +202,7 @@ fn leaves_a_good_swr_alone() {
 /// Disarmed is disarmed, however bad the antenna is.
 #[test]
 fn does_nothing_when_disarmed() {
-    let o = run(TxTelemetry { fwd_w: None, swr: Some(9.9) }, 2.5, false);
+    let o = run(TxTelemetry { fwd_w: None, swr: Some(9.9), alc: None }, 2.5, false);
     assert_eq!(o.tripped_at, None);
     assert!(o.still_keyed);
 }
@@ -211,7 +211,7 @@ fn does_nothing_when_disarmed() {
 /// having its silence read as either safe or dangerous.
 #[test]
 fn inert_when_the_rig_reports_no_swr() {
-    let o = run(TxTelemetry { fwd_w: Some(50.0), swr: None }, 2.5, true);
+    let o = run(TxTelemetry { fwd_w: Some(50.0), swr: None, alc: None }, 2.5, true);
     assert_eq!(o.tripped_at, None);
     assert!(o.still_keyed);
 }
@@ -220,7 +220,7 @@ fn inert_when_the_rig_reports_no_swr() {
 /// the ratio is then noise. This is the only thing the power floor may do.
 #[test]
 fn ignores_a_reading_taken_at_no_power() {
-    let o = run(TxTelemetry { fwd_w: Some(0.0), swr: Some(9.9) }, 2.5, true);
+    let o = run(TxTelemetry { fwd_w: Some(0.0), swr: Some(9.9), alc: None }, 2.5, true);
     assert_eq!(o.tripped_at, None, "0 W means the reading is meaningless, not that the SWR is bad");
 }
 
@@ -233,7 +233,7 @@ fn ignores_a_reading_taken_at_no_power() {
 #[test]
 fn a_tune_is_allowed_above_the_on_air_limit() {
     let o = run_keyed(
-        TxTelemetry { fwd_w: None, swr: Some(4.0) },
+        TxTelemetry { fwd_w: None, swr: Some(4.0), alc: None },
         2.5,
         true,
         Key::Tune,
@@ -248,7 +248,7 @@ fn a_tune_is_allowed_above_the_on_air_limit() {
 /// simply stopped working.
 #[test]
 fn the_same_swr_stops_an_ordinary_over() {
-    let o = run(TxTelemetry { fwd_w: None, swr: Some(4.0) }, 2.5, true);
+    let o = run(TxTelemetry { fwd_w: None, swr: Some(4.0), alc: None }, 2.5, true);
     assert_eq!(o.tripped_at, Some(4.0), "4:1 is over a 2.5:1 limit when it is not a tune");
     assert!(!o.still_keyed);
 }
@@ -259,7 +259,7 @@ fn the_same_swr_stops_an_ordinary_over() {
 #[test]
 fn a_tune_still_stops_on_a_dead_feeder() {
     let o = run_keyed(
-        TxTelemetry { fwd_w: None, swr: Some(9.9) },
+        TxTelemetry { fwd_w: None, swr: Some(9.9), alc: None },
         2.5,
         true,
         Key::Tune,
@@ -279,7 +279,7 @@ fn a_tune_still_stops_on_a_dead_feeder() {
 /// fraction of a second, which is the whole reason the guard exists.
 #[test]
 fn an_over_is_stopped_without_waiting_seconds() {
-    let o = run(TxTelemetry { fwd_w: None, swr: Some(9.9) }, 2.5, true);
+    let o = run(TxTelemetry { fwd_w: None, swr: Some(9.9), alc: None }, 2.5, true);
     let after = o.tripped_after.expect("a trip has a time");
     assert!(after < Duration::from_secs(1), "an over must not inherit the tune grace: {after:?}");
 }

--- a/crates/sdroxide-smartsdr/src/net.rs
+++ b/crates/sdroxide-smartsdr/src/net.rs
@@ -1210,7 +1210,7 @@ impl DataThread {
                         }
                         drop(table);
                         if changed && self.keyed {
-                            let _ = self.telem.send(TxTelemetry { fwd_w, swr });
+                            let _ = self.telem.send(TxTelemetry { fwd_w, swr, alc: None });
                         }
                     }
                 }

--- a/crates/sdroxide-tci/src/net.rs
+++ b/crates/sdroxide-tci/src/net.rs
@@ -1102,7 +1102,7 @@ impl NetThread {
 
     /// Emit the current aggregated TX telemetry snapshot.
     fn emit_tx_telem(&self) {
-        let _ = self.telem.send(TxTelemetry { fwd_w: self.tx_fwd_w, swr: self.tx_swr });
+        let _ = self.telem.send(TxTelemetry { fwd_w: self.tx_fwd_w, swr: self.tx_swr, alc: None });
     }
 }
 

--- a/crates/sdroxide-types/src/meters.rs
+++ b/crates/sdroxide-types/src/meters.rs
@@ -9,8 +9,8 @@ pub struct TxMeters {
     pub alc: f32,
 }
 
-/// TX-side telemetry a rig reports out-of-band (CAT / TCI): forward power and
-/// SWR. Distinct from [`TxMeters`], which also carries the engine's own ALC —
+/// TX-side telemetry a rig reports out-of-band (CAT / TCI): forward power,
+/// SWR and ALC. Distinct from [`TxMeters`], which also carries the engine's own ALC —
 /// this is only what the *device* measures, merged into `TxMeters` by the
 /// engine while transmitting.
 #[derive(Debug, Clone, Copy, PartialEq, Default, Serialize, Deserialize)]
@@ -19,6 +19,15 @@ pub struct TxTelemetry {
     pub fwd_w: Option<f32>,
     /// SWR as a ratio (e.g. `1.4` = 1.4:1), if the device measures it.
     pub swr: Option<f32>,
+    /// ALC as `0.0..=1.0` of the rig's own meter, if it reports one.
+    ///
+    /// This is the rig saying how hard its automatic level control is working,
+    /// which is the number that says whether the audio being fed to it is too
+    /// hot. Nothing on this side can compute it: [`TxMeters::alc`] is what
+    /// SDRoxide SENDS, and this is what the rig does about it. On a CAT rig the
+    /// two are different measurements and only this one is the operator's
+    /// answer to "am I overdriving it".
+    pub alc: Option<f32>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]

--- a/src/audio_cat_source.rs
+++ b/src/audio_cat_source.rs
@@ -523,8 +523,10 @@ impl IqSource for AudioCatSource {
                     }
                     out.push(ControlUpdate::RigTx(on));
                 }
-                // Both meters arrive on their own telemetry channels, not here.
-                sdroxide_cat::CatUpdate::Swr(_) | sdroxide_cat::CatUpdate::Signal(_) => {}
+                // The meters arrive on their own telemetry channels, not here.
+                sdroxide_cat::CatUpdate::Swr(_)
+                | sdroxide_cat::CatUpdate::Alc(_)
+                | sdroxide_cat::CatUpdate::Signal(_) => {}
             }
         }
         out

--- a/src/elad_source.rs
+++ b/src/elad_source.rs
@@ -341,8 +341,10 @@ impl IqSource for EladSource {
                 // `Protocol::tx_state_requests`), so this never arrives — but
                 // the day it does, it means the same thing here as anywhere.
                 sdroxide_cat::CatUpdate::Ptt(on) => out.push(ControlUpdate::RigTx(on)),
-                // Both meters arrive on their own telemetry channels, not here.
-                sdroxide_cat::CatUpdate::Swr(_) | sdroxide_cat::CatUpdate::Signal(_) => {}
+                // The meters arrive on their own telemetry channels, not here.
+                sdroxide_cat::CatUpdate::Swr(_)
+                | sdroxide_cat::CatUpdate::Alc(_)
+                | sdroxide_cat::CatUpdate::Signal(_) => {}
             }
         }
         out


### PR DESCRIPTION
The drive level the meter showed was SDRoxide's own: how hard the audio being sent to the rig is driving the modulator. That is a useful number and it is not the one the operator wants, which is what the RIG's ALC is doing about that audio. On a CAT rig the two are different measurements, and only the rig's answers "am I overdriving it". On a CAT rig driving an external radio our figure says nothing useful at all about whether the audio is too hot for it.

Read on Icom cmd 0x15 sub 0x13, beside the SWR meter already read there, and reported as a fraction of full scale rather than in dB. There is no published Icom curve for the ALC meter, unlike the S-meter and SWR, so the raw 0..255 is passed through as a fraction rather than fitted to an invented calibration. The manual says only that the meter should stay within the ALC zone, which is what the operator reads on the rig's face anyway.

**Two things that would have broken quietly.** SWR and ALC arrive as separate replies and the consumer keeps only the last `TxTelemetry` of each batch (`poll_telemetry` is `try_iter().last()`), so sending one field at a time would have each blank the other. The casualty would have been the SWR guard, which reads `None` as "the rig has not said anything yet" and would sit at that forever, never tripping. Both readings are held in the reader and sent together. And each parser checks the sub-command byte and refuses the others: SWR, ALC and the S-meter all answer on 0x15 and nothing else tells them apart, so without the guard an ALC reply would be reported as an SWR ratio, which the guard acts on.

The engine prefers the rig's ALC where it reports one and falls back to the modulator's peak otherwise, so a source with no such sensor behaves exactly as before. The ELAD source matches exhaustively on `CatUpdate`, so it gains the new variant here rather than in a follow-up, or this commit would not build on its own.

**Checked on air.** The second commit records it: verified against an IC-7300 on 18 August 2026, where the percentage agrees with the rig's own meter and reads much as WSJT-X 3.2.0's does beside its SWR figure. The open question in the parser's doc comment is therefore closed, and closed in the direction of leaving the scale alone. Fitting a curve now would be inventing precision against no published reference, to improve a reading already shown to track the rig.

**Testing.** Rebased onto current main today, which brings the new `rig_own_ptt` test and its operator-keyed meter path; the widened `engine.tx_active || engine.rig_tx` condition is kept, so an over the operator keys at the rig now reaches this meter too, and on that path the rig's own figure is the only real reading available. `TxTelemetry` gains a field, so the exhaustive literals in `rig_own_ptt.rs` and `swr_guard.rs` now pass `alc: None`. `cargo check --release --no-default-features` and `cargo test --release --no-default-features --no-run` are both clean.
