### PR TITLE
QO-100 satellite beacon sync offset and decode plugin

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5301,7 +5301,7 @@ dependencies = [
 
 [[package]]
 name = "sdroxide-qo100"
-version = "1.5.3"
+version = "1.5.4"
 dependencies = [
  "crossbeam-channel",
  "sdroxide-dsp",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5354,6 +5354,7 @@ dependencies = [
  "sdroxide-ism",
  "sdroxide-kiss",
  "sdroxide-net",
+ "sdroxide-qo100",
  "sdroxide-rigctld",
  "sdroxide-rotator",
  "sdroxide-skimmer",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5300,6 +5300,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "sdroxide-qo100"
+version = "1.5.3"
+dependencies = [
+ "crossbeam-channel",
+ "sdroxide-dsp",
+ "sdroxide-types",
+ "tracing",
+]
+
+[[package]]
 name = "sdroxide-r82xx"
 version = "1.5.4"
 dependencies = [

--- a/crates/sdroxide-proto/src/lib.rs
+++ b/crates/sdroxide-proto/src/lib.rs
@@ -827,7 +827,26 @@ use sdroxide_types::{
 /// Appended at the end of the struct; postcard numbers fields by position, so a
 /// v99 peer desynchronises on the tail of every `AdsbStatus` and the
 /// handshake's equality test is what stops it trying.
-pub const PROTO_VERSION: u16 = 100;
+///
+/// **101** — the QO-100 beacon calibration decoder.
+///
+/// [`sdroxide_types::RadioState`] gained `qo100`
+/// ([`sdroxide_types::Qo100Settings`]) holding whether the decoder runs and how
+/// wide it searches, and [`sdroxide_types::Command`] gained `SetQo100Config` to
+/// move it — the ISM decoder's shape, no apply step, the engine echoes the
+/// setting back in the state. Both are appended at the tail of their type, so
+/// every field and variant already on the wire keeps its number; a v100 peer
+/// desynchronises on the tail of every `RadioState` regardless, and the
+/// handshake's equality test is what stops it trying.
+///
+/// The live side — [`sdroxide_types::Qo100Status`] (lock, measured offset,
+/// decoded telemetry text) — is a native-engine `RadioEvent` only and never
+/// reaches the wire: `sdroxide-server` maps it to no `ServerMsg`, the same as
+/// the spectrum lanes that travel their own way. So there is no new `ServerMsg`
+/// here, and a remote client's window shows that the reading is local-only
+/// rather than sitting on "starting…". If it is bridged later that is its own
+/// append and its own bump.
+pub const PROTO_VERSION: u16 = 101;
 const VERSION_BYTE: u8 = 0x12;
 
 #[derive(Debug, thiserror::Error)]

--- a/crates/sdroxide-qo100/Cargo.toml
+++ b/crates/sdroxide-qo100/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "sdroxide-qo100"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+
+# Native-only: the QO-100 beacon decoder runs server-side in the engine, off
+# the raw IQ, like the skimmers and the ISM decoder. Not linked by the wasm
+# client.
+#
+# The BPSK-400/AO-40-uncoded framing implemented here is written from public
+# protocol facts (sync word, frame length, CRC variant, encoding order) — not
+# ported from any existing decoder's code — cross-checked against the open
+# reference implementation in Daniel Estévez's gr-satellites project
+# (GPL-3.0-or-later, https://github.com/daniestevez/gr-satellites,
+# python/components/deframers/ao40_uncoded_deframer.py and
+# python/satyaml/QO-100.yml). See `bpsk.rs` for the citations inline.
+
+[dependencies]
+sdroxide-types.workspace = true
+sdroxide-dsp.workspace = true
+crossbeam-channel.workspace = true
+tracing.workspace = true

--- a/crates/sdroxide-qo100/src/bpsk.rs
+++ b/crates/sdroxide-qo100/src/bpsk.rs
@@ -1,0 +1,577 @@
+//! BPSK-400 demodulation and AO-40 "uncoded" frame decode for the QO-100
+//! narrowband beacon.
+//!
+//! # Protocol, confirmed rather than guessed
+//!
+//! Every number below is taken from Daniel Estévez's (EA4GPZ) gr-satellites
+//! project (GPL-3.0-or-later, <https://github.com/daniestevez/gr-satellites>)
+//! — he wrote and maintains the QO-100 beacon decoder there — cross-checked
+//! against his write-up at
+//! <https://destevez.net/2017/05/decoding-ao-40-uncoded-telemetry/>. Nothing
+//! here is ported from that code; these are protocol facts (a sync pattern,
+//! a frame length, a CRC variant), not an implementation.
+//!
+//! - `python/satyaml/QO-100.yml`: 10489.750 MHz, "DBPSK Manchester", 400 baud,
+//!   framing "AO-40 uncoded" (the satellite also sends an FEC-coded variant on
+//!   alternate frames; this module does not attempt that one — see the crate
+//!   doc).
+//! - `python/components/deframers/ao40_uncoded_deframer.py`: sync word
+//!   `'00111001000101011110110100110000'` (32 bits, MSB first —
+//!   [`SYNC_WORD`]/[`SYNC_LEN`]), frame length `512 + 2` bytes
+//!   ([`PAYLOAD_BYTES`]/[`CRC_BYTES`]), `crc16_ccitt_false` (poly 0x1021,
+//!   init 0xFFFF, not reflected, no xorout), sync-word threshold 3 bit errors
+//!   ([`SYNC_MAX_ERRORS`]).
+//! - `python/telemetry/qo100.py`: the payload is plain ASCII text, no binary
+//!   header — `packet[:-2].decode('ascii')`.
+//! - The write-up: data is differentially encoded first (`1` = a phase
+//!   change, `0` = none), then Manchester encoded.
+//!
+//! # Demodulation: search, not a tracking loop
+//!
+//! There is no way to test a Costas/Gardner loop's acquisition behaviour
+//! against the real signal from here, so this does not attempt one. Instead —
+//! matching `sdroxide_ism`'s slicer, which solves the same problem the same
+//! way — [`acquire`] tries a grid of candidate frequency offsets and, at each,
+//! every chip-timing phase and Manchester bit-parity, decodes the whole block
+//! and checks the sync word and CRC. Whichever combination validates the CRC
+//! *is* the calibration answer: its frequency offset is exactly how far the
+//! beacon sits from where it was assumed to be.
+//!
+//! The differential+Manchester combination is decoded in one pass, without
+//! ever resolving absolute carrier phase: comparing each chip against the one
+//! immediately before it (a delay-and-multiply, not a coherent reference)
+//! gives a flip/no-flip bit that is robust to whatever the residual carrier
+//! phase is doing, and — because Manchester always flips at a bit's own
+//! midpoint but the *inter-bit* transition flips exactly when the
+//! differentially-encoded source bit is `0` — keeping only the inter-bit
+//! comparisons recovers the original data directly. See the derivation in
+//! this module's tests.
+
+use sdroxide_dsp::Complex32;
+
+/// Chips per second on the air. Manchester encoding sends two of these per
+/// data bit.
+pub const CHIP_RATE: f64 = 800.0;
+/// Data bits per second — half the chip rate, Manchester's own cost.
+pub const BAUD: f64 = 400.0;
+
+/// The AO-40 uncoded beacon's sync pattern, MSB first, right-aligned in a
+/// u32. See the module doc for where this number comes from.
+const SYNC_WORD: u32 = 0x3915_ED30;
+const SYNC_LEN: u32 = 32;
+/// Bit errors tolerated in the sync match — gr-satellites' own default
+/// (`ao40_uncoded_deframer`'s `syncword_threshold`).
+const SYNC_MAX_ERRORS: u32 = 3;
+
+const PAYLOAD_BYTES: usize = 512;
+const CRC_BYTES: usize = 2;
+const FRAME_BYTES: usize = PAYLOAD_BYTES + CRC_BYTES;
+const FRAME_BITS: usize = FRAME_BYTES * 8;
+
+/// One whole frame's time on the air, sync word included — 10.36 s, matching
+/// destevez.net's own figure for it. [`crate::controller::Qo100Controller`]
+/// sizes its rolling buffer off this so a frame can never fall between two
+/// analysis windows unseen.
+pub const FRAME_SECONDS: f64 = (SYNC_LEN as usize + FRAME_BITS) as f64 / BAUD;
+
+/// Chip-timing phases tried per frequency candidate. A sixteenth of a chip is
+/// closer to optimal than the timing error a 400 baud link accumulates over
+/// one frame, so trying more would be measuring noise — the same reasoning
+/// `sdroxide_ism::slice` uses for its own `PHASES`.
+const TIMING_PHASES: usize = 8;
+
+/// A successfully decoded frame: how far the beacon actually sits from the
+/// frequency [`acquire`] was told to assume, and what it said.
+#[derive(Debug, Clone, PartialEq)]
+pub struct Qo100Lock {
+    pub offset_hz: f64,
+    pub text: String,
+}
+
+/// CRC-16/CCITT-FALSE: poly 0x1021, init 0xFFFF, not reflected, no xorout.
+/// The variant `ao40_uncoded_deframer.py` names (`crc16_ccitt_false`); the
+/// well-known check value for `"123456789"` is `0x29B1`, asserted in this
+/// module's tests.
+fn crc16_ccitt_false(data: &[u8]) -> u16 {
+    let mut crc: u16 = 0xFFFF;
+    for &b in data {
+        crc ^= (b as u16) << 8;
+        for _ in 0..8 {
+            crc = if crc & 0x8000 != 0 { (crc << 1) ^ 0x1021 } else { crc << 1 };
+        }
+    }
+    crc
+}
+
+/// Differential-encode `bits` (`1` = phase change, `0` = none) — the
+/// transmit-side half of the demodulation this module reverses, and needed
+/// again itself by [`refine_offset_hz`], which has to know exactly which
+/// chip polarities a *decoded* frame implies in order to strip them back out.
+fn differential_encode(bits: &[bool]) -> Vec<bool> {
+    let mut state = false;
+    bits.iter()
+        .map(|&d| {
+            state ^= d;
+            state
+        })
+        .collect()
+}
+
+/// Manchester-encode `e` into chip polarities (`true` = one BPSK sense,
+/// `false` = the other — which is which is arbitrary and resolved by nothing
+/// here, exactly as [`chip_flips`] needs it to be).
+fn manchester_chips(e: &[bool]) -> Vec<bool> {
+    e.iter().flat_map(|&b| [b, !b]).collect()
+}
+
+/// The full on-air chip sequence (differential, then Manchester) for
+/// `source_bits` — sync word included, in transmit order.
+fn source_chips(source_bits: &[bool]) -> Vec<bool> {
+    manchester_chips(&differential_encode(source_bits))
+}
+
+/// Delay-and-multiply detection between every adjacent chip: `true` where the
+/// phase flipped from one chip to the next. Robust to a residual carrier
+/// frequency error too small to notice between two chips 1.25 ms apart, which
+/// is the whole reason this is used instead of a coherent (absolute-phase)
+/// slicer — see the module doc.
+fn chip_flips(chips: &[Complex32]) -> Vec<bool> {
+    chips.windows(2).map(|w| (w[1] * w[0].conj()).re < 0.0).collect()
+}
+
+/// The differentially-encoded, Manchester-encoded data bits `chip_flips`
+/// implies, for one of the two possible Manchester bit-parities (which half
+/// of each adjacent-chip pair is the *inter-bit* boundary — the intra-bit
+/// transition Manchester guarantees every bit carries no information and is
+/// skipped). See the module doc's derivation.
+///
+/// `parity == 0`: bit boundaries are flips at odd indices of `flips` (chip 1
+/// to chip 2, chip 3 to chip 4, …). `parity == 1`: the other set.
+fn data_bits(flips: &[bool], parity: usize) -> Vec<bool> {
+    flips.iter().skip(parity).step_by(2).map(|&f| !f).collect()
+}
+
+/// `bits`, packed MSB-first into bytes. Trailing bits short of a full byte
+/// are dropped.
+fn pack_bits(bits: &[bool]) -> Vec<u8> {
+    bits.as_chunks::<8>()
+        .0
+        .iter()
+        .map(|c| c.iter().fold(0u8, |acc, &b| (acc << 1) | b as u8))
+        .collect()
+}
+
+/// The bit offset in `bits` where [`SYNC_WORD`] matches within
+/// [`SYNC_MAX_ERRORS`], and how many errors it took — the *first* match, read
+/// left to right, since a frame beacon transmits continuously and the first
+/// candidate in a block is as good as any later one.
+fn find_sync(bits: &[bool], from: usize) -> Option<usize> {
+    if from + SYNC_LEN as usize > bits.len() {
+        return None;
+    }
+    let mut window: u32 = 0;
+    for (i, &b) in bits.iter().enumerate().skip(from) {
+        window = (window << 1) | b as u32;
+        if i + 1 < from + SYNC_LEN as usize {
+            continue;
+        }
+        if (window ^ SYNC_WORD).count_ones() <= SYNC_MAX_ERRORS {
+            return Some(i + 1 - SYNC_LEN as usize);
+        }
+    }
+    None
+}
+
+/// One matched, CRC-valid frame's essentials: the bits it actually carried
+/// (sync word included, so its exact on-air chips can be reconstructed) and
+/// the decoded text, plus where in `data_bits`-space the sync word began —
+/// [`refine_offset_hz`] needs all of it to re-locate the exact samples.
+struct FrameMatch {
+    db_start: usize,
+    source_bits: Vec<bool>,
+    text: String,
+}
+
+/// Try to decode one AO-40 uncoded frame from `bits` (already chip- and
+/// Manchester-decoded data bits — see [`data_bits`]). `None` when nothing in
+/// range is both a sync match and a CRC-valid frame after it.
+///
+/// Keeps searching past a sync match whose CRC fails, rather than stopping at
+/// the first one: a 32-bit pattern matched within 3 errors turns up by pure
+/// chance often enough in a block this long (noise, or another satellite's
+/// frame ahead of the real one) that giving up there would refuse a perfectly
+/// good frame sitting right after it.
+fn decode_frame(bits: &[bool]) -> Option<FrameMatch> {
+    let mut from = 0;
+    while let Some(start) = find_sync(bits, from) {
+        let frame_bits = bits.get(start + SYNC_LEN as usize..);
+        if let Some(frame_bits) = frame_bits
+            && frame_bits.len() >= FRAME_BITS
+        {
+            let frame = pack_bits(&frame_bits[..FRAME_BITS]);
+            let want = u16::from_be_bytes([frame[PAYLOAD_BYTES], frame[PAYLOAD_BYTES + 1]]);
+            let got = crc16_ccitt_false(&frame[..PAYLOAD_BYTES]);
+            if got == want {
+                let mut source_bits = Vec::with_capacity(SYNC_LEN as usize + FRAME_BITS);
+                source_bits.extend((0..SYNC_LEN).rev().map(|i| (SYNC_WORD >> i) & 1 != 0));
+                source_bits.extend_from_slice(&frame_bits[..FRAME_BITS]);
+                return Some(FrameMatch {
+                    db_start: start,
+                    source_bits,
+                    text: String::from_utf8_lossy(&frame[..PAYLOAD_BYTES]).into_owned(),
+                });
+            }
+        }
+        from = start + 1;
+    }
+    None
+}
+
+/// Extract one complex sample per chip from `iq` (already mixed to the
+/// candidate frequency), starting `phase` samples in, at `samples_per_chip`
+/// spacing. Nearest-sample selection — no interpolation — which is enough at
+/// the oversampling ratios this runs at (12+ samples/chip in practice).
+fn chip_samples(iq: &[Complex32], samples_per_chip: f64, phase: usize) -> Vec<Complex32> {
+    let mut out = Vec::with_capacity((iq.len() as f64 / samples_per_chip) as usize);
+    let mut pos = phase as f64;
+    while (pos as usize) < iq.len() {
+        out.push(iq[pos as usize]);
+        pos += samples_per_chip;
+    }
+    out
+}
+
+/// One coarse-search hit: everything [`refine_offset_hz`] needs to re-find
+/// the exact samples the matched frame came from.
+struct CoarseMatch {
+    parity: usize,
+    phase: usize,
+    m: FrameMatch,
+}
+
+/// Try every chip-timing phase and Manchester parity against `iq` (already
+/// mixed to one candidate frequency, `rate_hz` samples/s). `Some` on the
+/// first combination whose sync word and CRC both check out.
+fn try_frequency(iq: &[Complex32], rate_hz: f64) -> Option<CoarseMatch> {
+    let samples_per_chip = rate_hz / CHIP_RATE;
+    if samples_per_chip < 2.0 {
+        return None; // not enough oversampling for chip_samples to mean anything
+    }
+    let phase_step = (samples_per_chip / TIMING_PHASES as f64).max(1.0);
+    for p in 0..TIMING_PHASES {
+        let phase = (p as f64 * phase_step) as usize;
+        let chips = chip_samples(iq, samples_per_chip, phase);
+        if chips.len() < 3 {
+            continue;
+        }
+        let flips = chip_flips(&chips);
+        for parity in 0..2 {
+            let bits = data_bits(&flips, parity);
+            if let Some(m) = decode_frame(&bits) {
+                return Some(CoarseMatch { parity, phase, m });
+            }
+        }
+    }
+    None
+}
+
+/// Precisely measure the residual carrier frequency of a frame
+/// [`try_frequency`] already found, on top of whatever coarse offset `iq` was
+/// already mixed by.
+///
+/// The coarse chip-rate delay-detector that found the frame tolerates
+/// whatever residual frequency error let it decode at all — a wide window,
+/// [`CHIP_RATE`] Hz wide before it repeats — which is exactly what makes it
+/// useless for saying *where inside that window* the true carrier sits. Now
+/// that the frame is known exactly, its modulation can be stripped from every
+/// *raw* sample (not just one per chip) and the residual phase averaged at
+/// the full sample rate instead: far more samples to average over, and an
+/// alias period of `rate_hz` rather than [`CHIP_RATE`] — wide enough that no
+/// realistic search width can be fooled by it.
+fn refine_offset_hz(iq: &[Complex32], rate_hz: f64, cm: &CoarseMatch) -> f64 {
+    let samples_per_chip = rate_hz / CHIP_RATE;
+    let chips = source_chips(&cm.m.source_bits);
+    let chip0 = cm.parity + 2 * cm.m.db_start;
+    let sample_start = cm.phase + (chip0 as f64 * samples_per_chip).round() as usize;
+    let sample_end = (cm.phase
+        + ((chip0 + chips.len()) as f64 * samples_per_chip).round() as usize)
+        .min(iq.len());
+    if sample_end <= sample_start + 1 {
+        return 0.0;
+    }
+    let mut sum = Complex32::new(0.0, 0.0);
+    let mut prev: Option<Complex32> = None;
+    for (offset, &z) in iq[sample_start..sample_end].iter().enumerate() {
+        let chip_idx = (offset as f64 / samples_per_chip) as usize;
+        let Some(&bit) = chips.get(chip_idx) else { break };
+        let clean = z * if bit { -1.0f32 } else { 1.0f32 };
+        if let Some(p) = prev {
+            sum += clean * p.conj();
+        }
+        prev = Some(clean);
+    }
+    if sum.norm() < 1e-6 {
+        return 0.0;
+    }
+    sum.arg() as f64 * rate_hz / std::f64::consts::TAU
+}
+
+/// Search `iq` (complex baseband, `rate_hz` samples/s, the beacon assumed to
+/// sit somewhere within `±search_half_width_hz` of DC) for one CRC-valid
+/// AO-40 uncoded frame, stepping the candidate frequency by `freq_step_hz`.
+/// The frequency reported is refined well past that step's own resolution —
+/// see [`refine_offset_hz`] — so `freq_step_hz` only needs to be fine enough
+/// to land *somewhere* inside a real signal's capture range, not to measure
+/// it.
+///
+/// `iq` needs to span at least one whole frame (`FRAME_BITS` bits plus the
+/// sync word, [`BAUD`] bits/s) for a frame to have any chance of falling
+/// inside it whole; the caller — [`crate::controller::Qo100Controller`] —
+/// keeps a rolling window comfortably longer than that so no alignment of the
+/// buffer against the frame can miss one.
+pub fn acquire(
+    iq: &[Complex32],
+    rate_hz: f64,
+    search_half_width_hz: f64,
+    freq_step_hz: f64,
+) -> Option<Qo100Lock> {
+    if freq_step_hz <= 0.0 || rate_hz <= 0.0 {
+        return None;
+    }
+    let steps = (search_half_width_hz / freq_step_hz).round() as i64;
+    let mut mixed = Vec::with_capacity(iq.len());
+    for step in -steps..=steps {
+        let coarse_hz = step as f64 * freq_step_hz;
+        mixed.clear();
+        mixed.extend(iq.iter().enumerate().map(|(n, &z)| {
+            let phase = -2.0 * std::f64::consts::PI * coarse_hz * n as f64 / rate_hz;
+            z * Complex32::new(phase.cos() as f32, phase.sin() as f32)
+        }));
+        if let Some(cm) = try_frequency(&mixed, rate_hz) {
+            let offset_hz = coarse_hz + refine_offset_hz(&mixed, rate_hz, &cm);
+            return Some(Qo100Lock { offset_hz, text: cm.m.text });
+        }
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// xorshift64* — cheap, deterministic, good enough for test noise and
+    /// jitter. The same technique `sdroxide_radio::source::SigGenSource`
+    /// uses for its own noise floor, kept local here rather than pulling in
+    /// a `rand` dependency no other first-party crate in this workspace
+    /// carries.
+    struct TestRng(u64);
+
+    impl TestRng {
+        fn new(seed: u64) -> Self {
+            Self(seed.max(1))
+        }
+
+        /// Uniform in `[0, 1)`.
+        fn next_unit(&mut self) -> f64 {
+            self.0 ^= self.0 << 13;
+            self.0 ^= self.0 >> 7;
+            self.0 ^= self.0 << 17;
+            (self.0.wrapping_mul(0x2545_F491_4F6C_DD1D) >> 11) as f64 / (1u64 << 53) as f64
+        }
+
+        /// Uniform in `[lo, hi)`.
+        fn range(&mut self, lo: f64, hi: f64) -> f64 {
+            lo + self.next_unit() * (hi - lo)
+        }
+    }
+
+    #[test]
+    fn crc16_ccitt_false_matches_the_published_check_value() {
+        // The catalogue check value for CRC-16/CCITT-FALSE: CRC of the ASCII
+        // string "123456789".
+        assert_eq!(crc16_ccitt_false(b"123456789"), 0x29B1);
+    }
+
+    fn pack_msb(bits: &[bool]) -> Vec<u8> {
+        pack_bits(bits)
+    }
+
+    fn unpack_msb(bytes: &[u8]) -> Vec<bool> {
+        bytes.iter().flat_map(|&b| (0..8).rev().map(move |i| (b >> i) & 1 != 0)).collect()
+    }
+
+    /// Build one complete on-air AO-40 uncoded frame (sync + payload + CRC),
+    /// as data bits — before differential/Manchester encoding.
+    fn build_frame_bits(text: &str) -> Vec<bool> {
+        let mut payload = text.as_bytes().to_vec();
+        payload.resize(PAYLOAD_BYTES, b' ');
+        let crc = crc16_ccitt_false(&payload);
+        let mut frame = payload;
+        frame.extend_from_slice(&crc.to_be_bytes());
+        let sync_bits: Vec<bool> = (0..SYNC_LEN).rev().map(|i| (SYNC_WORD >> i) & 1 != 0).collect();
+        let mut bits = sync_bits;
+        bits.extend(unpack_msb(&frame));
+        bits
+    }
+
+    /// Synthesize `rate_hz` samples/s of complex baseband carrying `text` as
+    /// an AO-40 uncoded frame, with some quiet chips either side (so a
+    /// frame boundary lands away from the buffer's own edges, like it would
+    /// in a continuously-transmitting real signal sliced at an arbitrary
+    /// time), a constant frequency offset, a random starting phase and chip
+    /// timing offset, and light noise.
+    fn synth_signal(
+        text: &str,
+        rate_hz: f64,
+        offset_hz: f64,
+        noise: f32,
+        seed: u64,
+    ) -> Vec<Complex32> {
+        let mut rng = TestRng::new(seed);
+        let data_bits = build_frame_bits(text);
+        let e = differential_encode(&data_bits);
+        let chips: Vec<bool> = manchester_chips(&e);
+
+        let samples_per_chip = rate_hz / CHIP_RATE;
+        let lead_chips = 40usize; // quiet-ish run before the frame, like real air time
+        let total_chips = lead_chips + chips.len() + 10;
+        let start_phase: f64 = rng.range(0.0, std::f64::consts::TAU);
+        let sub_chip_offset: f64 = rng.range(0.0, 1.0); // sub-sample timing error
+
+        let mut out = Vec::with_capacity((total_chips as f64 * samples_per_chip) as usize + 8);
+        let mut n = 0usize;
+        for c in 0..total_chips {
+            let bit = if c < lead_chips || c >= lead_chips + chips.len() {
+                // Filler chips outside the frame — a real receiver sees the
+                // *previous* frame's tail and the *next* one's head here, not
+                // silence, so this is the more honest test. Pseudo-random
+                // rather than a fixed pattern: a periodic filler is itself
+                // periodic Manchester data and can correlate with the sync
+                // word by construction, not by chance — exactly what this is
+                // supposed to rule out.
+                rng.range(0.0, 1.0) < 0.5
+            } else {
+                chips[c - lead_chips]
+            };
+            let sym = if bit { -1.0f32 } else { 1.0f32 };
+            let n_this_chip = (((c + 1) as f64 + sub_chip_offset) * samples_per_chip) as usize - n;
+            for _ in 0..n_this_chip {
+                let carrier_phase =
+                    start_phase + std::f64::consts::TAU * offset_hz * n as f64 / rate_hz;
+                let noise_c = Complex32::new(
+                    rng.range(-1.0, 1.0) as f32 * noise,
+                    rng.range(-1.0, 1.0) as f32 * noise,
+                );
+                out.push(
+                    Complex32::new(
+                        sym * carrier_phase.cos() as f32,
+                        sym * carrier_phase.sin() as f32,
+                    ) + noise_c,
+                );
+                n += 1;
+            }
+        }
+        out
+    }
+
+    const TEST_RATE: f64 = 16_000.0;
+
+    #[test]
+    fn a_clean_frame_at_zero_offset_decodes_and_reports_no_drift() {
+        let iq = synth_signal("QO-100 TEST TELEMETRY LINE ONE", TEST_RATE, 0.0, 0.0, 1);
+        let lock = acquire(&iq, TEST_RATE, 50.0, 10.0).expect("should lock");
+        // Refined well past the 10 Hz search grid — see `refine_offset_hz`.
+        assert!(lock.offset_hz.abs() < 1.0, "found {}", lock.offset_hz);
+        assert!(lock.text.starts_with("QO-100 TEST TELEMETRY LINE ONE"), "{:?}", lock.text);
+    }
+
+    /// The whole point of the feature: a beacon that is not exactly where the
+    /// dial assumes it is still gets found, and the frequency the search
+    /// lands on *is* the calibration answer — refined well past the coarse
+    /// search grid's own 10 Hz step, not just "the nearest step".
+    #[test]
+    fn a_drifted_frame_is_found_and_the_drift_is_reported() {
+        for &true_offset in &[37.0f64, -68.0, 91.0] {
+            let iq = synth_signal("DRIFT CASE", TEST_RATE, true_offset, 0.02, 2);
+            let lock = acquire(&iq, TEST_RATE, 150.0, 10.0)
+                .unwrap_or_else(|| panic!("should lock at offset {true_offset}"));
+            assert!(
+                (lock.offset_hz - true_offset).abs() <= 1.0,
+                "true {true_offset}, found {}",
+                lock.offset_hz
+            );
+            assert!(lock.text.starts_with("DRIFT CASE"));
+        }
+    }
+
+    #[test]
+    fn noise_with_no_signal_never_reports_a_lock() {
+        let mut rng = TestRng::new(3);
+        let n = (TEST_RATE * 12.0) as usize;
+        let iq: Vec<Complex32> = (0..n)
+            .map(|_| Complex32::new(rng.range(-1.0, 1.0) as f32, rng.range(-1.0, 1.0) as f32))
+            .collect();
+        assert!(acquire(&iq, TEST_RATE, 100.0, 10.0).is_none());
+    }
+
+    #[test]
+    fn a_corrupted_payload_bit_is_refused_by_the_crc() {
+        let clean = build_frame_bits("SHOULD APPEAR");
+        assert!(decode_frame(&clean).is_some(), "the undamaged frame must decode");
+
+        let mut corrupted = clean.clone();
+        // Flip a bit well inside the payload, away from the sync word.
+        let i = SYNC_LEN as usize + 100;
+        corrupted[i] = !corrupted[i];
+        assert!(decode_frame(&corrupted).is_none(), "a single flipped payload bit must fail CRC");
+    }
+
+    #[test]
+    fn find_sync_tolerates_a_few_bit_errors_but_not_many() {
+        let sync_bits: Vec<bool> = (0..SYNC_LEN).rev().map(|i| (SYNC_WORD >> i) & 1 != 0).collect();
+        let mut noisy = sync_bits.clone();
+        noisy[3] = !noisy[3];
+        noisy[10] = !noisy[10];
+        noisy[20] = !noisy[20];
+        assert_eq!(find_sync(&noisy, 0), Some(0), "3 errors is within threshold");
+        let mut too_noisy = noisy.clone();
+        too_noisy[15] = !too_noisy[15];
+        assert_eq!(find_sync(&too_noisy, 0), None, "4 errors is not");
+    }
+
+    #[test]
+    fn pack_and_unpack_bits_round_trip() {
+        let bytes = [0x5Au8, 0x00, 0xFF, 0x81];
+        assert_eq!(pack_msb(&unpack_msb(&bytes)), bytes);
+    }
+
+    /// The chip pipeline in complete isolation — one sample per chip, no
+    /// noise, no frequency or timing offset — pins down whether [`data_bits`]
+    /// really is the inverse of encode-then-Manchester for *some* parity
+    /// (bit 0 of the source has no predecessor to compare against, so the
+    /// match is against `want[1..]`), independent of the search/synthesis
+    /// machinery built on top of it.
+    #[test]
+    fn chip_pipeline_round_trips_at_unit_oversampling() {
+        let want = build_frame_bits("ROUND TRIP CHECK");
+        let chip_bits = source_chips(&want);
+        let chips: Vec<Complex32> =
+            chip_bits.iter().map(|&b| Complex32::new(if b { -1.0 } else { 1.0 }, 0.0)).collect();
+        let flips = chip_flips(&chips);
+        let ok = (0..2).any(|parity| {
+            let got = data_bits(&flips, parity);
+            got.len() >= want.len() - 1 && got[..want.len() - 1] == want[1..]
+        });
+        assert!(ok, "neither parity reconstructed the source bits");
+    }
+
+    /// The demodulator itself (no search) tolerates a real residual frequency
+    /// error, not just an exact match — otherwise the coarse search grid in
+    /// [`acquire`] would have to be implausibly fine to ever land inside a
+    /// real signal's capture window at all.
+    #[test]
+    fn the_demod_tolerates_a_realistic_residual_frequency_error_unaided() {
+        let iq = synth_signal("CAPTURE RANGE", TEST_RATE, 100.0, 0.0, 1);
+        assert!(try_frequency(&iq, TEST_RATE).is_some());
+    }
+}

--- a/crates/sdroxide-qo100/src/bpsk.rs
+++ b/crates/sdroxide-qo100/src/bpsk.rs
@@ -398,8 +398,10 @@ pub fn acquire(
     None
 }
 
+// `pub(crate)` so `controller`'s own test module can build a real on-air frame
+// through `synth_signal` without a second copy of the synthesis living there.
 #[cfg(test)]
-mod tests {
+pub(crate) mod tests {
     use super::*;
 
     /// xorshift64* — cheap, deterministic, good enough for test noise and
@@ -463,7 +465,7 @@ mod tests {
     /// in a continuously-transmitting real signal sliced at an arbitrary
     /// time), a constant frequency offset, a random starting phase and chip
     /// timing offset, and light noise.
-    fn synth_signal(
+    pub(crate) fn synth_signal(
         text: &str,
         rate_hz: f64,
         offset_hz: f64,

--- a/crates/sdroxide-qo100/src/bpsk.rs
+++ b/crates/sdroxide-qo100/src/bpsk.rs
@@ -316,6 +316,31 @@ fn refine_offset_hz(iq: &[Complex32], rate_hz: f64, cm: &CoarseMatch) -> f64 {
     sum.arg() as f64 * rate_hz / std::f64::consts::TAU
 }
 
+/// Mix `iq` down by `shift_hz` and integer-decimate by `deci` in one pass,
+/// each output sample the mean of its `deci` inputs. That boxcar is a crude
+/// anti-alias filter, but its nulls sit exactly at multiples of the output
+/// rate — where any energy would fold — and the beacon is 400 baud, far
+/// inside the output passband, so nothing that carries the frame is touched.
+/// Output rate is `rate_hz / deci`.
+fn mix_decimate(iq: &[Complex32], rate_hz: f64, shift_hz: f64, deci: usize) -> Vec<Complex32> {
+    let deci = deci.max(1);
+    let w = -std::f64::consts::TAU * shift_hz / rate_hz;
+    let mut out = Vec::with_capacity(iq.len() / deci + 1);
+    let mut acc = Complex32::new(0.0, 0.0);
+    let mut k = 0usize;
+    for (n, &z) in iq.iter().enumerate() {
+        let ph = w * n as f64;
+        acc += z * Complex32::new(ph.cos() as f32, ph.sin() as f32);
+        k += 1;
+        if k == deci {
+            out.push(acc / deci as f32);
+            acc = Complex32::new(0.0, 0.0);
+            k = 0;
+        }
+    }
+    out
+}
+
 /// Search `iq` (complex baseband, `rate_hz` samples/s, the beacon assumed to
 /// sit somewhere within `±search_half_width_hz` of DC) for one CRC-valid
 /// AO-40 uncoded frame, stepping the candidate frequency by `freq_step_hz`.
@@ -323,6 +348,19 @@ fn refine_offset_hz(iq: &[Complex32], rate_hz: f64, cm: &CoarseMatch) -> f64 {
 /// see [`refine_offset_hz`] — so `freq_step_hz` only needs to be fine enough
 /// to land *somewhere* inside a real signal's capture range, not to measure
 /// it.
+///
+/// Each candidate is mixed down to `demod_rate_hz` (a fixed ~16 kHz — all the
+/// 400 baud beacon ever needs) *before* the chip search runs, no matter how
+/// wide `rate_hz` made the capture. Without that step the per-candidate work
+/// scaled with the capture rate while the candidate count scaled with the
+/// search width, so the total grew with the *square* of the width and the
+/// widest settings ran many times slower than real time.
+///
+/// Candidates are tried from the centre outward, so a beacon near the assumed
+/// frequency — the common case for a roughly-calibrated station — is found
+/// without walking the whole grid first. `cancel` is polled between
+/// candidates so the engine can drop the controller (turning the decoder off,
+/// or changing the search width) without waiting out a search in progress.
 ///
 /// `iq` needs to span at least one whole frame (`FRAME_BITS` bits plus the
 /// sync word, [`BAUD`] bits/s) for a frame to have any chance of falling
@@ -334,21 +372,26 @@ pub fn acquire(
     rate_hz: f64,
     search_half_width_hz: f64,
     freq_step_hz: f64,
+    demod_rate_hz: f64,
+    cancel: &std::sync::atomic::AtomicBool,
 ) -> Option<Qo100Lock> {
-    if freq_step_hz <= 0.0 || rate_hz <= 0.0 {
+    use std::sync::atomic::Ordering;
+    if freq_step_hz <= 0.0 || rate_hz <= 0.0 || demod_rate_hz <= 0.0 {
         return None;
     }
+    let deci = (rate_hz / demod_rate_hz).round().max(1.0) as usize;
+    let dr = rate_hz / deci as f64;
     let steps = (search_half_width_hz / freq_step_hz).round() as i64;
-    let mut mixed = Vec::with_capacity(iq.len());
-    for step in -steps..=steps {
+    // 0, +1, -1, +2, -2, … — centre outward.
+    let order = (0..=2 * steps).map(|i| if i % 2 == 0 { i / 2 } else { -(i / 2 + 1) });
+    for step in order {
+        if cancel.load(Ordering::Relaxed) {
+            return None;
+        }
         let coarse_hz = step as f64 * freq_step_hz;
-        mixed.clear();
-        mixed.extend(iq.iter().enumerate().map(|(n, &z)| {
-            let phase = -2.0 * std::f64::consts::PI * coarse_hz * n as f64 / rate_hz;
-            z * Complex32::new(phase.cos() as f32, phase.sin() as f32)
-        }));
-        if let Some(cm) = try_frequency(&mixed, rate_hz) {
-            let offset_hz = coarse_hz + refine_offset_hz(&mixed, rate_hz, &cm);
+        let mixed = mix_decimate(iq, rate_hz, coarse_hz, deci);
+        if let Some(cm) = try_frequency(&mixed, dr) {
+            let offset_hz = coarse_hz + refine_offset_hz(&mixed, dr, &cm);
             return Some(Qo100Lock { offset_hz, text: cm.m.text });
         }
     }
@@ -475,12 +518,26 @@ mod tests {
     }
 
     const TEST_RATE: f64 = 16_000.0;
+    const TEST_STEP: f64 = 150.0;
+
+    /// `acquire` with the production demod rate and no cancellation, so the
+    /// tests exercise exactly the mix-down-then-search path the worker uses.
+    fn acq(iq: &[Complex32], rate_hz: f64, half_width_hz: f64) -> Option<Qo100Lock> {
+        acquire(
+            iq,
+            rate_hz,
+            half_width_hz,
+            TEST_STEP,
+            crate::controller::DEMOD_RATE_HZ,
+            &std::sync::atomic::AtomicBool::new(false),
+        )
+    }
 
     #[test]
     fn a_clean_frame_at_zero_offset_decodes_and_reports_no_drift() {
         let iq = synth_signal("QO-100 TEST TELEMETRY LINE ONE", TEST_RATE, 0.0, 0.0, 1);
-        let lock = acquire(&iq, TEST_RATE, 50.0, 10.0).expect("should lock");
-        // Refined well past the 10 Hz search grid — see `refine_offset_hz`.
+        let lock = acq(&iq, TEST_RATE, 50.0).expect("should lock");
+        // Refined well past the coarse search grid — see `refine_offset_hz`.
         assert!(lock.offset_hz.abs() < 1.0, "found {}", lock.offset_hz);
         assert!(lock.text.starts_with("QO-100 TEST TELEMETRY LINE ONE"), "{:?}", lock.text);
     }
@@ -488,12 +545,12 @@ mod tests {
     /// The whole point of the feature: a beacon that is not exactly where the
     /// dial assumes it is still gets found, and the frequency the search
     /// lands on *is* the calibration answer — refined well past the coarse
-    /// search grid's own 10 Hz step, not just "the nearest step".
+    /// search grid's own step, not just "the nearest step".
     #[test]
     fn a_drifted_frame_is_found_and_the_drift_is_reported() {
         for &true_offset in &[37.0f64, -68.0, 91.0] {
             let iq = synth_signal("DRIFT CASE", TEST_RATE, true_offset, 0.02, 2);
-            let lock = acquire(&iq, TEST_RATE, 150.0, 10.0)
+            let lock = acq(&iq, TEST_RATE, 150.0)
                 .unwrap_or_else(|| panic!("should lock at offset {true_offset}"));
             assert!(
                 (lock.offset_hz - true_offset).abs() <= 1.0,
@@ -511,7 +568,42 @@ mod tests {
         let iq: Vec<Complex32> = (0..n)
             .map(|_| Complex32::new(rng.range(-1.0, 1.0) as f32, rng.range(-1.0, 1.0) as f32))
             .collect();
-        assert!(acquire(&iq, TEST_RATE, 100.0, 10.0).is_none());
+        assert!(acq(&iq, TEST_RATE, 100.0).is_none());
+    }
+
+    /// The cost regression guard: a search at a *realistic* capture rate and
+    /// width — the engine's default ±5 kHz, captured at 16 kHz — still finds
+    /// the beacon, and the mix-down-per-candidate path keeps the sweep short
+    /// enough to matter (the earlier code searched every candidate at the
+    /// full capture rate and this width was already seconds of work). Every
+    /// other test runs a ±50–150 Hz search, which is why the blow-up went
+    /// unnoticed.
+    #[test]
+    fn a_default_width_search_at_a_realistic_rate_still_locks() {
+        // ±5 kHz search wants a capture a little over 2.5× wide — the same
+        // rule `Engine::qo100_target_rate_hz` follows.
+        let rate = 12_500.0f64.max(16_000.0);
+        let iq = synth_signal("REALISTIC WIDTH", rate, 3_200.0, 0.02, 7);
+        let started = std::time::Instant::now();
+        let lock = acq(&iq, rate, 5_000.0).expect("should still lock at the default width");
+        assert!((lock.offset_hz - 3_200.0).abs() <= 2.0, "found {}", lock.offset_hz);
+        assert!(lock.text.starts_with("REALISTIC WIDTH"));
+        assert!(
+            started.elapsed().as_secs() < 5,
+            "default-width search took {:?} — the per-candidate cost has regressed",
+            started.elapsed()
+        );
+    }
+
+    /// A cancelled search returns without walking the grid.
+    #[test]
+    fn a_cancelled_search_bails_out() {
+        let iq = synth_signal("CANCELLED", TEST_RATE, 40.0, 0.0, 1);
+        let cancel = std::sync::atomic::AtomicBool::new(true);
+        assert!(
+            acquire(&iq, TEST_RATE, 20_000.0, TEST_STEP, crate::controller::DEMOD_RATE_HZ, &cancel)
+                .is_none()
+        );
     }
 
     #[test]

--- a/crates/sdroxide-qo100/src/controller.rs
+++ b/crates/sdroxide-qo100/src/controller.rs
@@ -1,13 +1,28 @@
 //! Threading wrapper around [`crate::bpsk::acquire`], mirroring
 //! `sdroxide_skimmer::SkimmerController`: the realtime engine thread ships IQ
-//! blocks to a worker over a bounded channel (dropping on backpressure — a
-//! frame lost to a dropped block just gets tried again in the next window)
-//! and drains status updates non-blocking via [`Qo100Controller::poll`]. All
-//! the DSP runs on the worker thread.
+//! blocks to a worker over a bounded channel and drains status updates
+//! non-blocking via [`Qo100Controller::poll`]. All the DSP runs on the worker
+//! thread.
+//!
+//! Two things it does *not* copy from `SkimmerController`, because that one's
+//! unit of work is a single block's FFT and this one's is a whole
+//! [`bpsk::acquire`] sweep that can run for seconds:
+//!
+//! * dropping an IQ block on backpressure would punch a hole into a buffer a
+//!   10.36 s frame has to sit inside contiguously — the same rule the DeepCW
+//!   window follows. So a dropped block instead *restarts* the rolling
+//!   buffer: fewer search windows under sustained backpressure, but every one
+//!   of them is a contiguous span of air.
+//! * `Drop` cannot simply join the worker — a sweep in progress would hold
+//!   the engine thread for as long as the sweep takes. A shared cancel flag,
+//!   polled between candidates inside `acquire`, brings that back to at most
+//!   one candidate's work.
 //!
 //! Settings ride a separate unbounded channel: rare, and must never be
 //! dropped even while the IQ queue is backed up.
 
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::thread::JoinHandle;
 
 use crossbeam_channel::{Receiver, Sender, bounded, select, unbounded};
@@ -41,91 +56,144 @@ fn keep_seconds() -> f64 {
     FRAME_SECONDS * 1.15
 }
 
-/// Frequency grid step the search tries, in Hz. Coarser than this and a
-/// real LNB's drift could sit between two candidates that both miss; finer
-/// buys nothing a 400 baud link's own frequency tolerance needs.
-const FREQ_STEP_HZ: f64 = 10.0;
+/// Coarse frequency-grid step the search tries, in Hz. The delay-and-multiply
+/// chip detector `bpsk::acquire` runs at each candidate tolerates a residual
+/// carrier error of well over 100 Hz (its own tests decode an uncorrected
+/// 100 Hz offset), and `bpsk::refine_offset_hz` then measures the true offset
+/// to about a hertz — so the grid only has to land *inside* that capture
+/// range, not resolve it. 150 Hz keeps the nearest candidate within 75 Hz of
+/// any real signal while keeping the candidate count — and so the sweep
+/// time — an order of magnitude below a 10 Hz grid's.
+const FREQ_STEP_HZ: f64 = 150.0;
+
+/// The rate every candidate is mixed down to before the chip search, whatever
+/// the capture rate above it. The beacon is 400 baud; 16 kHz is heavily
+/// oversampled for it and is the floor `Engine::qo100_target_rate_hz` uses
+/// too. Fixing it here is what stops the sweep cost growing with the square
+/// of the search width — see [`bpsk::acquire`].
+pub(crate) const DEMOD_RATE_HZ: f64 = 16_000.0;
+
+/// Bounded IQ queue depth. Roughly a second and a half of channel-rate audio
+/// at a typical device read, enough that an ordinary scheduling hiccup does
+/// not cost a window; sustained backpressure past this restarts the buffer
+/// rather than splicing it (see the module doc).
+const IQ_QUEUE_DEPTH: usize = 256;
 
 pub struct Qo100Controller {
     iq_tx: Sender<Iq>,
     ctl_tx: Sender<Ctl>,
     res_rx: Receiver<sdroxide_types::Qo100Status>,
+    /// Set true when the realtime side had to drop a block: the worker sees
+    /// it, throws away the spliced buffer and starts a fresh contiguous one.
+    spliced: Arc<AtomicBool>,
+    /// Set true by `Drop` so a sweep in progress returns at the next
+    /// candidate instead of running to completion under the engine thread's
+    /// `join`.
+    cancel: Arc<AtomicBool>,
     worker: Option<JoinHandle<()>>,
 }
 
 impl Qo100Controller {
     pub fn new(rate_hz: f64, cfg: Qo100Settings) -> Self {
-        let (iq_tx, iq_rx) = bounded::<Iq>(64);
+        let (iq_tx, iq_rx) = bounded::<Iq>(IQ_QUEUE_DEPTH);
         let (ctl_tx, ctl_rx) = unbounded::<Ctl>();
         let (res_tx, res_rx) = unbounded::<sdroxide_types::Qo100Status>();
+        let spliced = Arc::new(AtomicBool::new(false));
+        let cancel = Arc::new(AtomicBool::new(false));
         let window_len = (rate_hz * window_seconds()).round() as usize;
         let keep_len = (rate_hz * keep_seconds()).round() as usize;
         let worker = std::thread::Builder::new()
             .name("sdroxide-qo100".into())
-            .spawn(move || {
-                let mut cfg = cfg;
-                let mut buf: Vec<Complex32> = Vec::with_capacity(window_len);
-                let (mut tried, mut locked) = (0u64, 0u64);
-                let mut last: Option<(f64, String, i64)> = None; // offset, text, unix
-                loop {
-                    select! {
-                        recv(ctl_rx) -> msg => match msg {
-                            Ok(Ctl::Config(next)) => cfg = next,
-                            Ok(Ctl::Stop) | Err(_) => break,
-                        },
-                        recv(iq_rx) -> msg => match msg {
-                            Ok(Iq(block)) => {
-                                buf.extend_from_slice(&block);
-                                if buf.len() < window_len {
-                                    continue;
+            .spawn({
+                let spliced = Arc::clone(&spliced);
+                let cancel = Arc::clone(&cancel);
+                move || {
+                    let mut cfg = cfg;
+                    let mut buf: Vec<Complex32> = Vec::with_capacity(window_len);
+                    let (mut tried, mut locked) = (0u64, 0u64);
+                    let mut last: Option<(f64, String, i64)> = None; // offset, text, unix
+                    loop {
+                        select! {
+                            recv(ctl_rx) -> msg => match msg {
+                                Ok(Ctl::Config(next)) => cfg = next,
+                                Ok(Ctl::Stop) | Err(_) => break,
+                            },
+                            recv(iq_rx) -> msg => match msg {
+                                Ok(Iq(block)) => {
+                                    // A dropped block since the last read means
+                                    // `buf` now spans a discontinuity. Nothing
+                                    // coherent can come out of that, so start
+                                    // over from this block, which *is*
+                                    // contiguous with what follows it.
+                                    if spliced.swap(false, Ordering::Relaxed) {
+                                        buf.clear();
+                                    }
+                                    buf.extend_from_slice(&block);
+                                    if buf.len() < window_len {
+                                        continue;
+                                    }
+                                    tried += 1;
+                                    let lock = bpsk::acquire(
+                                        &buf,
+                                        rate_hz,
+                                        cfg.search_half_width_hz,
+                                        FREQ_STEP_HZ,
+                                        DEMOD_RATE_HZ,
+                                        &cancel,
+                                    );
+                                    if let Some(l) = lock {
+                                        locked += 1;
+                                        let unix = std::time::SystemTime::now()
+                                            .duration_since(std::time::UNIX_EPOCH)
+                                            .map(|d| d.as_secs() as i64)
+                                            .unwrap_or(0);
+                                        last = Some((l.offset_hz, l.text, unix));
+                                    }
+                                    // Keep the newest slice — enough overlap
+                                    // that no frame can fall in the gap —
+                                    // rather than clearing outright, so a
+                                    // frame that straddles this cut is still
+                                    // whole in the *next* window instead of
+                                    // being thrown away twice.
+                                    let start = buf.len().saturating_sub(keep_len);
+                                    buf.drain(..start);
+                                    let (offset_hz, text, locked_unix) =
+                                        last.clone().unwrap_or_default();
+                                    let _ = res_tx.send(sdroxide_types::Qo100Status {
+                                        running: true,
+                                        locked: lock_is_fresh(locked_unix),
+                                        offset_hz,
+                                        text,
+                                        locked_unix,
+                                        blocks_tried: tried,
+                                        blocks_locked: locked,
+                                    });
                                 }
-                                tried += 1;
-                                let lock = bpsk::acquire(
-                                    &buf,
-                                    rate_hz,
-                                    cfg.search_half_width_hz,
-                                    FREQ_STEP_HZ,
-                                );
-                                if let Some(l) = lock {
-                                    locked += 1;
-                                    let unix = std::time::SystemTime::now()
-                                        .duration_since(std::time::UNIX_EPOCH)
-                                        .map(|d| d.as_secs() as i64)
-                                        .unwrap_or(0);
-                                    last = Some((l.offset_hz, l.text, unix));
-                                }
-                                // Keep the newest slice — enough overlap that
-                                // no frame can fall in the gap — rather than
-                                // clearing outright, so a frame that straddles
-                                // this cut is still whole in the *next*
-                                // window instead of being thrown away twice.
-                                let start = buf.len().saturating_sub(keep_len);
-                                buf.drain(..start);
-                                let (offset_hz, text, locked_unix) =
-                                    last.clone().unwrap_or_default();
-                                let _ = res_tx.send(sdroxide_types::Qo100Status {
-                                    running: true,
-                                    locked: lock_is_fresh(locked_unix),
-                                    offset_hz,
-                                    text,
-                                    locked_unix,
-                                    blocks_tried: tried,
-                                    blocks_locked: locked,
-                                });
-                            }
-                            Err(_) => break,
-                        },
+                                Err(_) => break,
+                            },
+                        }
                     }
                 }
             })
             .expect("spawn qo100 worker");
-        Qo100Controller { iq_tx, ctl_tx, res_rx, worker: Some(worker) }
+        Qo100Controller {
+            iq_tx,
+            ctl_tx,
+            res_rx,
+            spliced,
+            cancel,
+            worker: Some(worker),
+        }
     }
 
     /// Realtime path: hand a block of channel-rate IQ to the worker.
-    /// Non-blocking; drops the block if the worker is behind.
+    /// Non-blocking; a block that will not fit is dropped and the worker is
+    /// told the buffer is now spliced so it restarts rather than searching a
+    /// buffer with a hole in it.
     pub fn on_rx_iq(&self, iq: &[Complex32]) {
-        let _ = self.iq_tx.try_send(Iq(iq.to_vec()));
+        if self.iq_tx.try_send(Iq(iq.to_vec())).is_err() {
+            self.spliced.store(true, Ordering::Relaxed);
+        }
     }
 
     /// Apply new settings (currently just the search width) to the running
@@ -163,6 +231,10 @@ fn lock_is_fresh(locked_unix: i64) -> bool {
 
 impl Drop for Qo100Controller {
     fn drop(&mut self) {
+        // Cancel first: a sweep already running inside `acquire` polls this
+        // between candidates, so the `join` below waits out at most one
+        // candidate rather than a whole search.
+        self.cancel.store(true, Ordering::Relaxed);
         let _ = self.ctl_tx.send(Ctl::Stop);
         if let Some(h) = self.worker.take() {
             let _ = h.join();

--- a/crates/sdroxide-qo100/src/controller.rs
+++ b/crates/sdroxide-qo100/src/controller.rs
@@ -241,3 +241,107 @@ impl Drop for Qo100Controller {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use sdroxide_types::Qo100Settings;
+
+    fn now_unix() -> i64 {
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_secs() as i64)
+            .unwrap_or(0)
+    }
+
+    #[test]
+    fn a_lock_is_fresh_for_about_three_frame_times_then_stale() {
+        assert!(!lock_is_fresh(0), "0 means the decoder has never locked");
+        assert!(lock_is_fresh(now_unix()), "a lock from just now is fresh");
+        // The beacon alternates an uncoded frame (this decoder) with a coded
+        // one it skips, so a real gap runs a bit over two frame times; three
+        // is the grace. Just inside it, then well outside:
+        assert!(lock_is_fresh(now_unix() - (FRAME_SECONDS * 2.5) as i64));
+        assert!(!lock_is_fresh(now_unix() - (FRAME_SECONDS * 4.0) as i64));
+    }
+
+    #[test]
+    fn the_rolling_window_holds_a_whole_frame_and_overlaps_by_more_than_one() {
+        // A frame beginning anywhere in the buffer has to be captured whole at
+        // least once regardless of where the cut lands, so the window must
+        // exceed two frame times ...
+        assert!(window_seconds() > 2.0 * FRAME_SECONDS);
+        // ... and consecutive windows must overlap by more than a frame, or a
+        // frame could fall exactly on a cut and be lost from both.
+        assert!(keep_seconds() > FRAME_SECONDS);
+        assert!(keep_seconds() < window_seconds());
+    }
+
+    /// Poll `c` until `pred` holds on a status, or ~10 s pass. Returns the last
+    /// status seen either way.
+    fn wait_for(
+        c: &Qo100Controller,
+        pred: impl Fn(&sdroxide_types::Qo100Status) -> bool,
+    ) -> Option<sdroxide_types::Qo100Status> {
+        let mut latest = None;
+        for _ in 0..500 {
+            if let Some(s) = c.poll() {
+                let hit = pred(&s);
+                latest = Some(s);
+                if hit {
+                    return latest;
+                }
+            }
+            std::thread::sleep(std::time::Duration::from_millis(20));
+        }
+        latest
+    }
+
+    /// The plumbing end to end on a signal that cannot lock: blocks accumulate
+    /// to a full window, a search runs, a complete status snapshot comes back
+    /// through `poll`, and — pure noise — nothing locks. The test finishing is
+    /// also the assertion that dropping the controller with a search behind it
+    /// returns promptly.
+    #[test]
+    fn the_worker_accumulates_a_window_searches_and_reports_through_poll() {
+        let rate = 16_000.0;
+        let c = Qo100Controller::new(
+            rate,
+            Qo100Settings { enabled: true, search_half_width_hz: 300.0 },
+        );
+        let n = (rate * FRAME_SECONDS * 2.4) as usize; // a hair over one window
+        let noise: Vec<Complex32> = (0..n)
+            .map(|i| {
+                let (a, b) = ((i as f32 * 0.7).sin(), (i as f32 * 1.9 + 1.0).sin());
+                Complex32::new(a, b)
+            })
+            .collect();
+        c.on_rx_iq(&noise);
+        let s = wait_for(&c, |s| s.blocks_tried >= 1).expect("a search should be attempted");
+        assert!(s.running);
+        assert!(!s.locked);
+        assert_eq!(s.blocks_locked, 0, "pure noise must never lock");
+    }
+
+    /// A synthesized frame fed through the controller comes back out of `poll`
+    /// as a lock, with the decoded text and the offset the search assumed —
+    /// the same contract `bpsk::acquire`'s tests check, but exercised through
+    /// the worker thread, the rolling buffer and the status channel.
+    #[test]
+    fn a_synthesized_frame_locks_through_the_worker() {
+        let rate = 16_000.0;
+        let c = Qo100Controller::new(
+            rate,
+            Qo100Settings { enabled: true, search_half_width_hz: 300.0 },
+        );
+        // One synth frame is ~10 s of signal and a window is ~24 s, so stack
+        // three; the frame in the first copy lands wholly inside the buffer.
+        let one = crate::bpsk::tests::synth_signal("CONTROLLER E2E", rate, 150.0, 0.02, 3);
+        let block: Vec<Complex32> = one.iter().chain(&one).chain(&one).copied().collect();
+        c.on_rx_iq(&block);
+        let s = wait_for(&c, |s| s.blocks_locked >= 1).expect("the frame should lock");
+        assert!(s.locked);
+        assert!((s.offset_hz - 150.0).abs() <= 3.0, "offset {}", s.offset_hz);
+        assert!(s.text.starts_with("CONTROLLER E2E"), "{:?}", s.text);
+    }
+}

--- a/crates/sdroxide-qo100/src/controller.rs
+++ b/crates/sdroxide-qo100/src/controller.rs
@@ -1,0 +1,171 @@
+//! Threading wrapper around [`crate::bpsk::acquire`], mirroring
+//! `sdroxide_skimmer::SkimmerController`: the realtime engine thread ships IQ
+//! blocks to a worker over a bounded channel (dropping on backpressure — a
+//! frame lost to a dropped block just gets tried again in the next window)
+//! and drains status updates non-blocking via [`Qo100Controller::poll`]. All
+//! the DSP runs on the worker thread.
+//!
+//! Settings ride a separate unbounded channel: rare, and must never be
+//! dropped even while the IQ queue is backed up.
+
+use std::thread::JoinHandle;
+
+use crossbeam_channel::{Receiver, Sender, bounded, select, unbounded};
+use sdroxide_dsp::Complex32;
+use sdroxide_types::Qo100Settings;
+
+use crate::bpsk::{self, FRAME_SECONDS};
+
+/// Realtime data, dropped on backpressure.
+struct Iq(Vec<Complex32>);
+
+/// Control traffic, never dropped.
+enum Ctl {
+    Config(Qo100Settings),
+    Stop,
+}
+
+/// How long a rolling buffer is kept before each search — comfortably more
+/// than two frame times, so a frame beginning anywhere in the buffer is
+/// always captured whole at least once, regardless of where the buffer
+/// happens to be cut relative to the beacon's own, unrelated, transmit
+/// timing.
+fn window_seconds() -> f64 {
+    FRAME_SECONDS * 2.3
+}
+
+/// How much of the window survives each search, so consecutive windows
+/// overlap by more than one frame time — the reason a frame can never land
+/// exactly on a cut.
+fn keep_seconds() -> f64 {
+    FRAME_SECONDS * 1.15
+}
+
+/// Frequency grid step the search tries, in Hz. Coarser than this and a
+/// real LNB's drift could sit between two candidates that both miss; finer
+/// buys nothing a 400 baud link's own frequency tolerance needs.
+const FREQ_STEP_HZ: f64 = 10.0;
+
+pub struct Qo100Controller {
+    iq_tx: Sender<Iq>,
+    ctl_tx: Sender<Ctl>,
+    res_rx: Receiver<sdroxide_types::Qo100Status>,
+    worker: Option<JoinHandle<()>>,
+}
+
+impl Qo100Controller {
+    pub fn new(rate_hz: f64, cfg: Qo100Settings) -> Self {
+        let (iq_tx, iq_rx) = bounded::<Iq>(64);
+        let (ctl_tx, ctl_rx) = unbounded::<Ctl>();
+        let (res_tx, res_rx) = unbounded::<sdroxide_types::Qo100Status>();
+        let window_len = (rate_hz * window_seconds()).round() as usize;
+        let keep_len = (rate_hz * keep_seconds()).round() as usize;
+        let worker = std::thread::Builder::new()
+            .name("sdroxide-qo100".into())
+            .spawn(move || {
+                let mut cfg = cfg;
+                let mut buf: Vec<Complex32> = Vec::with_capacity(window_len);
+                let (mut tried, mut locked) = (0u64, 0u64);
+                let mut last: Option<(f64, String, i64)> = None; // offset, text, unix
+                loop {
+                    select! {
+                        recv(ctl_rx) -> msg => match msg {
+                            Ok(Ctl::Config(next)) => cfg = next,
+                            Ok(Ctl::Stop) | Err(_) => break,
+                        },
+                        recv(iq_rx) -> msg => match msg {
+                            Ok(Iq(block)) => {
+                                buf.extend_from_slice(&block);
+                                if buf.len() < window_len {
+                                    continue;
+                                }
+                                tried += 1;
+                                let lock = bpsk::acquire(
+                                    &buf,
+                                    rate_hz,
+                                    cfg.search_half_width_hz,
+                                    FREQ_STEP_HZ,
+                                );
+                                if let Some(l) = lock {
+                                    locked += 1;
+                                    let unix = std::time::SystemTime::now()
+                                        .duration_since(std::time::UNIX_EPOCH)
+                                        .map(|d| d.as_secs() as i64)
+                                        .unwrap_or(0);
+                                    last = Some((l.offset_hz, l.text, unix));
+                                }
+                                // Keep the newest slice — enough overlap that
+                                // no frame can fall in the gap — rather than
+                                // clearing outright, so a frame that straddles
+                                // this cut is still whole in the *next*
+                                // window instead of being thrown away twice.
+                                let start = buf.len().saturating_sub(keep_len);
+                                buf.drain(..start);
+                                let (offset_hz, text, locked_unix) =
+                                    last.clone().unwrap_or_default();
+                                let _ = res_tx.send(sdroxide_types::Qo100Status {
+                                    running: true,
+                                    locked: lock_is_fresh(locked_unix),
+                                    offset_hz,
+                                    text,
+                                    locked_unix,
+                                    blocks_tried: tried,
+                                    blocks_locked: locked,
+                                });
+                            }
+                            Err(_) => break,
+                        },
+                    }
+                }
+            })
+            .expect("spawn qo100 worker");
+        Qo100Controller { iq_tx, ctl_tx, res_rx, worker: Some(worker) }
+    }
+
+    /// Realtime path: hand a block of channel-rate IQ to the worker.
+    /// Non-blocking; drops the block if the worker is behind.
+    pub fn on_rx_iq(&self, iq: &[Complex32]) {
+        let _ = self.iq_tx.try_send(Iq(iq.to_vec()));
+    }
+
+    /// Apply new settings (currently just the search width) to the running
+    /// worker.
+    pub fn set_config(&self, cfg: Qo100Settings) {
+        let _ = self.ctl_tx.send(Ctl::Config(cfg));
+    }
+
+    /// Drain the latest status, if a search finished since the last poll.
+    /// Non-blocking. Only the newest matters — a status is a full snapshot,
+    /// like `IsmStatus`.
+    pub fn poll(&self) -> Option<sdroxide_types::Qo100Status> {
+        let mut out = None;
+        while let Ok(s) = self.res_rx.try_recv() {
+            out = Some(s);
+        }
+        out
+    }
+}
+
+/// Whether a lock reported at `locked_unix` is still worth showing as
+/// "locked" — the beacon alternates an uncoded frame (this decoder) with a
+/// coded one (not attempted) roughly every 10.36 s, so a gap of a bit over
+/// twice that is expected and not evidence the beacon went away.
+fn lock_is_fresh(locked_unix: i64) -> bool {
+    if locked_unix == 0 {
+        return false;
+    }
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs() as i64)
+        .unwrap_or(0);
+    (now - locked_unix) as f64 <= FRAME_SECONDS * 3.0
+}
+
+impl Drop for Qo100Controller {
+    fn drop(&mut self) {
+        let _ = self.ctl_tx.send(Ctl::Stop);
+        if let Some(h) = self.worker.take() {
+            let _ = h.join();
+        }
+    }
+}

--- a/crates/sdroxide-qo100/src/lib.rs
+++ b/crates/sdroxide-qo100/src/lib.rs
@@ -1,0 +1,10 @@
+//! The QO-100 narrowband beacon decoder: BPSK-400/AO-40-uncoded telemetry,
+//! run off a dedicated downconversion of the raw IQ — the same shape
+//! `sdroxide_skimmer` and `sdroxide_ism` use for their own narrowband work.
+//! Native-only (runs in the engine); see [`bpsk`] for the protocol itself and
+//! [`controller`] for how it is driven from the engine's audio-block loop.
+
+pub mod bpsk;
+mod controller;
+
+pub use controller::Qo100Controller;

--- a/crates/sdroxide-radio/Cargo.toml
+++ b/crates/sdroxide-radio/Cargo.toml
@@ -34,6 +34,7 @@ sdroxide-ax25 = { path = "../sdroxide-ax25" }
 sdroxide-skimmer = { path = "../sdroxide-skimmer" }
 sdroxide-ism = { path = "../sdroxide-ism" }
 sdroxide-adsb = { path = "../sdroxide-adsb" }
+sdroxide-qo100 = { path = "../sdroxide-qo100" }
 sdroxide-net = { path = "../sdroxide-net" }
 sdroxide-winlink = { path = "../sdroxide-winlink" }
 # Only for `tlesub`: the engine persists the satellite subscriptions and, being

--- a/crates/sdroxide-radio/src/engine.rs
+++ b/crates/sdroxide-radio/src/engine.rs
@@ -1974,8 +1974,12 @@ struct Engine {
     /// The stream rate `qo100_ddc` was built to decimate — the same reason
     /// `ism_in_rate` exists.
     qo100_in_rate: f64,
-    /// The operator's persisted QO-100 preference, kept apart from
-    /// `state.qo100` for the same reason as `skim_cfg`.
+    /// The last QO-100 setting the operator chose, held in step with
+    /// `state.qo100` for symmetry with `ism_cfg` and `skim_cfg`. Nothing
+    /// reads it back yet: like the ISM decoder, a source swap into audio mode
+    /// turns the decoder off and a swap back leaves it off until the operator
+    /// turns it on again. Not persisted to disk — there is nothing here worth
+    /// surviving a restart.
     qo100_cfg: sdroxide_types::Qo100Settings,
     /// Open capture file for `--record-iq`, and the interleaving scratch it is
     /// written from.
@@ -6547,12 +6551,9 @@ impl Engine {
 
             SetQo100Config(cfg) => {
                 self.state.qo100 = cfg;
-                // Remembered before `sync_qo100` may force the live state off
-                // on an audio-mode source, so a swap back restores what was
-                // chosen — the same reason `ism_cfg` exists. Not saved to
-                // disk: unlike the ISM decoder, there is nothing here worth
-                // surviving a restart — the search width defaults to
-                // something sane, and the decoder itself defaults off.
+                // Held in step with the live setting for symmetry with the
+                // ISM and skimmer configs; see `qo100_cfg`'s own doc for why
+                // nothing reads it back and why it is not saved to disk.
                 self.qo100_cfg = cfg;
                 self.sync_qo100();
                 if let Some(c) = self.qo100.as_ref() {

--- a/crates/sdroxide-radio/src/engine.rs
+++ b/crates/sdroxide-radio/src/engine.rs
@@ -27,6 +27,7 @@ use sdroxide_dsp::{
     make_modulator,
 };
 use sdroxide_ism::{IsmAction, IsmController};
+use sdroxide_qo100::Qo100Controller;
 use sdroxide_rigctld::{RigState, RigctldController};
 use sdroxide_skimmer::{SkimmerAction, SkimmerController};
 use sdroxide_tci::server::{ServerRequest, TciServerController, TciStateSnapshot};
@@ -1962,6 +1963,20 @@ struct Engine {
     /// panel that connected while the lane was down would sit on "starting the
     /// decoder" forever.
     adsb_idle_sent: Option<Option<String>>,
+    /// QO-100 beacon decoder: a fixed downconversion onto
+    /// [`sdroxide_types::QO100_BEACON_HZ`] plus a worker-thread demodulator,
+    /// present only while the decoder is enabled. Simpler than the ISM
+    /// window: the target frequency never moves, so retuning it is always
+    /// just re-seating the mixer — see `sync_qo100_window`.
+    qo100_ddc: Option<Ddc>,
+    qo100: Option<Qo100Controller>,
+    qo100_buf: Vec<Complex32>,
+    /// The stream rate `qo100_ddc` was built to decimate — the same reason
+    /// `ism_in_rate` exists.
+    qo100_in_rate: f64,
+    /// The operator's persisted QO-100 preference, kept apart from
+    /// `state.qo100` for the same reason as `skim_cfg`.
+    qo100_cfg: sdroxide_types::Qo100Settings,
     /// Open capture file for `--record-iq`, and the interleaving scratch it is
     /// written from.
     iq_rec: Option<std::io::BufWriter<std::fs::File>>,
@@ -2750,6 +2765,13 @@ fn engine_thread(
         adsb_cfg,
         adsb_home: None,
         adsb_idle_sent: None,
+        qo100_ddc: None,
+        qo100: None,
+        qo100_buf: Vec::new(),
+        qo100_in_rate: 0.0,
+        // Session-scoped only, unlike `skim_cfg`/`ism_cfg` — see
+        // `sync_qo100`'s doc for why this one is not read back from disk.
+        qo100_cfg: sdroxide_types::Qo100Settings::default(),
         iq_rec,
         iq_rec_buf: Vec::new(),
         scan_cfg,
@@ -2856,6 +2878,7 @@ fn engine_thread(
         engine.sync_ism(); // likewise, from ism.json
         engine.sync_adsb_home();
         engine.sync_adsb(); // and the aircraft lane, if the mode is already ADS-B
+        engine.sync_qo100(); // a no-op today: `qo100_cfg` starts disabled and is never loaded
     }
     // Start any enabled network spot feeds from the persisted config. The
     // operator identity comes from the digi config — one identity for the whole
@@ -3034,6 +3057,7 @@ fn engine_thread(
         engine.poll_skimmer();
         engine.poll_ism();
         engine.poll_adsb();
+        engine.poll_qo100();
         engine.poll_scanner();
         engine.poll_tci_server();
         engine.poll_rigctld();
@@ -3744,6 +3768,15 @@ impl Engine {
                 d.on_rx_iq(&self.adsb_buf);
             }
         }
+        // ...and the QO-100 beacon decoder from its own fixed downconversion
+        // onto the beacon frequency.
+        if let Some(ddc) = self.qo100_ddc.as_mut() {
+            self.qo100_buf.clear();
+            ddc.process(iq, &mut self.qo100_buf);
+            if let Some(c) = self.qo100.as_ref() {
+                c.on_rx_iq(&self.qo100_buf);
+            }
+        }
         // Feed TCI clients: the same clean tap the digital decoders use (so
         // muting or turning down sdroxide can't silence somebody's decoder),
         // resampled to the 48 kHz TCI mandates.
@@ -4161,6 +4194,7 @@ impl Engine {
                 self.sync_skim_window();
                 self.sync_ism_window();
                 self.sync_adsb_window();
+                self.sync_qo100_window();
                 self.update_tuning();
                 let _ = self.event_tx.send(RadioEvent::State(self.state.clone()));
             }
@@ -4367,6 +4401,10 @@ impl Engine {
         // target rather than a plan of them: 1090 MHz is where it has to be, and
         // the only question is whether the new span still reaches it.
         self.sync_adsb_window();
+        // The QO-100 window, unlike the ISM one, *does* follow the hardware
+        // centre — its one target frequency never moves, so re-seating the
+        // mixer is all a retune ever needs.
+        self.sync_qo100_window();
         // Re-seat the DDCs on the new centre. Without this the main receiver
         // keeps the offset it had against the old one, which is exactly how a
         // rig-initiated retune ends up demodulating somewhere the readout does
@@ -6507,6 +6545,21 @@ impl Engine {
                 }
             }
 
+            SetQo100Config(cfg) => {
+                self.state.qo100 = cfg;
+                // Remembered before `sync_qo100` may force the live state off
+                // on an audio-mode source, so a swap back restores what was
+                // chosen — the same reason `ism_cfg` exists. Not saved to
+                // disk: unlike the ISM decoder, there is nothing here worth
+                // surviving a restart — the search width defaults to
+                // something sane, and the decoder itself defaults off.
+                self.qo100_cfg = cfg;
+                self.sync_qo100();
+                if let Some(c) = self.qo100.as_ref() {
+                    c.set_config(cfg);
+                }
+            }
+
             ReloadIsmDecoders => {
                 // Seeded here as well as at startup, so deleting the file to get
                 // the commented example back works without a restart.
@@ -7297,6 +7350,76 @@ impl Engine {
         self.ism_center_hz = center;
         if let Some(d) = self.ism.as_ref() {
             d.set_window(center, want_rate);
+        }
+    }
+
+    /// The QO-100 beacon decoder's downconverter output rate. Comfortably
+    /// oversampled against the 800 chip/s the beacon transmits at — see
+    /// `sdroxide_qo100::bpsk`'s module doc for why the decoder wants that
+    /// margin — and far short of what the ISM plan or the skimmer ask for, so
+    /// it costs the engine almost nothing to leave running.
+    const QO100_TARGET_RATE_HZ: f64 = 16_000.0;
+
+    /// Construct or tear down the QO-100 beacon decoder, mirroring
+    /// [`Self::sync_ism`]'s shape. Simpler than the ISM window: the target
+    /// frequency ([`sdroxide_types::QO100_BEACON_HZ`]) never moves and the
+    /// rate it downconverts to never changes with the band, so nothing here
+    /// ever has to *choose* where the window goes — only whether it exists
+    /// and, in [`Self::sync_qo100_window`], where the hardware centre has
+    /// put it relative to the beacon.
+    fn sync_qo100(&mut self) {
+        // Wideband-only, for the same reason as the skimmers and ISM: a CAT
+        // rig on a sound card hands over demodulated audio, not IQ to mix a
+        // downconverter from.
+        if self.audio_mode {
+            self.state.qo100.enabled = false;
+        }
+        match (self.state.qo100.enabled, self.qo100.is_some()) {
+            (true, false) => {
+                let mut ddc = Ddc::new(self.state.sample_rate, Self::QO100_TARGET_RATE_HZ);
+                ddc.set_offset_hz(sdroxide_types::QO100_BEACON_HZ - self.state.center_hz);
+                let out_rate = ddc.out_rate();
+                self.qo100 = Some(Qo100Controller::new(out_rate, self.state.qo100));
+                self.qo100_ddc = Some(ddc);
+                self.qo100_in_rate = self.state.sample_rate;
+                info!(rate = out_rate, "QO-100 beacon decoder started");
+            }
+            (false, true) => {
+                self.qo100 = None;
+                self.qo100_ddc = None;
+                self.qo100_buf.clear();
+                info!("QO-100 beacon decoder stopped");
+            }
+            (true, true) => self.sync_qo100_window(),
+            _ => {}
+        }
+    }
+
+    /// Re-seat the downconverter's mixer after a retune, and rebuild it
+    /// outright if the sample rate feeding it has changed — a `Ddc` bakes its
+    /// input rate into both the NCO and the decimation chain and neither can
+    /// be changed in place, the same reason `sync_ism_window` rebuilds on a
+    /// rate change.
+    fn sync_qo100_window(&mut self) {
+        if self.qo100_ddc.is_none() {
+            return;
+        }
+        if (self.state.sample_rate - self.qo100_in_rate).abs() >= 1.0 {
+            let mut ddc = Ddc::new(self.state.sample_rate, Self::QO100_TARGET_RATE_HZ);
+            ddc.set_offset_hz(sdroxide_types::QO100_BEACON_HZ - self.state.center_hz);
+            self.qo100_ddc = Some(ddc);
+            self.qo100_in_rate = self.state.sample_rate;
+            return;
+        }
+        let Some(ddc) = self.qo100_ddc.as_mut() else { return };
+        ddc.set_offset_hz(sdroxide_types::QO100_BEACON_HZ - self.state.center_hz);
+    }
+
+    /// Drain the QO-100 beacon decoder's latest status and forward it.
+    fn poll_qo100(&mut self) {
+        let Some(c) = self.qo100.as_ref() else { return };
+        if let Some(status) = c.poll() {
+            let _ = self.event_tx.send(RadioEvent::Qo100Status(status));
         }
     }
 
@@ -9837,6 +9960,7 @@ impl Engine {
         self.sync_skimmer();
         self.sync_ism();
         self.sync_adsb();
+        self.sync_qo100();
         self.sync_audio_tap();
         self.sync_tci_iq();
         info!(factor, rate = self.state.sample_rate, "front-end decimation");
@@ -10199,6 +10323,7 @@ impl Engine {
             self.sync_skimmer();
             self.sync_ism();
             self.sync_adsb();
+            self.sync_qo100();
         }
         // Re-derive the TCI streams at the new device rate and push a fresh
         // state burst, so connected clients follow the swap.
@@ -11786,6 +11911,7 @@ impl Engine {
                 self.sync_skim_window();
                 self.sync_ism_window();
                 self.sync_adsb_window();
+                self.sync_qo100_window();
                 true
             }
             Err(e) => {

--- a/crates/sdroxide-radio/src/engine.rs
+++ b/crates/sdroxide-radio/src/engine.rs
@@ -2305,6 +2305,19 @@ fn skim_center_for(
     if holds { cur } else { want }
 }
 
+/// The QO-100 beacon decoder's down-converter output rate for a search
+/// half-width of `half_width_hz`: about 2.5× the search so the requested span
+/// fits under Nyquist with margin — see `sdroxide_qo100::bpsk` for why the
+/// decoder wants that oversampling — and floored at 16 kHz so the default
+/// (±5 kHz) and any narrower width still land on a sane, cheap rate. Widening
+/// the search really does widen the capture the decoder is handed; the
+/// demodulator inside it always runs at a fixed rate regardless
+/// (`sdroxide_qo100`'s `DEMOD_RATE_HZ`), which is what keeps the search cost
+/// from growing with the square of the width.
+fn qo100_capture_rate_for(half_width_hz: f64) -> f64 {
+    (half_width_hz * 2.5).max(16_000.0)
+}
+
 /// How soon after noticing a disconnected front-end the first reconnect attempt
 /// runs, and the ceiling the spacing doubles up to while attempts keep failing.
 const RETRY_FIRST: Duration = Duration::from_secs(1);
@@ -7365,7 +7378,7 @@ impl Engine {
     /// the skimmer ask for, so it costs the engine almost nothing at the
     /// default width.
     fn qo100_target_rate_hz(&self) -> f64 {
-        (self.state.qo100.search_half_width_hz * 2.5).max(16_000.0)
+        qo100_capture_rate_for(self.state.qo100.search_half_width_hz)
     }
 
     /// Construct or tear down the QO-100 beacon decoder, mirroring
@@ -12807,6 +12820,41 @@ mod skim_window_tests {
         let cur = 14_050_000.0;
         let view = Some((88_000_000.0, 88_200_000.0));
         assert_eq!(skim_center_for(view, 88_100_000.0, WIDE_CENTER, WIDE, WIN, Some(cur)), cur);
+    }
+}
+
+#[cfg(test)]
+mod qo100_rate_tests {
+    use super::qo100_capture_rate_for;
+
+    /// The engine default (±5 kHz) and anything narrower sit on the 16 kHz
+    /// floor — ×2.5 does not reach it until ±6.4 kHz.
+    #[test]
+    fn the_default_and_narrow_widths_sit_on_the_16_khz_floor() {
+        assert_eq!(qo100_capture_rate_for(5_000.0), 16_000.0);
+        assert_eq!(qo100_capture_rate_for(0.0), 16_000.0);
+        assert_eq!(qo100_capture_rate_for(6_400.0), 16_000.0);
+    }
+
+    /// Past the knee the capture tracks the search width, so widening the
+    /// window in the UI really does hand the decoder a wider span.
+    #[test]
+    fn a_wider_search_asks_for_a_proportionally_wider_capture() {
+        assert_eq!(qo100_capture_rate_for(10_000.0), 25_000.0);
+        assert_eq!(qo100_capture_rate_for(25_000.0), 62_500.0);
+        // ±50 kHz is the UI's MAX_HALF_WIDTH_HZ.
+        assert_eq!(qo100_capture_rate_for(50_000.0), 125_000.0);
+    }
+
+    #[test]
+    fn the_capture_rate_is_monotonic_and_never_below_the_floor() {
+        let mut prev = 0.0;
+        for hw in [0.0, 2_500.0, 5_000.0, 10_000.0, 20_000.0, 50_000.0] {
+            let r = qo100_capture_rate_for(hw);
+            assert!(r >= prev, "rate dropped at half-width {hw}");
+            assert!(r >= 16_000.0, "below the floor at half-width {hw}");
+            prev = r;
+        }
     }
 }
 

--- a/crates/sdroxide-radio/src/engine.rs
+++ b/crates/sdroxide-radio/src/engine.rs
@@ -7353,20 +7353,26 @@ impl Engine {
         }
     }
 
-    /// The QO-100 beacon decoder's downconverter output rate. Comfortably
-    /// oversampled against the 800 chip/s the beacon transmits at — see
-    /// `sdroxide_qo100::bpsk`'s module doc for why the decoder wants that
-    /// margin — and far short of what the ISM plan or the skimmer ask for, so
-    /// it costs the engine almost nothing to leave running.
-    const QO100_TARGET_RATE_HZ: f64 = 16_000.0;
+    /// The QO-100 beacon decoder's downconverter output rate for a given
+    /// search width: comfortably oversampled against the 800 chip/s the
+    /// beacon transmits at — see `sdroxide_qo100::bpsk`'s module doc for why
+    /// the decoder wants that margin — and wide enough that the requested
+    /// search actually fits under Nyquist with room to spare, so widening the
+    /// window in the UI really does widen what the receiver hands the
+    /// decoder rather than asking it to search past the edge of what it can
+    /// see. Floored at 16 kHz, and still far short of what the ISM plan or
+    /// the skimmer ask for, so it costs the engine almost nothing at the
+    /// default width.
+    fn qo100_target_rate_hz(&self) -> f64 {
+        (self.state.qo100.search_half_width_hz * 2.5).max(16_000.0)
+    }
 
     /// Construct or tear down the QO-100 beacon decoder, mirroring
-    /// [`Self::sync_ism`]'s shape. Simpler than the ISM window: the target
-    /// frequency ([`sdroxide_types::QO100_BEACON_HZ`]) never moves and the
-    /// rate it downconverts to never changes with the band, so nothing here
-    /// ever has to *choose* where the window goes — only whether it exists
-    /// and, in [`Self::sync_qo100_window`], where the hardware centre has
-    /// put it relative to the beacon.
+    /// [`Self::sync_ism`]'s shape. Simpler than the ISM window in one way —
+    /// the target frequency ([`sdroxide_types::QO100_BEACON_HZ`]) never moves
+    /// with the band — but not in another: the operator's search-width
+    /// buttons change how wide a downconversion the decoder needs, the same
+    /// reason ISM's own window resizes when the band plan does.
     fn sync_qo100(&mut self) {
         // Wideband-only, for the same reason as the skimmers and ISM: a CAT
         // rig on a sound card hands over demodulated audio, not IQ to mix a
@@ -7376,7 +7382,7 @@ impl Engine {
         }
         match (self.state.qo100.enabled, self.qo100.is_some()) {
             (true, false) => {
-                let mut ddc = Ddc::new(self.state.sample_rate, Self::QO100_TARGET_RATE_HZ);
+                let mut ddc = Ddc::new(self.state.sample_rate, self.qo100_target_rate_hz());
                 ddc.set_offset_hz(sdroxide_types::QO100_BEACON_HZ - self.state.center_hz);
                 let out_rate = ddc.out_rate();
                 self.qo100 = Some(Qo100Controller::new(out_rate, self.state.qo100));
@@ -7396,19 +7402,35 @@ impl Engine {
     }
 
     /// Re-seat the downconverter's mixer after a retune, and rebuild it
-    /// outright if the sample rate feeding it has changed — a `Ddc` bakes its
-    /// input rate into both the NCO and the decimation chain and neither can
-    /// be changed in place, the same reason `sync_ism_window` rebuilds on a
-    /// rate change.
+    /// outright if the sample rate feeding it has changed or the operator has
+    /// asked for a different search width — a `Ddc` bakes its input rate and
+    /// its decimation chain in at construction and neither can be changed in
+    /// place, the same reason `sync_ism_window` rebuilds on a rate change.
     fn sync_qo100_window(&mut self) {
         if self.qo100_ddc.is_none() {
             return;
         }
-        if (self.state.sample_rate - self.qo100_in_rate).abs() >= 1.0 {
-            let mut ddc = Ddc::new(self.state.sample_rate, Self::QO100_TARGET_RATE_HZ);
+        let want_rate = self.qo100_target_rate_hz();
+        let have_rate = self.qo100_ddc.as_ref().map(|d| d.out_rate()).unwrap_or(0.0);
+        // `Ddc` settles for the nearest *achievable* rate, so this compares
+        // against what a fresh chain would actually land on rather than the
+        // bare request — a request unchanged in effect must not rebuild the
+        // chain (and so drop whatever the decoder had buffered) every tick.
+        let rebuild = (self.state.sample_rate - self.qo100_in_rate).abs() >= 1.0
+            || (Ddc::rate_for(self.state.sample_rate, want_rate) - have_rate).abs() >= 1.0;
+        if rebuild {
+            let mut ddc = Ddc::new(self.state.sample_rate, want_rate);
             ddc.set_offset_hz(sdroxide_types::QO100_BEACON_HZ - self.state.center_hz);
+            let out_rate = ddc.out_rate();
             self.qo100_ddc = Some(ddc);
             self.qo100_in_rate = self.state.sample_rate;
+            // The controller bakes its sample rate into the worker's rolling
+            // buffer sizing and every `bpsk::acquire` call, so a rate change
+            // rebuilds it too rather than trying to reconfigure it in place —
+            // simple, and cheap: switching search width is a deliberate,
+            // infrequent click, not a hot path.
+            self.qo100 = Some(Qo100Controller::new(out_rate, self.state.qo100));
+            info!(rate = out_rate, "QO-100 window rebuilt");
             return;
         }
         let Some(ddc) = self.qo100_ddc.as_mut() else { return };

--- a/crates/sdroxide-server/src/lib.rs
+++ b/crates/sdroxide-server/src/lib.rs
@@ -974,6 +974,10 @@ fn handle_event(shared: &Shared, ev: RadioEvent) {
                 latest.adsb_status = Some(st.clone());
                 Some(ServerMsg::AdsbStatus(st))
             }
+            // Native-only for now: every station this shipped for runs its
+            // own hardware locally, so there is no `ServerMsg` variant for
+            // this yet — see `RadioEvent::Qo100Status`'s own doc.
+            RadioEvent::Qo100Status(_) => None,
             RadioEvent::SstvLine { image_id, y, rgb } => {
                 Some(ServerMsg::SstvLine { image_id, y, rgb })
             }

--- a/crates/sdroxide-types/src/command.rs
+++ b/crates/sdroxide-types/src/command.rs
@@ -791,4 +791,11 @@ pub enum Command {
     ///
     /// Appended for the usual reason — postcard numbers variants by position.
     SetAdsbConfig(crate::AdsbSettings),
+
+    /// Whether the QO-100 beacon decoder runs, and how wide it searches
+    /// around [`crate::QO100_BEACON_HZ`]. The engine persists this and
+    /// echoes it back in [`crate::RadioState`], so there is no apply step —
+    /// the same convention [`Command::SetIsmConfig`] follows. Appended for
+    /// the usual reason: postcard numbers variants by position.
+    SetQo100Config(crate::Qo100Settings),
 }

--- a/crates/sdroxide-types/src/controller.rs
+++ b/crates/sdroxide-types/src/controller.rs
@@ -297,6 +297,17 @@ pub enum RadioEvent {
     /// this enum, and an enum is as big as its largest variant everywhere it is
     /// held.
     AdsbStatus(Box<crate::AdsbStatus>),
+    /// What the QO-100 beacon decoder has made of the 10489.750 MHz downlink:
+    /// lock state, the measured frequency offset, and the last decoded
+    /// telemetry text. Sent whenever it changes, the same convention
+    /// [`RadioEvent::IsmStatus`] follows — settings travel separately, in
+    /// [`crate::RadioState::qo100`].
+    ///
+    /// Native-engine only for now: bridging this to a remote/WASM client
+    /// would mean a matching variant in `sdroxide_proto::ServerMsg`, the way
+    /// `IsmStatus` has one — not done yet, since every station this shipped
+    /// for runs its own hardware locally.
+    Qo100Status(crate::Qo100Status),
 }
 
 /// Snapshot of the frontend's switchable sound devices (native clients).

--- a/crates/sdroxide-types/src/lib.rs
+++ b/crates/sdroxide-types/src/lib.rs
@@ -33,6 +33,7 @@ mod pictures;
 mod probe;
 mod prop_store;
 mod propagation;
+mod qo100;
 mod radio;
 mod rds;
 pub mod region;
@@ -154,6 +155,7 @@ pub use propagation::{
     SPLAT_SIGMA_KM, cell_center, cell_of, fof2_floor_mhz, margin_db, muf3000_floor_mhz,
     obliquity_factor,
 };
+pub use qo100::{QO100_BEACON_HZ, Qo100Settings, Qo100Status};
 pub use radio::{
     AirspyConfig, AirspyDevice, AirspyGain, AirspyHfConfig, AirspyHfDevice, AirspyHfModel, Backend,
     CAT_IQ_DC_BLOCK_MAX_HZ, CAT_IQ_RATES, CAT_SCOPE_MIN_BAUD, CONVERTER_OFFSET_MAX_HZ,

--- a/crates/sdroxide-types/src/qo100.rs
+++ b/crates/sdroxide-types/src/qo100.rs
@@ -1,0 +1,62 @@
+//! QO-100 narrowband beacon calibration: what the operator asks the engine
+//! for, and what it reports back. Pure data + serde, shared by the native
+//! engine and the UI (native + WASM) — the demodulation itself lives in the
+//! native `sdroxide-qo100` crate, same split as [`crate::ism`].
+
+use serde::{Deserialize, Serialize};
+
+/// The QO-100 (Es'hail-2) narrowband transponder's 400 baud BPSK telemetry
+/// beacon. Confirmed against the satellite's own published parameters (see
+/// `sdroxide_qo100::bpsk` for the citation) — not a guess, and not one of the
+/// satellite's other two beacons, which is why there is only one constant
+/// here rather than a list.
+pub const QO100_BEACON_HZ: f64 = 10_489_750_000.0;
+
+/// What the operator asks the beacon decoder to do.
+#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
+pub struct Qo100Settings {
+    /// Whether the decoder runs at all. Off by default: it is a calibration
+    /// tool reached for occasionally, not something every station pays a
+    /// downconverter and a worker thread for by default.
+    pub enabled: bool,
+    /// Half the width, in Hz, of the frequency range searched around
+    /// [`QO100_BEACON_HZ`] — set from the QO-100 window's own width buttons.
+    pub search_half_width_hz: f64,
+}
+
+impl Default for Qo100Settings {
+    fn default() -> Self {
+        Self { enabled: false, search_half_width_hz: 5_000.0 }
+    }
+}
+
+/// What the engine tells the window about the decoder's own state. Re-sent
+/// whenever it changes, the same convention [`crate::IsmStatus`] follows.
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+pub struct Qo100Status {
+    /// Whether the downconverter and worker are actually running — mirrors
+    /// [`Qo100Settings::enabled`], but from the engine's side, so a client
+    /// that opens mid-session sees the true state rather than assuming it.
+    pub running: bool,
+    /// Whether the most recent search block found a CRC-valid frame.
+    pub locked: bool,
+    /// How far the beacon actually sits from [`QO100_BEACON_HZ`], in Hz —
+    /// only meaningful while `locked`. This *is* the calibration answer: the
+    /// frequency the search had to assume before a frame's sync word and CRC
+    /// both checked out.
+    pub offset_hz: f64,
+    /// The most recently decoded telemetry text, kept across a lock that
+    /// later drops so the window does not go blank between frames (the
+    /// beacon sends an uncoded frame roughly every 20 s, alternating with a
+    /// coded one this decoder does not attempt — see the crate doc).
+    pub text: String,
+    /// Unix time of the last successful lock. 0 if there has never been one.
+    pub locked_unix: i64,
+    /// Search blocks attempted and how many produced a valid frame, since the
+    /// decoder was switched on — the same reason [`crate::IsmStatus::bursts`]
+    /// and `decodes` exist: a high `blocks_tried` with `blocks_locked` still
+    /// at 0 says plainly that the search is running but the beacon has not
+    /// been found yet, rather than looking merely idle.
+    pub blocks_tried: u64,
+    pub blocks_locked: u64,
+}

--- a/crates/sdroxide-types/src/state.rs
+++ b/crates/sdroxide-types/src/state.rs
@@ -391,6 +391,13 @@ pub struct RadioState {
     /// panel learns that. Appended last: postcard numbers fields by position.
     #[serde(default)]
     pub adsb: crate::AdsbSettings,
+    /// The QO-100 beacon decoder: whether it runs, and how wide a search it
+    /// makes around [`crate::QO100_BEACON_HZ`]. Live status (lock, offset,
+    /// decoded text) is [`crate::Qo100Status`], sent separately like
+    /// [`crate::IsmStatus`] — this struct is settings, sent whole on every
+    /// change like [`Self::ism`].
+    #[serde(default)]
+    pub qo100: crate::Qo100Settings,
 }
 
 impl Default for RadioState {
@@ -430,6 +437,7 @@ impl Default for RadioState {
             // Open, until the radio says otherwise: the level is adopted from
             // the rig, and until one has answered there is nothing to claim.
             rig_squelch: 0.0,
+            qo100: crate::Qo100Settings::default(),
         }
     }
 }

--- a/crates/sdroxide-ui/src/app/frame.rs
+++ b/crates/sdroxide-ui/src/app/frame.rs
@@ -1206,6 +1206,7 @@ impl SdroxideApp {
                 RadioEvent::IsmReports(r) => self.ism_reports = r,
                 RadioEvent::IsmStatus(st) => self.ism_status = Some(st),
                 RadioEvent::AdsbStatus(st) => self.adsb_status = Some(st),
+                RadioEvent::Qo100Status(st) => self.qo100_status = Some(st),
                 RadioEvent::SstvStatus(s) => {
                     // Adopt a *newly* detected RX mode for the next transmit, but
                     // don't re-apply a steady detection every frame — that would

--- a/crates/sdroxide-ui/src/app/frame.rs
+++ b/crates/sdroxide-ui/src/app/frame.rs
@@ -794,6 +794,7 @@ impl eframe::App for SdroxideApp {
         self.awards_window(&ctx);
         self.bands_window(&ctx);
         self.sat_window(&ctx, &mut cmds);
+        self.qo100_window(&ctx, &mut cmds);
         self.help.ui(&ctx);
         // Last, so it lands on top of everything else that opened this frame.
         self.oob_tx_window(&ctx);

--- a/crates/sdroxide-ui/src/app/mod.rs
+++ b/crates/sdroxide-ui/src/app/mod.rs
@@ -360,6 +360,10 @@ pub struct SdroxideApp {
     /// How the device list is ordered, and which way round.
     ism_sort: ism::IsmSort,
     ism_sort_desc: bool,
+    /// The QO-100 beacon decoder's live status — lock state, measured
+    /// frequency offset, decoded telemetry — as last reported by the engine.
+    /// `None` until the decoder has been enabled at least once this session.
+    qo100_status: Option<sdroxide_types::Qo100Status>,
     show_settings: bool,
     /// Scroll the Settings window back to its tab bar on the frame it opens.
     /// The window's scroll offset is egui memory, which outlives both the
@@ -1096,6 +1100,7 @@ impl SdroxideApp {
             ism_status: None,
             ism_sort: ism::IsmSort::default(),
             ism_sort_desc: true,
+            qo100_status: None,
             show_settings: false,
             settings_scroll_top: true,
             voice: sdroxide_types::VoiceStatus::default(),

--- a/crates/sdroxide-ui/src/app/mod.rs
+++ b/crates/sdroxide-ui/src/app/mod.rs
@@ -28,6 +28,7 @@ pub(in crate::app) mod logbook;
 pub(in crate::app) mod net;
 pub(in crate::app) mod panels;
 pub(crate) mod persist;
+pub(in crate::app) mod qo100;
 pub(in crate::app) mod rds;
 pub(in crate::app) mod sat;
 pub(in crate::app) mod scanner;
@@ -711,6 +712,9 @@ pub struct SdroxideApp {
     /// The SAT window and everything it remembers between frames.
     show_sat: bool,
     sat_win: sat::SatWinState,
+    /// The QO-100 BEACON window and everything it remembers between frames.
+    show_qo100: bool,
+    qo100_win: qo100::Qo100WinState,
     /// The rotctld client's health, mirrored from
     /// [`RadioEvent::RotatorStatus`].
     rotator_status: Option<(bool, f64, f64, Option<String>)>,
@@ -1243,6 +1247,8 @@ impl SdroxideApp {
             sat_track: None,
             show_sat: false,
             sat_win: Default::default(),
+            show_qo100: false,
+            qo100_win: Default::default(),
             rotator_status: None,
             rot_cfg_edit: Default::default(),
             rot_cfg_seeded: false,

--- a/crates/sdroxide-ui/src/app/qo100.rs
+++ b/crates/sdroxide-ui/src/app/qo100.rs
@@ -511,15 +511,27 @@ impl SdroxideApp {
 
         ui.add_space(6.0);
         ui.horizontal(|ui| {
-            let can_apply = measured_hz.is_some() && radio_cfg.is_some();
+            // A 32-bit sync word matched within 3 errors, times a 16-bit CRC,
+            // turns up by chance about once every couple of hours of
+            // searching — and APPLY writes the measured offset straight into
+            // the converter setting, so a single lock is not enough to act
+            // on. Two CRC-valid frames (`blocks_locked >= 2`) and a
+            // non-empty ASCII payload make a false positive vanishingly
+            // unlikely; the operator can still eyeball the TELEMETRY panel.
+            let confirmed =
+                status.as_ref().is_some_and(|s| s.blocks_locked >= 2 && !s.text.is_empty());
+            let can_apply = measured_hz.is_some() && radio_cfg.is_some() && confirmed;
             let apply = ui.add_enabled(
                 can_apply,
                 egui::Button::new(RichText::new(" APPLY CORRECTION ").strong()),
             );
-            let apply = apply.on_hover_text(
+            let apply = apply.on_hover_text(if measured_hz.is_some() && !confirmed {
+                "Waiting for a second CRC-valid frame at this frequency before offering to write \
+                 it — one lock alone could be a chance match"
+            } else {
                 "Write the corrected converter/LNB offset and reopen the receiver — a brief \
-                 interruption, the same one Settings ▸ Radio ▸ Apply makes",
-            );
+                 interruption, the same one Settings ▸ Radio ▸ Apply makes"
+            });
             if apply.clicked()
                 && let (Some(mut c), Some(measured)) = (radio_cfg.clone(), measured_hz)
             {

--- a/crates/sdroxide-ui/src/app/qo100.rs
+++ b/crates/sdroxide-ui/src/app/qo100.rs
@@ -572,7 +572,9 @@ fn status_line(enabled: bool, status: Option<&Qo100Status>) -> String {
                 s.blocks_locked
             )
         }
-        Some(s) if s.blocks_tried == 0 => "searching — first block takes about 10 s".to_string(),
+        Some(s) if s.blocks_tried == 0 => {
+            "searching — the first window fills after about 24 s, then repeats".to_string()
+        }
         Some(s) => format!(
             "searching — {} block{} tried, none locked yet",
             s.blocks_tried,

--- a/crates/sdroxide-ui/src/app/qo100.rs
+++ b/crates/sdroxide-ui/src/app/qo100.rs
@@ -515,15 +515,7 @@ impl SdroxideApp {
 
         ui.add_space(6.0);
         ui.horizontal(|ui| {
-            // A 32-bit sync word matched within 3 errors, times a 16-bit CRC,
-            // turns up by chance about once every couple of hours of
-            // searching — and APPLY writes the measured offset straight into
-            // the converter setting, so a single lock is not enough to act
-            // on. Two CRC-valid frames (`blocks_locked >= 2`) and a
-            // non-empty ASCII payload make a false positive vanishingly
-            // unlikely; the operator can still eyeball the TELEMETRY panel.
-            let confirmed =
-                status.as_ref().is_some_and(|s| s.blocks_locked >= 2 && !s.text.is_empty());
+            let confirmed = apply_is_confirmed(status.as_ref());
             let can_apply = measured_hz.is_some() && radio_cfg.is_some() && confirmed;
             let apply = ui.add_enabled(
                 can_apply,
@@ -572,6 +564,19 @@ impl SdroxideApp {
 /// period is) or if the decoder has never locked at all.
 fn locked_freq(status: Option<&Qo100Status>) -> Option<f64> {
     status.filter(|s| s.locked).map(|s| QO100_BEACON_HZ + s.offset_hz)
+}
+
+/// Whether a measured offset is safe to offer for `APPLY CORRECTION`, which
+/// writes it straight into the converter/LNB setting.
+///
+/// A 32-bit sync word matched within three bit errors, times a 16-bit CRC,
+/// turns up by chance roughly once every couple of hours of searching, so a
+/// single lock is not enough to act on. The button stays disabled until a
+/// second CRC-valid frame lands (`blocks_locked >= 2`) carrying a non-empty
+/// decoded payload — a false positive that clears both is vanishingly
+/// unlikely, and the operator can still eyeball the TELEMETRY panel.
+fn apply_is_confirmed(status: Option<&Qo100Status>) -> bool {
+    status.is_some_and(|s| s.blocks_locked >= 2 && !s.text.is_empty())
 }
 
 /// The one-line summary under the strip: off, searching (with how many
@@ -705,5 +710,33 @@ mod tests {
         let line = status_line(true, None, true);
         assert!(line.contains("receiving station"), "{line:?}");
         assert_ne!(line, "starting…");
+    }
+
+    #[test]
+    fn status_line_before_the_first_window_says_how_long_it_takes() {
+        // A search that is running but has not filled a window yet — distinct
+        // from one that never started (`None` → "starting…").
+        let mut s = status(false, 0.0);
+        s.blocks_tried = 0;
+        let line = status_line(true, Some(&s), false);
+        assert!(line.starts_with("searching"), "{line:?}");
+        assert!(line.contains("24 s"), "{line:?}");
+    }
+
+    #[test]
+    fn apply_stays_disabled_until_a_second_crc_valid_frame_with_text() {
+        assert!(!apply_is_confirmed(None), "nothing decoded yet");
+
+        let mut s = status(true, 1_000.0);
+        s.blocks_locked = 1;
+        s.text = "QO-100 XX".into();
+        assert!(!apply_is_confirmed(Some(&s)), "one lock could be a chance match");
+
+        s.blocks_locked = 2;
+        s.text = String::new();
+        assert!(!apply_is_confirmed(Some(&s)), "a blank payload is not a confirmation");
+
+        s.text = "QO-100 XX".into();
+        assert!(apply_is_confirmed(Some(&s)), "two locks and real text: safe to offer");
     }
 }

--- a/crates/sdroxide-ui/src/app/qo100.rs
+++ b/crates/sdroxide-ui/src/app/qo100.rs
@@ -276,7 +276,12 @@ impl SdroxideApp {
     }
 
     fn qo100_body(&mut self, ui: &mut egui::Ui, win: &mut Qo100WinState, cmds: &mut Vec<Command>) {
-        let reachable = self.caps.as_ref().is_none_or(|c| c.can_rx_hz(QO100_BEACON_HZ));
+        // `may_rx_hz`, not `can_rx_hz`: a driver that publishes no tuning
+        // ranges (SoapySDR makes `getFrequencyRange` optional, and plenty of
+        // backends skip it) has not said it *cannot* reach the beacon. Gating
+        // on `can_rx_hz` there greys ON out on a correctly-set-up LNB station
+        // and tells it to configure a converter offset it already has.
+        let reachable = self.caps.as_ref().is_none_or(|c| c.may_rx_hz(QO100_BEACON_HZ));
         let frame = self.frame.clone();
         // Edited in place and sent whole on any change, the same convention
         // the ISM window follows for `IsmSettings` — the engine persists this

--- a/crates/sdroxide-ui/src/app/qo100.rs
+++ b/crates/sdroxide-ui/src/app/qo100.rs
@@ -1,0 +1,652 @@
+//! The QO-100 BEACON window: calibrate the station's frequency chain against
+//! Es'hail-2's narrowband beacon.
+//!
+//! The narrowband transponder carries three beacons — one at each edge and one
+//! in the middle — of which [`BEACON_HZ`] is the easiest to pick out: an
+//! unmodulated carrier, not a telemetry signal buried in noise. Turning
+//! tracking ON tunes there and hunts the strongest bin in view; a double-click
+//! on the strip picks one by hand when the automatic search cannot (the
+//! signal is too weak, or drift has carried it out of the default window).
+//! Either way the difference between where the beacon actually sits and where
+//! it *should* — [`BEACON_HZ`] exactly — is the station's whole frequency
+//! error: the LNB's real LO plus whatever the SDR's own clock is off by,
+//! lumped together the way an operator would correct them by hand. APPLY
+//! writes that correction into [`sdroxide_types::RadioConfig::converter_offset_hz`]
+//! and reopens the front end — the same round trip Settings ▸ Radio ▸ Apply
+//! makes — rather than doing it silently on every frame, so a bad reading
+//! never yanks a running receiver.
+//!
+//! Deliberately its own small waterfall rather than a second
+//! [`crate::widgets::spectrum_view`] or a borrowed
+//! [`crate::widgets::wide_spectrum::WideWaterfall`]: neither offers a
+//! double-click-to-pick gesture, and both are built for the main panadapter's
+//! much larger job. This one reads the same [`sdroxide_types::SpectrumFrame`]
+//! everything else on screen already gets, cropped to a window around
+//! [`BEACON_HZ`].
+
+use std::collections::VecDeque;
+
+use eframe::egui::{
+    self, Color32, ColorImage, Pos2, Rect, RichText, Sense, Stroke, TextureHandle, Vec2,
+};
+use sdroxide_types::{Command, SpectrumFrame, Vfo};
+
+use crate::app::SdroxideApp;
+use crate::{colormap, theme};
+
+/// The beacon this window tracks: the upper edge of the QO-100 narrowband
+/// transponder. The band-edge and mid-band beacons carry telemetry and are
+/// harder to pick a clean centre frequency from; this one is a plain carrier.
+pub(in crate::app) const BEACON_HZ: f64 = 10_489_750_000.0;
+
+/// Columns the mini waterfall's history is resampled to — independent of the
+/// widget's pixel width, like [`crate::widgets::wide_spectrum`]'s `COLS`.
+const COLS: usize = 240;
+/// Rows of history kept.
+const ROWS: usize = 90;
+/// Height of the strip, in points.
+const STRIP_H: f32 = 130.0;
+
+/// Half-widths the width buttons step through, in Hz. 5 kHz either side is
+/// where most stations land after a first calibration; the wider steps are
+/// for finding the beacon at all when the station has drifted further than
+/// that or has never been calibrated.
+const HALF_WIDTHS: [f64; 6] = [2_000.0, 5_000.0, 10_000.0, 25_000.0, 50_000.0, 100_000.0];
+/// Index into [`HALF_WIDTHS`] the window opens with.
+const DEFAULT_HW_IDX: usize = 1;
+
+/// How far above the visible slice's own median a bin must stand to count as
+/// the beacon rather than noise. A plain carrier stands proud of the noise
+/// floor by a lot more than this; the point is only to refuse a flat,
+/// beacon-free slice rather than reporting its loudest bin of static.
+const SNR_DB: f32 = 6.0;
+
+/// Everything the window remembers between frames.
+pub(in crate::app) struct Qo100WinState {
+    /// Whether the strip is hunting the beacon each frame.
+    pub tracking: bool,
+    /// Index into [`HALF_WIDTHS`] — how wide a slice either side of
+    /// [`BEACON_HZ`] is shown and searched.
+    hw_idx: usize,
+    /// The beacon's last-known dial-domain frequency: from the automatic
+    /// search, or from a double-click that overrode it.
+    measured_hz: Option<f64>,
+    /// Whether `measured_hz` came from a double-click. While set, the
+    /// automatic search stops overwriting it — a manual pick stands until the
+    /// operator clicks again or tracking is switched off.
+    manual_pick: bool,
+    /// Newest row last, each [`COLS`] bytes of 0..=255 magnitude, resampled
+    /// from whatever of the live [`SpectrumFrame`] falls in the current
+    /// window.
+    rows: VecDeque<Vec<u8>>,
+    tex: Option<TextureHandle>,
+    last_seq: u32,
+    /// The (lo_hz, hi_hz) the stored rows were drawn against — a width change
+    /// invalidates them outright rather than trying to rescale history drawn
+    /// at a different span.
+    window: Option<(f64, f64)>,
+    /// The last correction actually written: old offset, new offset, and the
+    /// wall-clock second it was applied, so the operator sees what happened
+    /// even after the numbers above have moved on.
+    applied: Option<(f64, f64, i64)>,
+}
+
+impl Default for Qo100WinState {
+    fn default() -> Self {
+        Self {
+            tracking: false,
+            hw_idx: DEFAULT_HW_IDX,
+            measured_hz: None,
+            manual_pick: false,
+            rows: VecDeque::new(),
+            tex: None,
+            last_seq: 0,
+            window: None,
+            applied: None,
+        }
+    }
+}
+
+fn fmt_hz_signed(hz: f64) -> String {
+    if hz.abs() >= 1000.0 { format!("{:+.2} kHz", hz / 1000.0) } else { format!("{hz:+.0} Hz") }
+}
+
+/// New [`sdroxide_types::RadioConfig::converter_offset_hz`] that puts the
+/// beacon — currently read at `measured_hz` where it should read `target_hz`
+/// — exactly on `target_hz`, for the same physical LNB and receiver.
+///
+/// Derived from the converter's own convention
+/// (`sdroxide_radio::converter_open_hz`: `hardware_hz = dial_hz + offset`, so
+/// `dial_hz = hardware_hz - offset`). The same physical signal read under two
+/// offsets gives `measured_hz - target_hz = new_offset - old_offset`.
+pub(in crate::app) fn corrected_offset_hz(old_offset_hz: f64, measured_hz: f64, target_hz: f64) -> f64 {
+    old_offset_hz + (measured_hz - target_hz)
+}
+
+/// The bin range of `frame` overlapping `[lo_hz, hi_hz)`, clamped to what the
+/// frame actually covers. `None` when the frame has no bins, no span, or does
+/// not reach the requested window at all.
+fn bin_range(frame: &SpectrumFrame, lo_hz: f64, hi_hz: f64) -> Option<std::ops::Range<usize>> {
+    let n = frame.bins.len();
+    if n == 0 || frame.span_hz <= 0.0 {
+        return None;
+    }
+    let flo = frame.center_hz - frame.span_hz / 2.0;
+    let fhi = frame.center_hz + frame.span_hz / 2.0;
+    if hi_hz <= flo || lo_hz >= fhi {
+        return None;
+    }
+    let bin_hz = frame.span_hz / n as f64;
+    let b0 = (((lo_hz.max(flo) - flo) / bin_hz).floor() as isize).clamp(0, n as isize - 1) as usize;
+    let b1 = (((hi_hz.min(fhi) - flo) / bin_hz).ceil() as isize).clamp(1, n as isize) as usize;
+    (b1 > b0).then_some(b0..b1)
+}
+
+/// The strongest bin of `frame` inside `range`, refined to sub-bin precision
+/// by a three-point parabolic fit around it, and how far above the range's
+/// own median (in dB) it stands. `None` for an empty range or a peak that
+/// does not clear [`SNR_DB`] — a flat slice with nothing in it, most often
+/// meaning the beacon has drifted outside the current window.
+fn find_peak(frame: &SpectrumFrame, range: std::ops::Range<usize>) -> Option<(f64, f32)> {
+    if range.is_empty() {
+        return None;
+    }
+    let bins = &frame.bins[range.clone()];
+    let (mut best_i, mut best_v) = (0usize, bins[0]);
+    for (i, &v) in bins.iter().enumerate() {
+        if v > best_v {
+            (best_i, best_v) = (i, v);
+        }
+    }
+    let mut sorted = bins.to_vec();
+    sorted.sort_unstable();
+    let median = sorted[sorted.len() / 2];
+    let db_span = frame.db_ceil - frame.db_floor;
+    let to_db = |v: u8| frame.db_floor + (v as f32 / 255.0) * db_span;
+    let snr = to_db(best_v) - to_db(median);
+    if snr < SNR_DB {
+        return None;
+    }
+
+    // Parabolic refinement against the *full* bin array, so a peak at the
+    // edge of the search range can still borrow the one neighbour outside it.
+    let gi = range.start + best_i;
+    let y0 = frame.bins.get(gi.wrapping_sub(1)).copied().unwrap_or(best_v) as f32;
+    let y1 = best_v as f32;
+    let y2 = frame.bins.get(gi + 1).copied().unwrap_or(best_v) as f32;
+    let denom = y0 - 2.0 * y1 + y2;
+    let delta = if denom.abs() > f32::EPSILON { (0.5 * (y0 - y2) / denom).clamp(-1.0, 1.0) } else { 0.0 };
+
+    let bin_hz = frame.span_hz / frame.bins.len().max(1) as f64;
+    let lo = frame.center_hz - frame.span_hz / 2.0;
+    let freq = lo + (gi as f64 + 0.5 + delta as f64) * bin_hz;
+    Some((freq, snr))
+}
+
+/// Fold a new frame into the history, resampled onto [`COLS`] against the
+/// fixed `(lo, hi)` window. A width change clears the history outright rather
+/// than rescaling it — cheap, and correct, since nothing here promises a
+/// scrolling record of *other* widths.
+fn push_row(win: &mut Qo100WinState, frame: &SpectrumFrame, lo: f64, hi: f64) {
+    if frame.seq == win.last_seq && win.window == Some((lo, hi)) {
+        return;
+    }
+    if win.window != Some((lo, hi)) {
+        win.rows.clear();
+        win.window = Some((lo, hi));
+    }
+    win.last_seq = frame.seq;
+
+    let flo = frame.center_hz - frame.span_hz / 2.0;
+    let fhi = frame.center_hz + frame.span_hz / 2.0;
+    let n = frame.bins.len();
+    let mut row = vec![0u8; COLS];
+    if n > 0 && frame.span_hz > 0.0 && hi > flo && lo < fhi {
+        let bin_hz = frame.span_hz / n as f64;
+        for (c, slot) in row.iter_mut().enumerate() {
+            let x0 = lo + (hi - lo) * c as f64 / COLS as f64;
+            let x1 = lo + (hi - lo) * (c + 1) as f64 / COLS as f64;
+            let (ox0, ox1) = (x0.max(flo), x1.min(fhi));
+            if ox1 <= ox0 {
+                continue; // this column falls outside what the receiver currently covers
+            }
+            let b0 = (((ox0 - flo) / bin_hz).floor() as isize).clamp(0, n as isize - 1) as usize;
+            let b1 = (((ox1 - flo) / bin_hz).ceil() as isize).clamp(1, n as isize) as usize;
+            if b1 > b0 {
+                *slot = frame.bins[b0..b1].iter().copied().max().unwrap_or(0);
+            }
+        }
+    }
+    win.rows.push_back(row);
+    while win.rows.len() > ROWS {
+        win.rows.pop_front();
+    }
+    win.tex = None; // rebuilt on the next draw
+}
+
+fn texture<'a>(win: &'a mut Qo100WinState, ctx: &egui::Context, palette: usize) -> Option<&'a TextureHandle> {
+    if win.tex.is_none() && !win.rows.is_empty() {
+        let lut = colormap::lut(palette);
+        // Newest row first, so the strip scrolls downward like every other
+        // waterfall in the app.
+        let mut pixels = Vec::with_capacity(COLS * win.rows.len());
+        for row in win.rows.iter().rev() {
+            pixels.extend(row.iter().map(|v| {
+                let i = *v as usize * 4;
+                Color32::from_rgb(lut[i], lut[i + 1], lut[i + 2])
+            }));
+        }
+        let img = ColorImage::new([COLS, win.rows.len()], pixels);
+        win.tex = Some(ctx.load_texture("qo100-waterfall", img, egui::TextureOptions::LINEAR));
+    }
+    win.tex.as_ref()
+}
+
+/// Draw the strip and handle its one gesture — a double-click picks a beacon
+/// by hand. Returns the picked frequency, if any.
+fn paint_strip(
+    ui: &mut egui::Ui,
+    win: &mut Qo100WinState,
+    frame: Option<&SpectrumFrame>,
+    palette: usize,
+) -> Option<f64> {
+    let (lo, hi) = (BEACON_HZ - HALF_WIDTHS[win.hw_idx], BEACON_HZ + HALF_WIDTHS[win.hw_idx]);
+    let (rect, resp) =
+        ui.allocate_exact_size(Vec2::new(ui.available_width(), STRIP_H), Sense::click());
+    if !ui.is_rect_visible(rect) {
+        return None;
+    }
+    let painter = ui.painter_at(rect);
+    painter.rect_filled(rect, 2.0, Color32::BLACK);
+
+    if let Some(f) = frame {
+        push_row(win, f, lo, hi);
+    }
+    let ctx = ui.ctx().clone();
+    if let Some(tex) = texture(win, &ctx, palette) {
+        painter.image(
+            tex.id(),
+            rect,
+            Rect::from_min_max(Pos2::new(0.0, 0.0), Pos2::new(1.0, 1.0)),
+            Color32::WHITE,
+        );
+    }
+
+    let x_of = |hz: f64| -> f32 {
+        rect.left() + ((hz - lo) / (hi - lo)).clamp(0.0, 1.0) as f32 * rect.width()
+    };
+    // The target: where the beacon belongs.
+    let tx = x_of(BEACON_HZ);
+    painter.line_segment(
+        [Pos2::new(tx, rect.top()), Pos2::new(tx, rect.bottom())],
+        Stroke::new(1.0, theme::CYAN()),
+    );
+    // Where it was actually found (or picked).
+    if let Some(m) = win.measured_hz
+        && (lo..=hi).contains(&m)
+    {
+        let mx = x_of(m);
+        let colour = if win.manual_pick { theme::YELLOW() } else { theme::GREEN() };
+        painter.line_segment(
+            [Pos2::new(mx, rect.top()), Pos2::new(mx, rect.bottom())],
+            Stroke::new(1.6, colour),
+        );
+    }
+
+    let font = egui::FontId::monospace(9.0);
+    let dim = Color32::from_white_alpha(200);
+    painter.text(
+        Pos2::new(rect.left() + 3.0, rect.top() + 1.0),
+        egui::Align2::LEFT_TOP,
+        format!("{:.3} MHz", lo / 1e6),
+        font.clone(),
+        dim,
+    );
+    painter.text(
+        Pos2::new(rect.right() - 3.0, rect.top() + 1.0),
+        egui::Align2::RIGHT_TOP,
+        format!("{:.3} MHz", hi / 1e6),
+        font,
+        dim,
+    );
+    crate::chrome::paint_cut_border(&painter, rect, theme::LINE_LIT(), theme::PANEL());
+
+    if resp.hovered() {
+        ui.ctx().set_cursor_icon(egui::CursorIcon::Crosshair);
+    }
+    resp.double_clicked()
+        .then(|| resp.interact_pointer_pos())
+        .flatten()
+        .map(|p| lo + ((p.x - rect.left()) / rect.width()).clamp(0.0, 1.0) as f64 * (hi - lo))
+}
+
+impl SdroxideApp {
+    pub(in crate::app) fn qo100_window(&mut self, ctx: &egui::Context, cmds: &mut Vec<Command>) {
+        if !self.show_qo100 {
+            return;
+        }
+        let mut win = std::mem::take(&mut self.qo100_win);
+        let mut open = self.show_qo100;
+        let resp = egui::Window::new("QO-100 BEACON")
+            .id(crate::layout::salted_id(ctx, "Qo100"))
+            .open(&mut open)
+            .frame(crate::chrome::window_frame())
+            .resizable(true)
+            .default_width(crate::layout::window_w(ctx, 420.0))
+            .show(ctx, |ui| {
+                crate::chrome::window_body_bg(ui);
+                self.qo100_body(ui, &mut win, cmds)
+            });
+        if let Some(r) = &resp {
+            crate::chrome::paint_window_border(ctx, &r.response);
+        }
+        self.show_qo100 = open;
+        self.qo100_win = win;
+    }
+
+    fn qo100_body(&mut self, ui: &mut egui::Ui, win: &mut Qo100WinState, cmds: &mut Vec<Command>) {
+        let reachable = self.caps.as_ref().is_none_or(|c| c.can_rx_hz(BEACON_HZ));
+        let frame = self.frame.clone();
+        let (lo, hi) = (BEACON_HZ - HALF_WIDTHS[win.hw_idx], BEACON_HZ + HALF_WIDTHS[win.hw_idx]);
+        // Whether whatever the receiver is *actually* capturing right now
+        // reaches anywhere near the beacon at all — as against `reachable`,
+        // which asks whether it ever could. A capable receiver still shows a
+        // blank strip while it is parked on 144 MHz, and that is the second
+        // most likely reason (after no converter at all) this window opens on
+        // an empty waterfall.
+        let in_view = frame.as_deref().is_some_and(|f| bin_range(f, lo, hi).is_some());
+        let dial_hz = self.state.active_freq_hz();
+
+        ui.horizontal(|ui| {
+            let run = crate::chrome::chip_enabled(
+                ui,
+                reachable,
+                win.tracking,
+                if win.tracking { "ON" } else { "OFF" },
+            );
+            if run.clicked() {
+                win.tracking = !win.tracking;
+                if win.tracking {
+                    cmds.push(Command::SetVfo { vfo: Vfo::A, hz: BEACON_HZ });
+                } else {
+                    win.manual_pick = false;
+                }
+            }
+            if !reachable {
+                run.on_hover_text(
+                    "This receiver cannot reach 10489.750 MHz on its own — set up an \
+                     LNB/converter offset first (Settings ▸ Radio)",
+                );
+            } else {
+                run.on_hover_text("Tune to the beacon and hunt its centre frequency");
+            }
+
+            ui.add_space(8.0);
+            ui.label(RichText::new("width").size(10.0).color(theme::CYAN_DIM()));
+            if ui.small_button("−").on_hover_text("Narrower — search a smaller slice").clicked() {
+                win.hw_idx = win.hw_idx.saturating_sub(1);
+            }
+            ui.label(
+                RichText::new(format!("±{:.0} kHz", HALF_WIDTHS[win.hw_idx] / 1000.0))
+                    .size(11.0)
+                    .monospace(),
+            );
+            if ui
+                .small_button("+")
+                .on_hover_text("Wider — for when the beacon isn't visible at the current width")
+                .clicked()
+            {
+                win.hw_idx = (win.hw_idx + 1).min(HALF_WIDTHS.len() - 1);
+            }
+        });
+
+        // Unmissable, not just a hover: a fresh station has no converter set
+        // up yet, so ON stays disabled and the strip would otherwise sit
+        // there blank with no clue why — the single most likely reason
+        // anyone ever opens this window and sees nothing.
+        if !reachable {
+            ui.add_space(4.0);
+            ui.horizontal_wrapped(|ui| {
+                ui.label(
+                    RichText::new(
+                        "This radio's own tuning range doesn't reach 10489.750 MHz — it needs an \
+                         LNB/converter offset (Settings ▸ Radio ▸ Converter) before this window can \
+                         do anything.",
+                    )
+                    .size(10.5)
+                    .color(theme::YELLOW()),
+                );
+                if ui.small_button("Open Settings ▸ Radio").clicked() {
+                    self.open_radio_settings();
+                }
+            });
+        }
+
+        // The receiver *can* reach the beacon but currently is not — parked
+        // on some other band, most often. The strip has nothing to show
+        // either way, but here the fix is one click rather than a trip to
+        // Settings, and worth naming exactly where the dial actually is.
+        if reachable && !in_view {
+            ui.add_space(4.0);
+            ui.horizontal_wrapped(|ui| {
+                ui.label(
+                    RichText::new(format!(
+                        "The receiver is currently listening around {:.6} MHz — nowhere near the \
+                         10489.750 MHz beacon, so there is nothing here to show.",
+                        dial_hz / 1e6
+                    ))
+                    .size(10.5)
+                    .color(theme::YELLOW()),
+                );
+                if ui.small_button("Tune to 10489.750 MHz").clicked() {
+                    cmds.push(Command::SetVfo { vfo: Vfo::A, hz: BEACON_HZ });
+                }
+            });
+        }
+
+        if let Some(f) = self.frame.as_ref() {
+            let capped = f.span_hz / 2.0 < HALF_WIDTHS[win.hw_idx];
+            if capped && f.span_hz > 0.0 {
+                ui.label(
+                    RichText::new(format!(
+                        "receiver currently covers only ±{:.0} kHz here — the rest of the strip stays blank",
+                        f.span_hz / 2e3
+                    ))
+                    .size(9.5)
+                    .color(theme::YELLOW()),
+                );
+            }
+        }
+
+        ui.add_space(4.0);
+        let picked = paint_strip(ui, win, frame.as_deref(), self.ui_settings.waterfall_palette);
+        if let Some(hz) = picked {
+            win.measured_hz = Some(hz);
+            win.manual_pick = true;
+        } else if win.tracking && !win.manual_pick {
+            win.measured_hz = frame
+                .as_deref()
+                .and_then(|f| bin_range(f, lo, hi).and_then(|r| find_peak(f, r)))
+                .map(|(hz, _)| hz);
+        } else if !win.tracking {
+            win.measured_hz = None;
+        }
+
+        ui.add_space(6.0);
+        ui.label(
+            RichText::new(if win.manual_pick { "picked by hand — double-click again to repick" } else { "" })
+                .size(9.5)
+                .color(theme::CYAN_DIM()),
+        );
+
+        let cfg = self.ctrl.radio_config();
+        let old_offset = cfg.as_ref().map(|c| c.converter_offset_hz).unwrap_or(0.0);
+
+        egui::Grid::new("qo100-grid").num_columns(2).spacing([16.0, 3.0]).show(ui, |ui| {
+            let dim = |s: &str| RichText::new(s).size(9.5).color(theme::CYAN_DIM());
+            // What the receiver is actually listening to right now — the
+            // direct answer to "why is the strip empty", always on screen
+            // rather than only when it explains a problem.
+            ui.label(dim("RECEIVER"));
+            ui.label(
+                RichText::new(format!("{:.6} MHz", dial_hz / 1e6))
+                    .size(11.0)
+                    .monospace()
+                    .color(if in_view { theme::TEXT() } else { theme::YELLOW() }),
+            );
+            ui.end_row();
+
+            ui.label(dim("TARGET"));
+            ui.label(RichText::new(format!("{:.6} MHz", BEACON_HZ / 1e6)).size(12.0).monospace());
+            ui.end_row();
+
+            ui.label(dim("MEASURED"));
+            match win.measured_hz {
+                Some(hz) => ui.label(
+                    RichText::new(format!("{:.6} MHz", hz / 1e6)).size(12.0).monospace().strong(),
+                ),
+                None => ui.label(
+                    RichText::new(if win.tracking { "not found — try a wider width" } else { "—" })
+                        .size(11.0)
+                        .color(theme::CYAN_DIM()),
+                ),
+            };
+            ui.end_row();
+
+            ui.label(dim("DRIFT"));
+            match win.measured_hz {
+                Some(hz) => {
+                    let err = hz - BEACON_HZ;
+                    let colour = if err.abs() < 200.0 {
+                        theme::GREEN()
+                    } else if err.abs() < 3000.0 {
+                        theme::YELLOW()
+                    } else {
+                        theme::TEXT()
+                    };
+                    ui.label(RichText::new(fmt_hz_signed(err)).size(12.0).monospace().color(colour))
+                }
+                None => ui.label(RichText::new("—").size(11.0).color(theme::CYAN_DIM())),
+            };
+            ui.end_row();
+
+            ui.label(dim("CONVERTER OFFSET"));
+            ui.label(RichText::new(format!("{old_offset:.0} Hz")).size(11.0).monospace());
+            ui.end_row();
+        });
+
+        ui.add_space(6.0);
+        ui.horizontal(|ui| {
+            let can_apply = win.measured_hz.is_some() && cfg.is_some();
+            let apply = ui.add_enabled(
+                can_apply,
+                egui::Button::new(RichText::new(" APPLY CORRECTION ").strong()),
+            );
+            let apply = apply.on_hover_text(
+                "Write the corrected converter/LNB offset and reopen the receiver — a brief \
+                 interruption, the same one Settings ▸ Radio ▸ Apply makes",
+            );
+            if apply.clicked()
+                && let (Some(mut c), Some(measured)) = (cfg.clone(), win.measured_hz)
+            {
+                let new_offset = corrected_offset_hz(c.converter_offset_hz, measured, BEACON_HZ);
+                c.converter_offset_hz = new_offset;
+                self.ctrl.set_radio_config(c.clone());
+                self.ctrl.reopen_source();
+                self.radio_cfg = Some(c);
+                win.applied = Some((old_offset, new_offset, crate::time::now_unix()));
+                win.manual_pick = false;
+            }
+            if let Some((old, new, at)) = win.applied {
+                let ago = crate::time::now_unix() - at;
+                ui.label(
+                    RichText::new(format!(
+                        "last applied {ago}s ago: {old:.0} → {new:.0} Hz ({:+.0} Hz)",
+                        new - old
+                    ))
+                    .size(9.5)
+                    .color(theme::CYAN_DIM()),
+                );
+            }
+        });
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn a_beacon_read_high_needs_the_offset_raised() {
+        // Beacon really sits on BEACON_HZ but reads 5 kHz high — the LNB's LO
+        // is 5 kHz low, which the software currently under-subtracts.
+        let old = -9_750_000_000.0;
+        let measured = BEACON_HZ + 5_000.0;
+        assert_eq!(corrected_offset_hz(old, measured, BEACON_HZ), old + 5_000.0);
+    }
+
+    #[test]
+    fn a_beacon_read_low_needs_the_offset_lowered() {
+        let old = -9_750_000_000.0;
+        let measured = BEACON_HZ - 1_200.0;
+        assert_eq!(corrected_offset_hz(old, measured, BEACON_HZ), old - 1_200.0);
+    }
+
+    #[test]
+    fn a_correctly_calibrated_station_gets_the_same_offset_back() {
+        let old = -9_750_000_000.0;
+        assert_eq!(corrected_offset_hz(old, BEACON_HZ, BEACON_HZ), old);
+    }
+
+    fn frame_with(center_hz: f64, span_hz: f64, bins: Vec<u8>) -> SpectrumFrame {
+        SpectrumFrame { seq: 1, center_hz, span_hz, db_floor: -120.0, db_ceil: -20.0, bins }
+    }
+
+    #[test]
+    fn a_flat_peak_lands_on_its_own_bin_centre() {
+        // A symmetric peak (equal neighbours) has no reason to shift either
+        // way: the parabola through equal shoulders is flat at the top.
+        let mut bins = vec![20u8; 64];
+        bins[32] = 200;
+        bins[31] = 120;
+        bins[33] = 120;
+        let frame = frame_with(10_489_750_000.0, 640_000.0, bins);
+        let (hz, snr) = find_peak(&frame, 0..64).expect("clears SNR_DB");
+        assert!(snr > SNR_DB);
+        let expected = frame.freq_at_bin(32);
+        assert!((hz - expected).abs() < 1.0, "expected {expected}, got {hz}");
+    }
+
+    #[test]
+    fn a_lopsided_peak_is_pulled_toward_its_stronger_shoulder() {
+        let mut bins = vec![20u8; 64];
+        bins[32] = 200;
+        bins[31] = 100;
+        bins[33] = 160; // stronger on the high side — true peak sits above bin 32
+        let frame = frame_with(10_489_750_000.0, 640_000.0, bins);
+        let (hz, _) = find_peak(&frame, 0..64).expect("clears SNR_DB");
+        assert!(hz > frame.freq_at_bin(32));
+    }
+
+    #[test]
+    fn a_flat_noise_floor_reports_no_beacon() {
+        let bins = vec![40u8; 64];
+        let frame = frame_with(10_489_750_000.0, 640_000.0, bins);
+        assert!(find_peak(&frame, 0..64).is_none());
+    }
+
+    #[test]
+    fn bin_range_refuses_a_window_the_frame_never_reaches() {
+        let frame = frame_with(14_000_000.0, 100_000.0, vec![0u8; 64]);
+        assert!(bin_range(&frame, BEACON_HZ - 5_000.0, BEACON_HZ + 5_000.0).is_none());
+    }
+
+    #[test]
+    fn bin_range_clamps_to_what_the_frame_actually_covers() {
+        // Requested window straddles the frame's edge; the range returned
+        // must stay inside 0..bins.len().
+        let frame = frame_with(BEACON_HZ + 3_000.0, 10_000.0, vec![0u8; 100]);
+        let r = bin_range(&frame, BEACON_HZ - 5_000.0, BEACON_HZ + 5_000.0).expect("overlaps");
+        assert!(r.end <= 100);
+    }
+}

--- a/crates/sdroxide-ui/src/app/qo100.rs
+++ b/crates/sdroxide-ui/src/app/qo100.rs
@@ -608,7 +608,16 @@ mod tests {
     }
 
     fn frame_with(center_hz: f64, span_hz: f64, bins: Vec<u8>) -> SpectrumFrame {
-        SpectrumFrame { seq: 1, center_hz, span_hz, db_floor: -120.0, db_ceil: -20.0, bins }
+        SpectrumFrame {
+            seq: 1,
+            center_hz,
+            span_hz,
+            db_floor: -120.0,
+            db_ceil: -20.0,
+            bins,
+            rows: Vec::new(),
+            rows_clocked: false,
+        }
     }
 
     #[test]

--- a/crates/sdroxide-ui/src/app/qo100.rs
+++ b/crates/sdroxide-ui/src/app/qo100.rs
@@ -429,9 +429,13 @@ impl SdroxideApp {
 
         ui.add_space(6.0);
         ui.label(
-            RichText::new(status_line(cfg.enabled, status.as_ref()))
-                .size(9.5)
-                .color(theme::CYAN_DIM()),
+            RichText::new(status_line(
+                cfg.enabled,
+                status.as_ref(),
+                self.ctrl.engine_is_remote(),
+            ))
+            .size(9.5)
+            .color(theme::CYAN_DIM()),
         );
 
         let radio_cfg = self.ctrl.radio_config();
@@ -575,9 +579,18 @@ fn locked_freq(status: Option<&Qo100Status>) -> Option<f64> {
 /// distinction `IsmStatus`'s bursts/decodes line exists for, so a search
 /// that is running but has not found the beacon yet reads differently from
 /// one that never started.
-fn status_line(enabled: bool, status: Option<&Qo100Status>) -> String {
+///
+/// `remote` is the client-does-not-own-the-engine case: the decoder runs on
+/// the station and its status has no path to a remote client yet (see
+/// `RadioEvent::Qo100Status`), so rather than sit on "starting…" forever the
+/// line says plainly that this readout is local to the receiving station.
+fn status_line(enabled: bool, status: Option<&Qo100Status>, remote: bool) -> String {
     if !enabled {
         return String::new();
+    }
+    if remote {
+        return "decoder runs on the receiving station — its readout is not sent to remote clients"
+            .to_string();
     }
     match status {
         None => "starting…".to_string(),
@@ -673,14 +686,24 @@ mod tests {
 
     #[test]
     fn status_line_is_blank_while_switched_off() {
-        assert_eq!(status_line(false, Some(&status(true, 0.0))), "");
+        assert_eq!(status_line(false, Some(&status(true, 0.0)), false), "");
+        assert_eq!(status_line(false, None, true), "");
     }
 
     #[test]
     fn status_line_distinguishes_locked_from_still_searching() {
-        assert!(status_line(true, Some(&status(true, 0.0))).starts_with("locked"));
+        assert!(status_line(true, Some(&status(true, 0.0)), false).starts_with("locked"));
         let mut searching = status(false, 0.0);
         searching.blocks_tried = 3;
-        assert!(status_line(true, Some(&searching)).starts_with("searching"));
+        assert!(status_line(true, Some(&searching), false).starts_with("searching"));
+    }
+
+    #[test]
+    fn status_line_tells_a_remote_client_the_readout_is_local() {
+        // No status will ever arrive on a remote client (the server drops
+        // the event), so the line must not sit on "starting…".
+        let line = status_line(true, None, true);
+        assert!(line.contains("receiving station"), "{line:?}");
+        assert_ne!(line, "starting…");
     }
 }

--- a/crates/sdroxide-ui/src/app/qo100.rs
+++ b/crates/sdroxide-ui/src/app/qo100.rs
@@ -1,43 +1,41 @@
 //! The QO-100 BEACON window: calibrate the station's frequency chain against
 //! Es'hail-2's narrowband beacon.
 //!
-//! The narrowband transponder carries three beacons — one at each edge and one
-//! in the middle — of which [`BEACON_HZ`] is the easiest to pick out: an
-//! unmodulated carrier, not a telemetry signal buried in noise. Turning
-//! tracking ON tunes there and hunts the strongest bin in view; a double-click
-//! on the strip picks one by hand when the automatic search cannot (the
-//! signal is too weak, or drift has carried it out of the default window).
-//! Either way the difference between where the beacon actually sits and where
-//! it *should* — [`BEACON_HZ`] exactly — is the station's whole frequency
-//! error: the LNB's real LO plus whatever the SDR's own clock is off by,
-//! lumped together the way an operator would correct them by hand. APPLY
-//! writes that correction into [`sdroxide_types::RadioConfig::converter_offset_hz`]
-//! and reopens the front end — the same round trip Settings ▸ Radio ▸ Apply
-//! makes — rather than doing it silently on every frame, so a bad reading
-//! never yanks a running receiver.
+//! The beacon this tracks — [`QO100_BEACON_HZ`] — is not a plain carrier: it
+//! is a 400 baud differential+Manchester BPSK telemetry signal (AO-40
+//! "uncoded" framing), which is why a magnitude peak search has no purpose
+//! here — Manchester encoding leaves a *null* at the carrier frequency, not a
+//! peak. The actual demodulator lives engine-side, in `sdroxide_qo100`
+//! (raw IQ and real phase information, neither of which the UI has); this
+//! window is a thin front end onto [`sdroxide_types::Qo100Settings`] (ON/OFF,
+//! search width) and [`sdroxide_types::Qo100Status`] (lock, measured
+//! frequency, decoded text) — the same split the ISM window keeps with
+//! [`sdroxide_types::IsmSettings`]/[`sdroxide_types::IsmStatus`].
 //!
-//! Deliberately its own small waterfall rather than a second
-//! [`crate::widgets::spectrum_view`] or a borrowed
-//! [`crate::widgets::wide_spectrum::WideWaterfall`]: neither offers a
-//! double-click-to-pick gesture, and both are built for the main panadapter's
-//! much larger job. This one reads the same [`sdroxide_types::SpectrumFrame`]
-//! everything else on screen already gets, cropped to a window around
-//! [`BEACON_HZ`].
+//! When the decoder locks, the frequency it had to assume for the sync word
+//! and CRC to check out *is* the station's whole frequency error — the LNB's
+//! real LO plus whatever the SDR's own clock is off by, lumped together the
+//! way an operator would correct them by hand. APPLY writes that correction
+//! into [`sdroxide_types::RadioConfig::converter_offset_hz`] and reopens the
+//! front end — the same round trip Settings ▸ Radio ▸ Apply makes — rather
+//! than doing it silently on every lock, so a bad reading never yanks a
+//! running receiver.
+//!
+//! The mini waterfall is visual context only now, not a measurement: it reads
+//! the same [`sdroxide_types::SpectrumFrame`] everything else on screen
+//! already gets, cropped to a window around the beacon, so the operator can
+//! see the Manchester null (and the search width buttons' effect) even
+//! though nothing here measures anything off it.
 
 use std::collections::VecDeque;
 
 use eframe::egui::{
     self, Color32, ColorImage, Pos2, Rect, RichText, Sense, Stroke, TextureHandle, Vec2,
 };
-use sdroxide_types::{Command, SpectrumFrame, Vfo};
+use sdroxide_types::{Command, QO100_BEACON_HZ, Qo100Status, SpectrumFrame, Vfo};
 
 use crate::app::SdroxideApp;
 use crate::{colormap, theme};
-
-/// The beacon this window tracks: the upper edge of the QO-100 narrowband
-/// transponder. The band-edge and mid-band beacons carry telemetry and are
-/// harder to pick a clean centre frequency from; this one is a plain carrier.
-pub(in crate::app) const BEACON_HZ: f64 = 10_489_750_000.0;
 
 /// Columns the mini waterfall's history is resampled to — independent of the
 /// widget's pixel width, like [`crate::widgets::wide_spectrum`]'s `COLS`.
@@ -47,34 +45,20 @@ const ROWS: usize = 90;
 /// Height of the strip, in points.
 const STRIP_H: f32 = 130.0;
 
-/// Half-widths the width buttons step through, in Hz. 5 kHz either side is
-/// where most stations land after a first calibration; the wider steps are
-/// for finding the beacon at all when the station has drifted further than
-/// that or has never been calibrated.
-const HALF_WIDTHS: [f64; 6] = [2_000.0, 5_000.0, 10_000.0, 25_000.0, 50_000.0, 100_000.0];
-/// Index into [`HALF_WIDTHS`] the window opens with.
-const DEFAULT_HW_IDX: usize = 1;
+/// The search-width step the width buttons move by, and the ends of the
+/// range they're clamped to — "5 kHz and its multiples", wide enough at the
+/// top for a station that has never been calibrated and narrow enough at the
+/// bottom that the search is not paying to cover more band than any real
+/// LNB drifts.
+const WIDTH_STEP_HZ: f64 = 5_000.0;
+const MIN_HALF_WIDTH_HZ: f64 = WIDTH_STEP_HZ;
+const MAX_HALF_WIDTH_HZ: f64 = 50_000.0;
 
-/// How far above the visible slice's own median a bin must stand to count as
-/// the beacon rather than noise. A plain carrier stands proud of the noise
-/// floor by a lot more than this; the point is only to refuse a flat,
-/// beacon-free slice rather than reporting its loudest bin of static.
-const SNR_DB: f32 = 6.0;
-
-/// Everything the window remembers between frames.
+/// Everything the window remembers between frames that is not a setting the
+/// engine already tracks — purely the mini waterfall's own drawing state,
+/// and the last correction actually applied.
+#[derive(Default)]
 pub(in crate::app) struct Qo100WinState {
-    /// Whether the strip is hunting the beacon each frame.
-    pub tracking: bool,
-    /// Index into [`HALF_WIDTHS`] — how wide a slice either side of
-    /// [`BEACON_HZ`] is shown and searched.
-    hw_idx: usize,
-    /// The beacon's last-known dial-domain frequency: from the automatic
-    /// search, or from a double-click that overrode it.
-    measured_hz: Option<f64>,
-    /// Whether `measured_hz` came from a double-click. While set, the
-    /// automatic search stops overwriting it — a manual pick stands until the
-    /// operator clicks again or tracking is switched off.
-    manual_pick: bool,
     /// Newest row last, each [`COLS`] bytes of 0..=255 magnitude, resampled
     /// from whatever of the live [`SpectrumFrame`] falls in the current
     /// window.
@@ -91,22 +75,6 @@ pub(in crate::app) struct Qo100WinState {
     applied: Option<(f64, f64, i64)>,
 }
 
-impl Default for Qo100WinState {
-    fn default() -> Self {
-        Self {
-            tracking: false,
-            hw_idx: DEFAULT_HW_IDX,
-            measured_hz: None,
-            manual_pick: false,
-            rows: VecDeque::new(),
-            tex: None,
-            last_seq: 0,
-            window: None,
-            applied: None,
-        }
-    }
-}
-
 fn fmt_hz_signed(hz: f64) -> String {
     if hz.abs() >= 1000.0 { format!("{:+.2} kHz", hz / 1000.0) } else { format!("{hz:+.0} Hz") }
 }
@@ -119,7 +87,11 @@ fn fmt_hz_signed(hz: f64) -> String {
 /// (`sdroxide_radio::converter_open_hz`: `hardware_hz = dial_hz + offset`, so
 /// `dial_hz = hardware_hz - offset`). The same physical signal read under two
 /// offsets gives `measured_hz - target_hz = new_offset - old_offset`.
-pub(in crate::app) fn corrected_offset_hz(old_offset_hz: f64, measured_hz: f64, target_hz: f64) -> f64 {
+pub(in crate::app) fn corrected_offset_hz(
+    old_offset_hz: f64,
+    measured_hz: f64,
+    target_hz: f64,
+) -> f64 {
     old_offset_hz + (measured_hz - target_hz)
 }
 
@@ -140,47 +112,6 @@ fn bin_range(frame: &SpectrumFrame, lo_hz: f64, hi_hz: f64) -> Option<std::ops::
     let b0 = (((lo_hz.max(flo) - flo) / bin_hz).floor() as isize).clamp(0, n as isize - 1) as usize;
     let b1 = (((hi_hz.min(fhi) - flo) / bin_hz).ceil() as isize).clamp(1, n as isize) as usize;
     (b1 > b0).then_some(b0..b1)
-}
-
-/// The strongest bin of `frame` inside `range`, refined to sub-bin precision
-/// by a three-point parabolic fit around it, and how far above the range's
-/// own median (in dB) it stands. `None` for an empty range or a peak that
-/// does not clear [`SNR_DB`] — a flat slice with nothing in it, most often
-/// meaning the beacon has drifted outside the current window.
-fn find_peak(frame: &SpectrumFrame, range: std::ops::Range<usize>) -> Option<(f64, f32)> {
-    if range.is_empty() {
-        return None;
-    }
-    let bins = &frame.bins[range.clone()];
-    let (mut best_i, mut best_v) = (0usize, bins[0]);
-    for (i, &v) in bins.iter().enumerate() {
-        if v > best_v {
-            (best_i, best_v) = (i, v);
-        }
-    }
-    let mut sorted = bins.to_vec();
-    sorted.sort_unstable();
-    let median = sorted[sorted.len() / 2];
-    let db_span = frame.db_ceil - frame.db_floor;
-    let to_db = |v: u8| frame.db_floor + (v as f32 / 255.0) * db_span;
-    let snr = to_db(best_v) - to_db(median);
-    if snr < SNR_DB {
-        return None;
-    }
-
-    // Parabolic refinement against the *full* bin array, so a peak at the
-    // edge of the search range can still borrow the one neighbour outside it.
-    let gi = range.start + best_i;
-    let y0 = frame.bins.get(gi.wrapping_sub(1)).copied().unwrap_or(best_v) as f32;
-    let y1 = best_v as f32;
-    let y2 = frame.bins.get(gi + 1).copied().unwrap_or(best_v) as f32;
-    let denom = y0 - 2.0 * y1 + y2;
-    let delta = if denom.abs() > f32::EPSILON { (0.5 * (y0 - y2) / denom).clamp(-1.0, 1.0) } else { 0.0 };
-
-    let bin_hz = frame.span_hz / frame.bins.len().max(1) as f64;
-    let lo = frame.center_hz - frame.span_hz / 2.0;
-    let freq = lo + (gi as f64 + 0.5 + delta as f64) * bin_hz;
-    Some((freq, snr))
 }
 
 /// Fold a new frame into the history, resampled onto [`COLS`] against the
@@ -224,7 +155,11 @@ fn push_row(win: &mut Qo100WinState, frame: &SpectrumFrame, lo: f64, hi: f64) {
     win.tex = None; // rebuilt on the next draw
 }
 
-fn texture<'a>(win: &'a mut Qo100WinState, ctx: &egui::Context, palette: usize) -> Option<&'a TextureHandle> {
+fn texture<'a>(
+    win: &'a mut Qo100WinState,
+    ctx: &egui::Context,
+    palette: usize,
+) -> Option<&'a TextureHandle> {
     if win.tex.is_none() && !win.rows.is_empty() {
         let lut = colormap::lut(palette);
         // Newest row first, so the strip scrolls downward like every other
@@ -242,19 +177,23 @@ fn texture<'a>(win: &'a mut Qo100WinState, ctx: &egui::Context, palette: usize) 
     win.tex.as_ref()
 }
 
-/// Draw the strip and handle its one gesture — a double-click picks a beacon
-/// by hand. Returns the picked frequency, if any.
+/// Draw the strip: the target line, and — while the decoder has a lock —
+/// where it actually found the beacon. Purely visual; nothing here is read
+/// back, unlike the version of this window that used to hunt a magnitude
+/// peak in it (see the module doc for why that never worked on this signal).
 fn paint_strip(
     ui: &mut egui::Ui,
     win: &mut Qo100WinState,
     frame: Option<&SpectrumFrame>,
     palette: usize,
-) -> Option<f64> {
-    let (lo, hi) = (BEACON_HZ - HALF_WIDTHS[win.hw_idx], BEACON_HZ + HALF_WIDTHS[win.hw_idx]);
+    lo: f64,
+    hi: f64,
+    measured_hz: Option<f64>,
+) {
     let (rect, resp) =
-        ui.allocate_exact_size(Vec2::new(ui.available_width(), STRIP_H), Sense::click());
+        ui.allocate_exact_size(Vec2::new(ui.available_width(), STRIP_H), Sense::hover());
     if !ui.is_rect_visible(rect) {
-        return None;
+        return;
     }
     let painter = ui.painter_at(rect);
     painter.rect_filled(rect, 2.0, Color32::BLACK);
@@ -276,20 +215,19 @@ fn paint_strip(
         rect.left() + ((hz - lo) / (hi - lo)).clamp(0.0, 1.0) as f32 * rect.width()
     };
     // The target: where the beacon belongs.
-    let tx = x_of(BEACON_HZ);
+    let tx = x_of(QO100_BEACON_HZ);
     painter.line_segment(
         [Pos2::new(tx, rect.top()), Pos2::new(tx, rect.bottom())],
         Stroke::new(1.0, theme::CYAN()),
     );
-    // Where it was actually found (or picked).
-    if let Some(m) = win.measured_hz
+    // Where the decoder actually locked, while that lock is still fresh.
+    if let Some(m) = measured_hz
         && (lo..=hi).contains(&m)
     {
         let mx = x_of(m);
-        let colour = if win.manual_pick { theme::YELLOW() } else { theme::GREEN() };
         painter.line_segment(
             [Pos2::new(mx, rect.top()), Pos2::new(mx, rect.bottom())],
-            Stroke::new(1.6, colour),
+            Stroke::new(1.6, theme::GREEN()),
         );
     }
 
@@ -310,14 +248,7 @@ fn paint_strip(
         dim,
     );
     crate::chrome::paint_cut_border(&painter, rect, theme::LINE_LIT(), theme::PANEL());
-
-    if resp.hovered() {
-        ui.ctx().set_cursor_icon(egui::CursorIcon::Crosshair);
-    }
-    resp.double_clicked()
-        .then(|| resp.interact_pointer_pos())
-        .flatten()
-        .map(|p| lo + ((p.x - rect.left()) / rect.width()).clamp(0.0, 1.0) as f64 * (hi - lo))
+    let _ = resp; // hover-only; kept so `ui.allocate_exact_size` reserves layout the usual way
 }
 
 impl SdroxideApp {
@@ -332,7 +263,7 @@ impl SdroxideApp {
             .open(&mut open)
             .frame(crate::chrome::window_frame())
             .resizable(true)
-            .default_width(crate::layout::window_w(ctx, 420.0))
+            .default_width(crate::layout::window_w(ctx, 440.0))
             .show(ctx, |ui| {
                 crate::chrome::window_body_bg(ui);
                 self.qo100_body(ui, &mut win, cmds)
@@ -345,31 +276,45 @@ impl SdroxideApp {
     }
 
     fn qo100_body(&mut self, ui: &mut egui::Ui, win: &mut Qo100WinState, cmds: &mut Vec<Command>) {
-        let reachable = self.caps.as_ref().is_none_or(|c| c.can_rx_hz(BEACON_HZ));
+        let reachable = self.caps.as_ref().is_none_or(|c| c.can_rx_hz(QO100_BEACON_HZ));
         let frame = self.frame.clone();
-        let (lo, hi) = (BEACON_HZ - HALF_WIDTHS[win.hw_idx], BEACON_HZ + HALF_WIDTHS[win.hw_idx]);
+        // Edited in place and sent whole on any change, the same convention
+        // the ISM window follows for `IsmSettings` — the engine persists this
+        // and echoes it back, so there is no separate apply step.
+        let mut cfg = self.state.qo100;
+        let (lo, hi) = (
+            QO100_BEACON_HZ - cfg.search_half_width_hz,
+            QO100_BEACON_HZ + cfg.search_half_width_hz,
+        );
         // Whether whatever the receiver is *actually* capturing right now
         // reaches anywhere near the beacon at all — as against `reachable`,
         // which asks whether it ever could. A capable receiver still shows a
         // blank strip while it is parked on 144 MHz, and that is the second
         // most likely reason (after no converter at all) this window opens on
-        // an empty waterfall.
+        // an empty waterfall. This only judges the *mini waterfall*'s own
+        // picture — the decoder itself reads the raw IQ straight from the
+        // hardware and does not depend on the main dial being anywhere near
+        // the beacon at all, only on the beacon being inside what the
+        // hardware actually captures.
         let in_view = frame.as_deref().is_some_and(|f| bin_range(f, lo, hi).is_some());
         let dial_hz = self.state.active_freq_hz();
+        let status = self.qo100_status.clone();
 
         ui.horizontal(|ui| {
             let run = crate::chrome::chip_enabled(
                 ui,
                 reachable,
-                win.tracking,
-                if win.tracking { "ON" } else { "OFF" },
+                cfg.enabled,
+                if cfg.enabled { "ON" } else { "OFF" },
             );
             if run.clicked() {
-                win.tracking = !win.tracking;
-                if win.tracking {
-                    cmds.push(Command::SetVfo { vfo: Vfo::A, hz: BEACON_HZ });
-                } else {
-                    win.manual_pick = false;
+                cfg.enabled = !cfg.enabled;
+                if cfg.enabled {
+                    // Visual convenience only — the decoder reads raw IQ
+                    // straight off the hardware and works regardless of
+                    // where the main dial happens to be, as long as the
+                    // beacon is inside what the hardware actually captures.
+                    cmds.push(Command::SetVfo { vfo: Vfo::A, hz: QO100_BEACON_HZ });
                 }
             }
             if !reachable {
@@ -378,25 +323,31 @@ impl SdroxideApp {
                      LNB/converter offset first (Settings ▸ Radio)",
                 );
             } else {
-                run.on_hover_text("Tune to the beacon and hunt its centre frequency");
+                run.on_hover_text(
+                    "Demodulate the beacon's own BPSK-400 telemetry and measure exactly how far \
+                     it sits from 10489.750 MHz",
+                );
             }
 
             ui.add_space(8.0);
             ui.label(RichText::new("width").size(10.0).color(theme::CYAN_DIM()));
-            if ui.small_button("−").on_hover_text("Narrower — search a smaller slice").clicked() {
-                win.hw_idx = win.hw_idx.saturating_sub(1);
+            if ui.small_button("−").on_hover_text("Narrower — search a smaller slice").clicked()
+            {
+                cfg.search_half_width_hz =
+                    (cfg.search_half_width_hz - WIDTH_STEP_HZ).max(MIN_HALF_WIDTH_HZ);
             }
             ui.label(
-                RichText::new(format!("±{:.0} kHz", HALF_WIDTHS[win.hw_idx] / 1000.0))
+                RichText::new(format!("±{:.0} kHz", cfg.search_half_width_hz / 1000.0))
                     .size(11.0)
                     .monospace(),
             );
             if ui
                 .small_button("+")
-                .on_hover_text("Wider — for when the beacon isn't visible at the current width")
+                .on_hover_text("Wider — for when the beacon isn't found at the current width")
                 .clicked()
             {
-                win.hw_idx = (win.hw_idx + 1).min(HALF_WIDTHS.len() - 1);
+                cfg.search_half_width_hz =
+                    (cfg.search_half_width_hz + WIDTH_STEP_HZ).min(MAX_HALF_WIDTH_HZ);
             }
         });
 
@@ -423,29 +374,30 @@ impl SdroxideApp {
         }
 
         // The receiver *can* reach the beacon but currently is not — parked
-        // on some other band, most often. The strip has nothing to show
-        // either way, but here the fix is one click rather than a trip to
-        // Settings, and worth naming exactly where the dial actually is.
+        // on some other band, most often. Only the *mini waterfall* has
+        // nothing to show either way; the decoder itself is unaffected (see
+        // `in_view`'s own doc), so this is about the picture, not the search.
         if reachable && !in_view {
             ui.add_space(4.0);
             ui.horizontal_wrapped(|ui| {
                 ui.label(
                     RichText::new(format!(
                         "The receiver is currently listening around {:.6} MHz — nowhere near the \
-                         10489.750 MHz beacon, so there is nothing here to show.",
+                         10489.750 MHz beacon, so there is nothing here to draw. The decoder keeps \
+                         searching regardless.",
                         dial_hz / 1e6
                     ))
                     .size(10.5)
                     .color(theme::YELLOW()),
                 );
                 if ui.small_button("Tune to 10489.750 MHz").clicked() {
-                    cmds.push(Command::SetVfo { vfo: Vfo::A, hz: BEACON_HZ });
+                    cmds.push(Command::SetVfo { vfo: Vfo::A, hz: QO100_BEACON_HZ });
                 }
             });
         }
 
         if let Some(f) = self.frame.as_ref() {
-            let capped = f.span_hz / 2.0 < HALF_WIDTHS[win.hw_idx];
+            let capped = f.span_hz / 2.0 < cfg.search_half_width_hz;
             if capped && f.span_hz > 0.0 {
                 ui.label(
                     RichText::new(format!(
@@ -459,28 +411,26 @@ impl SdroxideApp {
         }
 
         ui.add_space(4.0);
-        let picked = paint_strip(ui, win, frame.as_deref(), self.ui_settings.waterfall_palette);
-        if let Some(hz) = picked {
-            win.measured_hz = Some(hz);
-            win.manual_pick = true;
-        } else if win.tracking && !win.manual_pick {
-            win.measured_hz = frame
-                .as_deref()
-                .and_then(|f| bin_range(f, lo, hi).and_then(|r| find_peak(f, r)))
-                .map(|(hz, _)| hz);
-        } else if !win.tracking {
-            win.measured_hz = None;
-        }
+        let measured_hz = locked_freq(status.as_ref());
+        paint_strip(
+            ui,
+            win,
+            frame.as_deref(),
+            self.ui_settings.waterfall_palette,
+            lo,
+            hi,
+            measured_hz,
+        );
 
         ui.add_space(6.0);
         ui.label(
-            RichText::new(if win.manual_pick { "picked by hand — double-click again to repick" } else { "" })
+            RichText::new(status_line(cfg.enabled, status.as_ref()))
                 .size(9.5)
                 .color(theme::CYAN_DIM()),
         );
 
-        let cfg = self.ctrl.radio_config();
-        let old_offset = cfg.as_ref().map(|c| c.converter_offset_hz).unwrap_or(0.0);
+        let radio_cfg = self.ctrl.radio_config();
+        let old_offset = radio_cfg.as_ref().map(|c| c.converter_offset_hz).unwrap_or(0.0);
 
         egui::Grid::new("qo100-grid").num_columns(2).spacing([16.0, 3.0]).show(ui, |ui| {
             let dim = |s: &str| RichText::new(s).size(9.5).color(theme::CYAN_DIM());
@@ -497,16 +447,18 @@ impl SdroxideApp {
             ui.end_row();
 
             ui.label(dim("TARGET"));
-            ui.label(RichText::new(format!("{:.6} MHz", BEACON_HZ / 1e6)).size(12.0).monospace());
+            ui.label(
+                RichText::new(format!("{:.6} MHz", QO100_BEACON_HZ / 1e6)).size(12.0).monospace(),
+            );
             ui.end_row();
 
             ui.label(dim("MEASURED"));
-            match win.measured_hz {
+            match measured_hz {
                 Some(hz) => ui.label(
                     RichText::new(format!("{:.6} MHz", hz / 1e6)).size(12.0).monospace().strong(),
                 ),
                 None => ui.label(
-                    RichText::new(if win.tracking { "not found — try a wider width" } else { "—" })
+                    RichText::new(if cfg.enabled { "not locked yet" } else { "—" })
                         .size(11.0)
                         .color(theme::CYAN_DIM()),
                 ),
@@ -514,9 +466,9 @@ impl SdroxideApp {
             ui.end_row();
 
             ui.label(dim("DRIFT"));
-            match win.measured_hz {
+            match measured_hz {
                 Some(hz) => {
-                    let err = hz - BEACON_HZ;
+                    let err = hz - QO100_BEACON_HZ;
                     let colour = if err.abs() < 200.0 {
                         theme::GREEN()
                     } else if err.abs() < 3000.0 {
@@ -535,9 +487,26 @@ impl SdroxideApp {
             ui.end_row();
         });
 
+        // The decoded telemetry text — the beacon's own status report, shown
+        // for its own sake and as independent confirmation the decode is
+        // real: garbage here despite a "locked" CRC would be a red flag no
+        // number above could catch.
+        if let Some(s) = status.as_ref().filter(|s| !s.text.is_empty()) {
+            ui.add_space(4.0);
+            ui.label(RichText::new("TELEMETRY").size(9.5).color(theme::CYAN_DIM()));
+            egui::Frame::new().fill(theme::INPUT_BG()).inner_margin(6.0).show(ui, |ui| {
+                ui.add(
+                    egui::Label::new(
+                        RichText::new(&s.text).monospace().size(10.5).color(theme::GREEN()),
+                    )
+                    .wrap(),
+                );
+            });
+        }
+
         ui.add_space(6.0);
         ui.horizontal(|ui| {
-            let can_apply = win.measured_hz.is_some() && cfg.is_some();
+            let can_apply = measured_hz.is_some() && radio_cfg.is_some();
             let apply = ui.add_enabled(
                 can_apply,
                 egui::Button::new(RichText::new(" APPLY CORRECTION ").strong()),
@@ -547,15 +516,15 @@ impl SdroxideApp {
                  interruption, the same one Settings ▸ Radio ▸ Apply makes",
             );
             if apply.clicked()
-                && let (Some(mut c), Some(measured)) = (cfg.clone(), win.measured_hz)
+                && let (Some(mut c), Some(measured)) = (radio_cfg.clone(), measured_hz)
             {
-                let new_offset = corrected_offset_hz(c.converter_offset_hz, measured, BEACON_HZ);
+                let new_offset =
+                    corrected_offset_hz(c.converter_offset_hz, measured, QO100_BEACON_HZ);
                 c.converter_offset_hz = new_offset;
                 self.ctrl.set_radio_config(c.clone());
                 self.ctrl.reopen_source();
                 self.radio_cfg = Some(c);
                 win.applied = Some((old_offset, new_offset, crate::time::now_unix()));
-                win.manual_pick = false;
             }
             if let Some((old, new, at)) = win.applied {
                 let ago = crate::time::now_unix() - at;
@@ -569,6 +538,46 @@ impl SdroxideApp {
                 );
             }
         });
+
+        if cfg != self.state.qo100 {
+            cmds.push(Command::SetQo100Config(cfg));
+        }
+    }
+}
+
+/// The beacon's dial-domain frequency while the decoder's lock is still
+/// fresh — `None` once it has gone stale (see
+/// [`sdroxide_types::Qo100Status::locked`]'s own doc for how long that grace
+/// period is) or if the decoder has never locked at all.
+fn locked_freq(status: Option<&Qo100Status>) -> Option<f64> {
+    status.filter(|s| s.locked).map(|s| QO100_BEACON_HZ + s.offset_hz)
+}
+
+/// The one-line summary under the strip: off, searching (with how many
+/// blocks it has tried), or locked — the same "attempted vs. succeeded"
+/// distinction `IsmStatus`'s bursts/decodes line exists for, so a search
+/// that is running but has not found the beacon yet reads differently from
+/// one that never started.
+fn status_line(enabled: bool, status: Option<&Qo100Status>) -> String {
+    if !enabled {
+        return String::new();
+    }
+    match status {
+        None => "starting…".to_string(),
+        Some(s) if s.locked => {
+            format!(
+                "locked — {} block{} tried, {} locked",
+                s.blocks_tried,
+                if s.blocks_tried == 1 { "" } else { "s" },
+                s.blocks_locked
+            )
+        }
+        Some(s) if s.blocks_tried == 0 => "searching — first block takes about 10 s".to_string(),
+        Some(s) => format!(
+            "searching — {} block{} tried, none locked yet",
+            s.blocks_tried,
+            if s.blocks_tried == 1 { "" } else { "s" }
+        ),
     }
 }
 
@@ -578,24 +587,24 @@ mod tests {
 
     #[test]
     fn a_beacon_read_high_needs_the_offset_raised() {
-        // Beacon really sits on BEACON_HZ but reads 5 kHz high — the LNB's LO
-        // is 5 kHz low, which the software currently under-subtracts.
+        // Beacon really sits on QO100_BEACON_HZ but reads 5 kHz high — the
+        // LNB's LO is 5 kHz low, which the software currently under-subtracts.
         let old = -9_750_000_000.0;
-        let measured = BEACON_HZ + 5_000.0;
-        assert_eq!(corrected_offset_hz(old, measured, BEACON_HZ), old + 5_000.0);
+        let measured = QO100_BEACON_HZ + 5_000.0;
+        assert_eq!(corrected_offset_hz(old, measured, QO100_BEACON_HZ), old + 5_000.0);
     }
 
     #[test]
     fn a_beacon_read_low_needs_the_offset_lowered() {
         let old = -9_750_000_000.0;
-        let measured = BEACON_HZ - 1_200.0;
-        assert_eq!(corrected_offset_hz(old, measured, BEACON_HZ), old - 1_200.0);
+        let measured = QO100_BEACON_HZ - 1_200.0;
+        assert_eq!(corrected_offset_hz(old, measured, QO100_BEACON_HZ), old - 1_200.0);
     }
 
     #[test]
     fn a_correctly_calibrated_station_gets_the_same_offset_back() {
         let old = -9_750_000_000.0;
-        assert_eq!(corrected_offset_hz(old, BEACON_HZ, BEACON_HZ), old);
+        assert_eq!(corrected_offset_hz(old, QO100_BEACON_HZ, QO100_BEACON_HZ), old);
     }
 
     fn frame_with(center_hz: f64, span_hz: f64, bins: Vec<u8>) -> SpectrumFrame {
@@ -603,50 +612,47 @@ mod tests {
     }
 
     #[test]
-    fn a_flat_peak_lands_on_its_own_bin_centre() {
-        // A symmetric peak (equal neighbours) has no reason to shift either
-        // way: the parabola through equal shoulders is flat at the top.
-        let mut bins = vec![20u8; 64];
-        bins[32] = 200;
-        bins[31] = 120;
-        bins[33] = 120;
-        let frame = frame_with(10_489_750_000.0, 640_000.0, bins);
-        let (hz, snr) = find_peak(&frame, 0..64).expect("clears SNR_DB");
-        assert!(snr > SNR_DB);
-        let expected = frame.freq_at_bin(32);
-        assert!((hz - expected).abs() < 1.0, "expected {expected}, got {hz}");
-    }
-
-    #[test]
-    fn a_lopsided_peak_is_pulled_toward_its_stronger_shoulder() {
-        let mut bins = vec![20u8; 64];
-        bins[32] = 200;
-        bins[31] = 100;
-        bins[33] = 160; // stronger on the high side — true peak sits above bin 32
-        let frame = frame_with(10_489_750_000.0, 640_000.0, bins);
-        let (hz, _) = find_peak(&frame, 0..64).expect("clears SNR_DB");
-        assert!(hz > frame.freq_at_bin(32));
-    }
-
-    #[test]
-    fn a_flat_noise_floor_reports_no_beacon() {
-        let bins = vec![40u8; 64];
-        let frame = frame_with(10_489_750_000.0, 640_000.0, bins);
-        assert!(find_peak(&frame, 0..64).is_none());
-    }
-
-    #[test]
     fn bin_range_refuses_a_window_the_frame_never_reaches() {
         let frame = frame_with(14_000_000.0, 100_000.0, vec![0u8; 64]);
-        assert!(bin_range(&frame, BEACON_HZ - 5_000.0, BEACON_HZ + 5_000.0).is_none());
+        assert!(bin_range(&frame, QO100_BEACON_HZ - 5_000.0, QO100_BEACON_HZ + 5_000.0).is_none());
     }
 
     #[test]
     fn bin_range_clamps_to_what_the_frame_actually_covers() {
         // Requested window straddles the frame's edge; the range returned
         // must stay inside 0..bins.len().
-        let frame = frame_with(BEACON_HZ + 3_000.0, 10_000.0, vec![0u8; 100]);
-        let r = bin_range(&frame, BEACON_HZ - 5_000.0, BEACON_HZ + 5_000.0).expect("overlaps");
+        let frame = frame_with(QO100_BEACON_HZ + 3_000.0, 10_000.0, vec![0u8; 100]);
+        let r = bin_range(&frame, QO100_BEACON_HZ - 5_000.0, QO100_BEACON_HZ + 5_000.0)
+            .expect("overlaps");
         assert!(r.end <= 100);
+    }
+
+    fn status(locked: bool, offset_hz: f64) -> Qo100Status {
+        Qo100Status { running: true, locked, offset_hz, ..Default::default() }
+    }
+
+    #[test]
+    fn locked_freq_reads_off_the_target_plus_the_measured_offset() {
+        let s = status(true, 1_234.0);
+        assert_eq!(locked_freq(Some(&s)), Some(QO100_BEACON_HZ + 1_234.0));
+    }
+
+    #[test]
+    fn locked_freq_is_none_when_not_locked_or_absent() {
+        assert_eq!(locked_freq(None), None);
+        assert_eq!(locked_freq(Some(&status(false, 0.0))), None);
+    }
+
+    #[test]
+    fn status_line_is_blank_while_switched_off() {
+        assert_eq!(status_line(false, Some(&status(true, 0.0))), "");
+    }
+
+    #[test]
+    fn status_line_distinguishes_locked_from_still_searching() {
+        assert!(status_line(true, Some(&status(true, 0.0))).starts_with("locked"));
+        let mut searching = status(false, 0.0);
+        searching.blocks_tried = 3;
+        assert!(status_line(true, Some(&searching)).starts_with("searching"));
     }
 }

--- a/crates/sdroxide-ui/src/app/top_bar.rs
+++ b/crates/sdroxide-ui/src/app/top_bar.rs
@@ -1298,16 +1298,11 @@ impl SdroxideApp {
     /// itself each earn the column on their own — the offset so the column is
     /// there *before* the operator tunes up rather than appearing mid-digit.
     fn readout_digits(&self) -> u32 {
-        let range_reaches =
+        let range_reaches_10ghz =
             self.caps.as_ref().is_some_and(|c| c.freq_ranges_rx.iter().any(|&(_, hi)| hi >= 1e10));
-        let converter_reaches =
-            self.radio_cfg.as_ref().is_some_and(|c| c.converter_offset_hz.abs() >= 1e10);
-        let dial_reaches = self.state.active_freq_hz() >= 1e10;
-        if range_reaches || converter_reaches || dial_reaches {
-            freq_display::DIGITS_EXT
-        } else {
-            freq_display::DIGITS
-        }
+        let converter_offset_hz =
+            self.radio_cfg.as_ref().map(|c| c.converter_offset_hz).unwrap_or(0.0);
+        readout_digit_count(range_reaches_10ghz, converter_offset_hz, self.state.active_freq_hz())
     }
 
     /// The VFO frequency controls (A/B select + big readout + the inactive
@@ -5022,6 +5017,35 @@ fn sub_mode_picker(ui: &mut egui::Ui, cur: Mode, narrow: bool) -> Option<Mode> {
     picked
 }
 
+/// How many digit columns the frequency readout needs: [`freq_display::DIGITS`]
+/// normally, [`freq_display::DIGITS_EXT`] once anything puts a real digit in the
+/// ten-GHz column. Three independent tells, any one of them enough:
+///
+/// * `range_reaches_10ghz` — the receiver's published receive range (already
+///   shifted by the configured converter/LNB offset) reaches 10 GHz or past it.
+/// * `converter_offset_hz` — a 3-cm / 10 GHz converter is configured (LNB LO
+///   9750–10600 MHz, i.e. `|offset|` of about 9.75 GHz and up — a QO-100
+///   station's is 9.75 GHz exactly, well short of 10 GHz), so the column is
+///   there *before* the operator tunes up rather than appearing mid-digit. A
+///   driver that publishes no ranges at all (SoapySDR makes that optional)
+///   leaves the first tell blind, and this is what still earns that station
+///   its column. The `9e9` cut clears every 3-cm converter and stays above
+///   the next transverter down (13 cm, ~2.3 GHz).
+/// * `active_freq_hz` — the dial is already up there, converter or not (a
+///   wideband direct sampler, a paired panadapter).
+///
+/// Without the extra column the dial reading 10489.750 MHz has nowhere to put
+/// its leading "1" and is silently shown as "0489.750.000".
+fn readout_digit_count(
+    range_reaches_10ghz: bool,
+    converter_offset_hz: f64,
+    active_freq_hz: f64,
+) -> u32 {
+    let earns_extra =
+        range_reaches_10ghz || converter_offset_hz.abs() >= 9e9 || active_freq_hz >= 1e10;
+    if earns_extra { freq_display::DIGITS_EXT } else { freq_display::DIGITS }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -6372,5 +6396,44 @@ mod tests {
                 }
             }
         }
+    }
+
+    #[test]
+    fn the_readout_stays_at_ten_columns_for_an_ordinary_station() {
+        // No range past 10 GHz, no converter, dial on HF / VHF / 23 cm.
+        assert_eq!(readout_digit_count(false, 0.0, 14_074_000.0), freq_display::DIGITS);
+        assert_eq!(readout_digit_count(false, 0.0, 1_296_000_000.0), freq_display::DIGITS);
+        // A 13 cm transverter (~2.256 GHz offset) is the nearest converter
+        // below a 3 cm one and must not trip the extra column.
+        assert_eq!(readout_digit_count(false, -2_256_000_000.0, 144_000_000.0), freq_display::DIGITS);
+    }
+
+    #[test]
+    fn a_qo100_converter_offset_earns_the_eleventh_column_before_the_dial_moves() {
+        // A QO-100 LNB down-converts by 9.75 GHz — short of 10 GHz, which is
+        // why the cut is 9e9 — while the dial is still parked on HF and the
+        // driver may publish no ranges at all. The column has to be there
+        // already, or it appears mid-digit the moment the operator tunes up.
+        assert_eq!(
+            readout_digit_count(false, -9_750_000_000.0, 14_074_000.0),
+            freq_display::DIGITS_EXT
+        );
+        // A 10 GHz-LO LNB (some 3 cm setups) too.
+        assert_eq!(
+            readout_digit_count(false, -10_000_000_000.0, 14_074_000.0),
+            freq_display::DIGITS_EXT
+        );
+    }
+
+    #[test]
+    fn a_dial_at_the_beacon_earns_the_column_on_its_own() {
+        // A wideband front end tuned straight to 10489.750 MHz, no converter —
+        // the exact reading the extra column exists to keep from truncating.
+        assert_eq!(readout_digit_count(false, 0.0, 10_489_750_000.0), freq_display::DIGITS_EXT);
+    }
+
+    #[test]
+    fn a_published_range_reaching_10_ghz_is_enough_by_itself() {
+        assert_eq!(readout_digit_count(true, 0.0, 14_074_000.0), freq_display::DIGITS_EXT);
     }
 }

--- a/crates/sdroxide-ui/src/app/top_bar.rs
+++ b/crates/sdroxide-ui/src/app/top_bar.rs
@@ -1290,10 +1290,24 @@ impl SdroxideApp {
     /// receiver that reaches 10 GHz on its own hardware (a wideband direct
     /// sampler, a paired panadapter) gets the same extra column without
     /// needing a converter to ask for it.
+    ///
+    /// The published range is not the only tell, though: a SoapySDR driver
+    /// that never implemented `getFrequencyRange` publishes an empty list, so
+    /// a 3-cm LNB station driven through one would still truncate its
+    /// 10489.750 MHz dial. So the configured converter offset and the dial
+    /// itself each earn the column on their own — the offset so the column is
+    /// there *before* the operator tunes up rather than appearing mid-digit.
     fn readout_digits(&self) -> u32 {
-        let reaches_10ghz =
+        let range_reaches =
             self.caps.as_ref().is_some_and(|c| c.freq_ranges_rx.iter().any(|&(_, hi)| hi >= 1e10));
-        if reaches_10ghz { freq_display::DIGITS_EXT } else { freq_display::DIGITS }
+        let converter_reaches =
+            self.radio_cfg.as_ref().is_some_and(|c| c.converter_offset_hz.abs() >= 1e10);
+        let dial_reaches = self.state.active_freq_hz() >= 1e10;
+        if range_reaches || converter_reaches || dial_reaches {
+            freq_display::DIGITS_EXT
+        } else {
+            freq_display::DIGITS
+        }
     }
 
     /// The VFO frequency controls (A/B select + big readout + the inactive

--- a/crates/sdroxide-ui/src/app/top_bar.rs
+++ b/crates/sdroxide-ui/src/app/top_bar.rs
@@ -192,22 +192,27 @@ const STRIP_PTT_TEXT: f32 = 17.0;
 
 /// What a digit size costs the frequency readout, and what size fits a width.
 ///
-/// The readout is ten fixed-width digits, three group separators and a " Hz"
-/// tail, spaced 1 pt apart — so its width is linear in the digit size, and one
-/// measurement of the live fonts gives the slope. Inverting that is what lets
-/// one formula serve a 360 pt phone and a 2560 pt desktop.
+/// The readout is `digits` fixed-width digits ([`freq_display::DIGITS`]
+/// normally, [`freq_display::DIGITS_EXT`] on a radio whose converter reaches
+/// past 10 GHz — see [`SdroxideApp::readout_digits`]), three group separators
+/// and a " Hz" tail, spaced 1 pt apart — so its width is linear in the digit
+/// size, and one measurement of the live fonts gives the slope. Inverting
+/// that is what lets one formula serve a 360 pt phone and a 2560 pt desktop.
 struct ReadoutFit {
     /// Width per point of digit size.
     per_pt: f32,
     /// Height per point of digit size.
     h_per_pt: f32,
+    /// The 1 pt gaps between the readout's pieces — `digits` digits, 3 dots
+    /// and the " Hz" tail — added once rather than per point of size.
+    gaps: f32,
 }
 
 impl ReadoutFit {
     /// Everything up to the group separators scales with the digit size, and
     /// `freq_display` draws " Hz" at 0.3x it, so one reference measurement of
     /// each glyph is enough.
-    fn measure(ui: &egui::Ui) -> Self {
+    fn measure(ui: &egui::Ui, digits: u32) -> Self {
         const REF: f32 = 40.0;
         let w = |s: &str, f: egui::FontId| {
             ui.painter().layout_no_wrap(s.to_owned(), f, Color32::WHITE).size()
@@ -215,13 +220,17 @@ impl ReadoutFit {
         let digit = w("0", egui::FontId::monospace(REF));
         let dot = w(".", egui::FontId::monospace(REF)).x;
         let hz = w(" Hz", egui::FontId::proportional(REF)).x;
-        Self { per_pt: (10.0 * digit.x + 3.0 * dot + 0.3 * hz) / REF, h_per_pt: digit.y / REF }
+        Self {
+            per_pt: (digits as f32 * digit.x + 3.0 * dot + 0.3 * hz) / REF,
+            h_per_pt: digit.y / REF,
+            gaps: (digits + 3) as f32,
+        }
     }
 
     /// Width of the readout at `size`, including `freq_display`'s 1 pt spacing
-    /// between its fourteen pieces.
+    /// between its pieces.
     fn width(&self, size: f32) -> f32 {
-        size * self.per_pt + 13.0
+        size * self.per_pt + self.gaps
     }
 
     fn height(&self, size: f32) -> f32 {
@@ -231,7 +240,7 @@ impl ReadoutFit {
     /// The largest digit size whose readout fits `budget`. Uncapped and
     /// unfloored — callers clamp to their own limits.
     fn fit(&self, budget: f32) -> f32 {
-        (budget - 13.0) / self.per_pt
+        (budget - self.gaps) / self.per_pt
     }
 }
 
@@ -684,7 +693,7 @@ impl SdroxideApp {
         // strip against its own pane.
         let avail = ui.available_width();
         let gap = ui.spacing().item_spacing.x;
-        let fit = ReadoutFit::measure(ui);
+        let fit = ReadoutFit::measure(ui, self.readout_digits());
         // The readout keeps its design size wherever the row can hold it, and
         // shrinks against the full row where it cannot (a forced Desktop
         // layout on a narrow pane) — a box the packer cannot break up any
@@ -868,7 +877,7 @@ impl SdroxideApp {
         let div = self.has_diversity();
         let gap = ui.spacing().item_spacing.x;
         let chip_h = crate::chrome::chip_height(ui, None);
-        let fit = ReadoutFit::measure(ui);
+        let fit = ReadoutFit::measure(ui, self.readout_digits());
 
         let active = self.state.active_vfo;
         let tag = match active {
@@ -932,6 +941,7 @@ impl SdroxideApp {
                         shown,
                         plan.digit,
                         ink,
+                        self.readout_digits(),
                     ) {
                         cmds.push(Command::SetVfo { vfo: active, hz: hz - offset });
                     }
@@ -1268,6 +1278,24 @@ impl SdroxideApp {
         }
     }
 
+    /// How many digit columns the frequency readout needs: [`freq_display::DIGITS`]
+    /// on every radio this program reaches on its own, one more
+    /// ([`freq_display::DIGITS_EXT`]) once its published receive range —
+    /// already shifted by whatever converter/LNB offset is configured, see
+    /// `shift_caps` — reaches 10 GHz or past it. A QO-100 station is the case
+    /// this exists for: without it, the dial reading 10489.750 MHz has no
+    /// column for the leading "1" and silently shows "0489.750.000" instead.
+    ///
+    /// Read from the live capabilities rather than the offset alone, so a
+    /// receiver that reaches 10 GHz on its own hardware (a wideband direct
+    /// sampler, a paired panadapter) gets the same extra column without
+    /// needing a converter to ask for it.
+    fn readout_digits(&self) -> u32 {
+        let reaches_10ghz =
+            self.caps.as_ref().is_some_and(|c| c.freq_ranges_rx.iter().any(|&(_, hi)| hi >= 1e10));
+        if reaches_10ghz { freq_display::DIGITS_EXT } else { freq_display::DIGITS }
+    }
+
     /// The VFO frequency controls (A/B select + big readout + the inactive
     /// VFO's frequency) in a label-less box, always the first module.
     ///
@@ -1282,7 +1310,7 @@ impl SdroxideApp {
         cmds: &mut Vec<Command>,
         tier: crate::layout::Tier,
     ) -> bool {
-        let fit = ReadoutFit::measure(ui);
+        let fit = ReadoutFit::measure(ui, self.readout_digits());
         if tier == crate::layout::Tier::Phone {
             return self.freq_module_compact(ui, cmds, &fit);
         }
@@ -1399,6 +1427,7 @@ impl SdroxideApp {
                         self.input.cfg.wheel,
                         size,
                         ink,
+                        self.readout_digits(),
                     );
                 },
             );
@@ -1568,6 +1597,7 @@ impl SdroxideApp {
                 shown,
                 size,
                 ink,
+                self.readout_digits(),
             );
             if let Some(hz) = new_hz {
                 cmds.push(Command::SetVfo { vfo: active, hz: hz - offset });
@@ -4019,7 +4049,7 @@ impl SdroxideApp {
     /// The first five window chips — the condensed System box's top row.
     /// `extra` stretches each chip past its label; the popup passes 0.
     fn system_chips_top(&mut self, ui: &mut egui::Ui, extra: f32) {
-        let [log, spots, awards, bands, sat_label, ism, ..] = SYSTEM_CHIPS;
+        let [log, spots, awards, bands, sat_label, qo100_label, ism, ..] = SYSTEM_CHIPS;
         if chip_stretched(ui, self.show_logbook, log, extra)
             .on_hover_text("Logbook — all QSOs (digital + manual)")
             .clicked()
@@ -4070,6 +4100,29 @@ impl SdroxideApp {
             .clicked()
         {
             self.show_sat = !self.show_sat;
+        }
+        // Accented while the beacon hunt is running, like the satellite lock:
+        // it is worth knowing at a glance even with the window closed.
+        let qo100_chip = if self.qo100_win.tracking {
+            accent_chip_stretched(
+                ui,
+                true,
+                qo100_label,
+                crate::theme::GREEN(),
+                crate::theme::INK_ON_BRIGHT(),
+                extra,
+            )
+        } else {
+            chip_stretched(ui, self.show_qo100, qo100_label, extra)
+        };
+        if qo100_chip
+            .on_hover_text(
+                "QO-100 beacon — calibrate the LNB/converter offset against the 10489.750 MHz \
+                 beacon",
+            )
+            .clicked()
+        {
+            self.show_qo100 = !self.show_qo100;
         }
         // Accented while the decoder is actually running, like the scanner and
         // the satellite lock: it is spending CPU on four downconverters whether
@@ -4278,12 +4331,13 @@ impl PttPress {
 /// whatever crosses the window edge is lost. That is how SCAN, SETTINGS and
 /// HELP came to vanish on the layouts where the strip put this box near the
 /// end of a row.
-const SYSTEM_CHIPS: [&str; 11] = [
+const SYSTEM_CHIPS: [&str; 12] = [
     "LOG",
     "SPOTS",
     "AWARDS",
     "BANDS",
     "SAT",
+    "QO100",
     "ISM",
     "MAIL",
     "MEM",
@@ -4296,7 +4350,7 @@ const SYSTEM_CHIPS: [&str; 11] = [
 /// agree with the destructuring patterns in `system_chips_top` / `_bottom` —
 /// the array length pins both, so a chip added to the list forces all three
 /// to be revisited together.
-const SYSTEM_SPLIT: usize = 6;
+const SYSTEM_SPLIT: usize = 7;
 
 /// The Display box's top row: the solar view, then the chips that choose what
 /// the panadapter draws — the last of those only on a front end with a
@@ -5053,7 +5107,7 @@ mod tests {
     /// the shipped fonts; the assertions below are what that buys at each of
     /// the viewport widths the tiers were drawn for.
     fn shipped() -> ReadoutFit {
-        ReadoutFit { per_pt: 10.0 * 0.540 + 3.0 * 0.540 + 0.3 * 1.392, h_per_pt: 1.0 }
+        ReadoutFit { per_pt: 10.0 * 0.540 + 3.0 * 0.540 + 0.3 * 1.392, h_per_pt: 1.0, gaps: 13.0 }
     }
 
     #[test]
@@ -5936,7 +5990,7 @@ mod tests {
     /// that need an app to measure (the frequency readout's side columns) are
     /// priced at their design figures, which is what a desktop gets.
     fn cat_rig_strip_boxes(ui: &egui::Ui, mode: Mode) -> Vec<StripBox> {
-        let fit = ReadoutFit::measure(ui);
+        let fit = ReadoutFit::measure(ui, freq_display::DIGITS);
         let freq_w = 8.0
             + AB_W
             + 10.0

--- a/crates/sdroxide-ui/src/app/top_bar.rs
+++ b/crates/sdroxide-ui/src/app/top_bar.rs
@@ -4103,7 +4103,7 @@ impl SdroxideApp {
         }
         // Accented while the beacon hunt is running, like the satellite lock:
         // it is worth knowing at a glance even with the window closed.
-        let qo100_chip = if self.qo100_win.tracking {
+        let qo100_chip = if self.state.qo100.enabled {
             accent_chip_stretched(
                 ui,
                 true,

--- a/crates/sdroxide-ui/src/widgets/freq_display.rs
+++ b/crates/sdroxide-ui/src/widgets/freq_display.rs
@@ -244,11 +244,7 @@ fn edit_field(
         // the editor: the field spans what the digits spanned.
         let digits_w = ui
             .painter()
-            .layout_no_wrap(
-                digit_template(digits),
-                egui::FontId::monospace(size),
-                Color32::WHITE,
-            )
+            .layout_no_wrap(digit_template(digits), egui::FontId::monospace(size), Color32::WHITE)
             .size()
             .x;
         let resp = crate::chrome::field(

--- a/crates/sdroxide-ui/src/widgets/freq_display.rs
+++ b/crates/sdroxide-ui/src/widgets/freq_display.rs
@@ -10,6 +10,16 @@ use sdroxide_types::WheelSettings;
 /// The readout's design size, and the largest it is ever drawn at. Narrower
 /// layouts fit smaller digits into the room they have — see `freq_module`.
 pub const DIGIT_SIZE: f32 = 40.0;
+/// Digit columns the readout normally carries: enough for 9.999999999 GHz,
+/// which is every band this program reaches without a converter in front of
+/// the radio.
+pub const DIGITS: u32 = 10;
+/// One more than [`DIGITS`] — for a station whose LNB/converter puts real
+/// frequencies at or past 10 GHz, a QO-100 downlink chief among them. Callers
+/// decide which a radio needs; see `SdroxideApp::readout_digits`. Kept
+/// conditional rather than paid by every radio: the extra column costs the
+/// top strip a full digit's width, and the packer already runs tight.
+pub const DIGITS_EXT: u32 = 11;
 /// The lit digits' amber, shared by both readouts and the type-in field.
 ///
 /// The readout is the one number an operator reads from across the shack, so
@@ -23,7 +33,9 @@ fn digit_ink() -> Color32 {
     }
 }
 
-/// Shows `hz` as a 10-digit tunable readout. Returns `Some(new_hz)` on change.
+/// Shows `hz` as a `digits`-column tunable readout — [`DIGITS`] on every radio
+/// this program reaches without a converter, [`DIGITS_EXT`] on one whose
+/// LNB/converter offset puts it past 10 GHz. Returns `Some(new_hz)` on change.
 ///
 /// `wheel` supplies the operator's pointer preferences: `digit_wheel` turns the
 /// per-digit scroll stepping off for anyone who would rather scroll the page,
@@ -43,6 +55,7 @@ pub fn show(
     wheel: WheelSettings,
     size: f32,
     ink: Option<Color32>,
+    digits: u32,
 ) -> Option<f64> {
     let lit = ink.unwrap_or_else(digit_ink);
     let mut freq = hz.round().max(0.0) as i64;
@@ -50,8 +63,8 @@ pub fn show(
 
     ui.horizontal(|ui| {
         ui.spacing_mut().item_spacing.x = 1.0;
-        for p in (0..10u32).rev() {
-            if p < 9 && (p + 1) % 3 == 0 {
+        for p in (0..digits).rev() {
+            if p < digits - 1 && (p + 1) % 3 == 0 {
                 ui.add(Label::new(
                     RichText::new(".").monospace().size(size).color(crate::theme::gray(110)),
                 ));
@@ -126,20 +139,21 @@ fn zero_from_digit(freq: i64, step: i64) -> i64 {
 /// Losing the per-digit targets is also what lets the compact boxes shrink
 /// the digits below comfortable clicking size.
 ///
-/// Returns `Some(new_hz)` when a typed frequency is committed. `ink` is
-/// [`show`]'s.
+/// Returns `Some(new_hz)` when a typed frequency is committed. `ink` and
+/// `digits` are [`show`]'s.
 pub fn show_typed(
     ui: &mut Ui,
     id: egui::Id,
     hz: f64,
     size: f32,
     ink: Option<Color32>,
+    digits: u32,
 ) -> Option<f64> {
     let edit_id = id.with("edit");
     match ui.data(|d| d.get_temp::<String>(edit_id)) {
-        Some(text) => edit_field(ui, id, edit_id, text, size),
+        Some(text) => edit_field(ui, id, edit_id, text, size, digits),
         None => {
-            show_dial(ui, id, edit_id, hz, size, ink);
+            show_dial(ui, id, edit_id, hz, size, ink, digits);
             None
         }
     }
@@ -154,14 +168,15 @@ fn show_dial(
     hz: f64,
     size: f32,
     ink: Option<Color32>,
+    digits: u32,
 ) {
     let lit = ink.unwrap_or_else(digit_ink);
     let freq = hz.round().max(0.0) as i64;
     let row = ui
         .horizontal(|ui| {
             ui.spacing_mut().item_spacing.x = 1.0;
-            for p in (0..10u32).rev() {
-                if p < 9 && (p + 1) % 3 == 0 {
+            for p in (0..digits).rev() {
+                if p < digits - 1 && (p + 1) % 3 == 0 {
                     ui.add(Label::new(
                         RichText::new(".").monospace().size(size).color(crate::theme::gray(110)),
                     ));
@@ -197,6 +212,21 @@ fn show_dial(
     }
 }
 
+/// The digit-and-dot template a `digits`-column readout spans — "0.000.000.000"
+/// at [`DIGITS`], one more leading zero at [`DIGITS_EXT`]. Grouped the same way
+/// [`show`] draws it, so the template is always as wide as the dial it stands
+/// in for.
+fn digit_template(digits: u32) -> String {
+    let mut s = String::with_capacity(digits as usize + 3);
+    for p in (0..digits).rev() {
+        if p < digits - 1 && (p + 1) % 3 == 0 {
+            s.push('.');
+        }
+        s.push('0');
+    }
+    s
+}
+
 /// The type-in field the dial turns into, in the dial's own font and ink.
 fn edit_field(
     ui: &mut Ui,
@@ -204,17 +234,18 @@ fn edit_field(
     edit_id: egui::Id,
     mut text: String,
     size: f32,
+    digits: u32,
 ) -> Option<f64> {
     let field_id = id.with("field");
     let mut out = None;
     ui.horizontal(|ui| {
         ui.spacing_mut().item_spacing.x = 1.0;
         // Sized so the box the dial sits in does not move when it turns into
-        // the editor: the field spans what the ten digits spanned.
+        // the editor: the field spans what the digits spanned.
         let digits_w = ui
             .painter()
             .layout_no_wrap(
-                "0.000.000.000".to_owned(),
+                digit_template(digits),
                 egui::FontId::monospace(size),
                 Color32::WHITE,
             )
@@ -246,7 +277,7 @@ fn edit_field(
         // editor; only Enter carrying a parsable number tunes anything.
         let done = resp.lost_focus();
         if done && ui.input(|i| i.key_pressed(egui::Key::Enter)) {
-            out = parse_mhz(&text);
+            out = parse_mhz(&text, digits);
         }
         if done {
             ui.data_mut(|d| d.remove_temp::<String>(edit_id));
@@ -266,11 +297,19 @@ fn format_mhz(hz: f64) -> String {
 }
 
 /// A typed MHz value as Hz. Accepts the decimal comma half the world types.
-/// `None` — nothing to tune to — for anything unparsable or out of all range.
-fn parse_mhz(s: &str) -> Option<f64> {
+/// `None` — nothing to tune to — for anything unparsable or out of range for
+/// `digits` columns (`1e`*`digits`* Hz and up — [`DIGITS`] refuses 10 GHz and
+/// past it, [`DIGITS_EXT`] refuses 100 GHz and past it).
+///
+/// Gated by `digits` rather than a single generous ceiling: accepting a
+/// number the *resting* dial cannot hold would just have `show_dial` truncate
+/// it silently right back to a wrong-looking readout the moment focus left
+/// the field — the same corruption naming `digits` here exists to prevent.
+fn parse_mhz(s: &str, digits: u32) -> Option<f64> {
     let mhz: f64 = s.trim().replace(',', ".").parse().ok()?;
     let hz = (mhz * 1e6).round();
-    (hz.is_finite() && (0.0..1e10).contains(&hz)).then_some(hz)
+    let max = 10f64.powi(digits as i32);
+    (hz.is_finite() && (0.0..max).contains(&hz)).then_some(hz)
 }
 
 #[cfg(test)]
@@ -279,13 +318,23 @@ mod tests {
 
     #[test]
     fn typed_frequencies_parse_as_mhz() {
-        assert_eq!(parse_mhz("14.074"), Some(14_074_000.0));
-        assert_eq!(parse_mhz(" 7,1 "), Some(7_100_000.0), "decimal comma");
-        assert_eq!(parse_mhz("0.4776"), Some(477_600.0));
-        assert_eq!(parse_mhz(""), None);
-        assert_eq!(parse_mhz("ten"), None);
-        assert_eq!(parse_mhz("-7.1"), None, "a negative frequency is a typo");
-        assert_eq!(parse_mhz("1e7"), None, "10 THz is out of every range");
+        assert_eq!(parse_mhz("14.074", DIGITS), Some(14_074_000.0));
+        assert_eq!(parse_mhz(" 7,1 ", DIGITS), Some(7_100_000.0), "decimal comma");
+        assert_eq!(parse_mhz("0.4776", DIGITS), Some(477_600.0));
+        assert_eq!(parse_mhz("", DIGITS), None);
+        assert_eq!(parse_mhz("ten", DIGITS), None);
+        assert_eq!(parse_mhz("-7.1", DIGITS), None, "a negative frequency is a typo");
+        assert_eq!(parse_mhz("1e7", DIGITS), None, "10 THz is out of every range");
+    }
+
+    /// The QO-100 beacon (10489.75 MHz) is exactly the case [`DIGITS_EXT`]
+    /// exists for: refused at the normal digit count, where the resting dial
+    /// could not show it without silently dropping its leading digit, and
+    /// accepted once the radio's own converter has earned it the extra column.
+    #[test]
+    fn a_ten_gigahertz_frequency_needs_the_extended_digit_count() {
+        assert_eq!(parse_mhz("10489.75", DIGITS), None, "10 GHz+ needs DIGITS_EXT");
+        assert_eq!(parse_mhz("10489.75", DIGITS_EXT), Some(10_489_750_000.0));
     }
 
     #[test]
@@ -295,8 +344,22 @@ mod tests {
         assert_eq!(format_mhz(477_612.0), "0.477612");
         assert_eq!(format_mhz(0.0), "0");
         for hz in [14_074_000.0, 7_000_000.0, 477_612.0] {
-            assert_eq!(parse_mhz(&format_mhz(hz)), Some(hz), "prefill for {hz} did not round-trip");
+            assert_eq!(
+                parse_mhz(&format_mhz(hz), DIGITS),
+                Some(hz),
+                "prefill for {hz} did not round-trip"
+            );
         }
+    }
+
+    /// [`digit_template`] has to measure exactly as wide as what [`show`]
+    /// draws for the same `digits`, or the type-in field jumps sideways when
+    /// the dial turns into it — the whole reason it exists rather than a
+    /// literal.
+    #[test]
+    fn the_digit_template_groups_the_same_way_the_dial_does() {
+        assert_eq!(digit_template(DIGITS), "0.000.000.000");
+        assert_eq!(digit_template(DIGITS_EXT), "00.000.000.000");
     }
 
     #[test]

--- a/docs/USER_MANUAL.md
+++ b/docs/USER_MANUAL.md
@@ -112,6 +112,9 @@ or connects to a remote sdroxide server.
 - **ISM band decoder** — reads the unattended 868 MHz traffic around you and
   lists each device with its readings in real units. See
   [ISM band decoder](#5-ism-band-decoder).
+- **QO-100 beacon calibration** — decodes the 10489.750 MHz narrowband beacon,
+  measures how far your LNB has drifted, and writes the converter offset for
+  you. See [§2.21](#221-qo-100-beacon-calibration).
 - **Many radio backends:** SoapySDR devices, OpenHPSDR (Hermes/Metis) Ethernet
   SDRs, a TCI server (ExpertSDR3/Thetis), a SmartSDR radio (FlexRadio
   FLEX-6000/8000), RTL-SDR, RX-888, Airspy HF+ and SDRplay RSP receivers over
@@ -2039,6 +2042,76 @@ This is not `--record-iq` ([12](#12-command-line-reference)), which writes the
 raw IQ of the whole span — tens of megabytes a second — so that a band can be
 replayed offline. This records what came out of the receiver, at a size you can
 send to someone.
+
+### 2.21 QO-100 beacon calibration
+
+The QO-100 (Es'hail-2) narrowband transponder carries a beacon on its lower
+edge, at **10489.750 MHz**, that transmits AO-40 telemetry as 400 baud
+Manchester BPSK. Every ground station receives that beacon through an LNB, whose
+local oscillator is only roughly on frequency and drifts with temperature — so
+the dial and the signal disagree by a few kHz, and by different amounts on a
+cold morning and a warm afternoon. The **QO100** button in the System module
+opens a window that decodes the beacon, measures exactly how far it is from
+10489.750 MHz, and offers to write that figure into the converter/LNB offset in
+one click.
+
+> **Note:** like the skimmers and the ISM decoder, this is a wideband feature.
+> It needs a true IQ source and is unavailable when a CAT radio is feeding
+> demodulated audio.
+
+#### What the window shows
+
+- **ON / OFF** starts the decoder. It reads the raw IQ straight from the
+  hardware, so it works regardless of where the main dial is pointed, as long as
+  the beacon is inside the span the receiver is delivering — turning it on also
+  tunes VFO A to 10489.750 MHz as a convenience, nothing more. Like SCAN and
+  SAT, the button stays lit whenever the decoder is running, window open or not.
+  It is greyed out only if the receiver's own configuration says 10489.750 MHz
+  is unreachable — the usual cause is that no converter/LNB offset has been set
+  up yet (**Settings ▸ Radio ▸ Converter**).
+- **width ± / −** sets how far either side of 10489.750 MHz the search looks, in
+  5 kHz steps from ±5 to ±50 kHz. Start at the default ±5 kHz; widen it only if
+  the beacon is not found, which means the LNB is further off than usual. A
+  wider search asks the receiver for a wider capture and takes longer to sweep,
+  so it is not free — but the demodulator itself always runs at a fixed rate, so
+  even the widest setting stays comfortably ahead of real time.
+- The **mini waterfall** draws the slice of spectrum being searched, with the
+  measured beacon frequency marked once the decoder locks. It is only a picture:
+  if the receiver is parked on another band the strip is blank and the window
+  says so, but the decoder keeps working.
+- **RECEIVER / TARGET / MEASURED / DRIFT** are the dial frequency now, the
+  10489.750 MHz target, the frequency the beacon was actually found on, and the
+  difference. DRIFT is green within ±200 Hz, amber to ±3 kHz.
+- **TELEMETRY** shows the beacon's own decoded status text. It is there for its
+  own sake and as an independent check: a lock with a valid CRC but garbled text
+  is a warning that no number above would catch.
+- The status line under the strip is the honest measure, the same
+  "attempted vs. succeeded" idea as the ISM decoder's bursts/decoded line: the
+  first search window fills after about 24 seconds, then repeats, and a search
+  that is running but has not found the beacon reads differently from one that
+  never started.
+
+#### Applying the correction
+
+**APPLY CORRECTION** writes the corrected converter offset and reopens the
+receiver — the same brief interruption **Settings ▸ Radio ▸ Apply** makes, so a
+bad reading can never disturb a running receiver for more than that. The button
+stays disabled until the decoder has locked **twice** at the same frequency: a
+32-bit sync word matched within three bit errors and then a 16-bit CRC will pass
+by pure chance roughly once every couple of hours of searching, and one lock is
+not enough to change a setting on. After it is applied, the window shows what
+changed and when.
+
+Because the coded frames the beacon alternates with are not decoded, a lock
+lands roughly every 20 seconds rather than every 10 — which is normal and not a
+sign the beacon has gone away.
+
+#### Remote and browser clients
+
+The decoder runs on the machine the radio is on. Its readout is not sent to
+remote or browser clients yet, so on those the window opens, the strip draws
+from the shared spectrum, and the status line says the readout is local to the
+receiving station rather than sitting on "starting…".
 
 ---
 

--- a/docs/USER_MANUAL.md
+++ b/docs/USER_MANUAL.md
@@ -15,6 +15,7 @@ or connects to a remote sdroxide server.
 
 1. [Feature overview](#1-feature-overview)
 2. [Basic operation](#2-basic-operation)
+    - [2.21 QO-100 beacon calibration](#221-qo-100-beacon-calibration)
 3. [Digital modes (FT8, FT4, FT2, PSK31, RTTY, Olivia, THOR, FSQ, Hellschreiber, SSTV, RIFP, weather fax, JS8, RF Paint, WSPR, packet, APRS, ADS-B)](#3-digital-modes)
 4. [Skimmers (CW, PSK, RTTY)](#4-skimmers)
 5. [ISM band decoder (315 / 345 / 433 / 868 / 915 MHz devices)](#5-ism-band-decoder)
@@ -2054,6 +2055,15 @@ cold morning and a warm afternoon. The **QO100** button in the System module
 opens a window that decodes the beacon, measures exactly how far it is from
 10489.750 MHz, and offers to write that figure into the converter/LNB offset in
 one click.
+
+**In brief.** With an LNB or converter offset set up in the receiver for the
+QO-100 (Es'hail-2) geostationary satellite, the decoder searches a few kHz
+either side of 10489.750 MHz, locks onto the beacon there, and decodes its
+AO-40 telemetry. Having tuned itself onto the signal to get a clean decode, it
+then works out from the frequency it actually found the beacon on how far the
+LNB or receiver offset is in error, and **APPLY CORRECTION** writes the
+corrected figure back. This is the same task the QO-100 beacon plugin performs
+in SDR Console.
 
 > **Note:** like the skimmers and the ISM decoder, this is a wideband feature.
 > It needs a true IQ source and is unavailable when a CAT radio is feeding


### PR DESCRIPTION
when LNB or offset enabled in recever to work with QO-100 geostationay satellite , receiver locks to the beacon at 10489.750 Mhz, and also decodes the AO-40 telemetry from beacon and if succesfull decode is in place after automatically tuning the frequency for decode, it calculates the LNB or receiver offset error and corrects the frequency.
 Similar to QO-100 beacon plugin in SDR console