### PR TITLE
QO-100 beacon plugin: spectral tracker + auto-correct, opt-in AO-40 decode

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5182,6 +5182,7 @@ name = "sdroxide-qo100"
 version = "1.6.3"
 dependencies = [
  "crossbeam-channel",
+ "rustfft",
  "sdroxide-dsp",
  "sdroxide-types",
  "tracing",

--- a/crates/sdroxide-qo100/Cargo.toml
+++ b/crates/sdroxide-qo100/Cargo.toml
@@ -20,4 +20,5 @@ license.workspace = true
 sdroxide-types.workspace = true
 sdroxide-dsp.workspace = true
 crossbeam-channel.workspace = true
+rustfft.workspace = true
 tracing.workspace = true

--- a/crates/sdroxide-qo100/src/bpsk.rs
+++ b/crates/sdroxide-qo100/src/bpsk.rs
@@ -388,26 +388,38 @@ fn welch_psd(iq: &[Complex32], nfft: usize) -> Vec<f32> {
     acc
 }
 
-/// A coarse estimate of where the beacon's carrier sits, in Hz relative to
-/// the assumed centre (DC) — or `None` when the spectrum holds nothing shaped
-/// like the beacon.
+/// Where the beacon's carrier sits and how convincingly the spectrum said so.
+/// `hz` is relative to the assumed centre (DC).
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub(crate) struct CarrierEstimate {
+    pub hz: f64,
+    /// Depth of the central null between the two lobes, dB.
+    pub null_depth_db: f32,
+    /// Left/right evenness of the two lobes, 0..1.
+    pub symmetry: f32,
+    /// Lobe level over the scanned band's noise floor, dB.
+    pub snr_db: f32,
+}
+
+/// Scan `[lo_hz, hi_hz]` of `iq`'s power spectrum for the beacon's give-away
+/// shape and return the best match, or `None` when nothing in the band looks
+/// like it.
 ///
-/// The beacon is DBPSK + Manchester at 400 baud, so it shows in a spectrum
-/// not as a carrier peak but as a *pair* of lobes with a null between them at
-/// the carrier and another null near ±[`CHIP_RATE`] Hz further out (see the
-/// module doc). This scores every candidate centre across the whole captured
-/// span by exactly that shape — two shoulders up, a notch in the middle,
-/// quiet past the outer nulls, left/right symmetric — and returns the best
-/// only if it clears every part of that test by a margin. A bare carrier, an
-/// SSB signal or noise all fail it, so a `Some` here is worth seeding
-/// [`acquire`] with; being wrong could at worst reorder candidates it would
-/// have tried anyway.
-pub(crate) fn coarse_carrier_hz(
+/// The beacon is DBPSK + Manchester at 400 baud, so it shows not as a carrier
+/// peak but as a *pair* of lobes with a null between them at the carrier and
+/// another null near ±[`CHIP_RATE`] Hz further out (see the module doc). Every
+/// candidate centre is scored by exactly that shape — two shoulders up, a
+/// notch in the middle, quiet past the outer nulls, left/right symmetric — and
+/// the best is returned only if it clears every part of that test by a margin.
+/// A bare carrier, an SSB signal or noise all fail it. Anything in the band
+/// that is *not* two symmetric lobes is simply not what wins.
+pub(crate) fn estimate_carrier(
     iq: &[Complex32],
     rate_hz: f64,
-    search_half_width_hz: f64,
-) -> Option<f64> {
-    if rate_hz <= 0.0 || search_half_width_hz <= 0.0 {
+    lo_hz: f64,
+    hi_hz: f64,
+) -> Option<CarrierEstimate> {
+    if rate_hz <= 0.0 || hi_hz - lo_hz < 1_500.0 {
         return None;
     }
     // ~15–25 Hz bins: fine enough to resolve the ±CHIP_RATE null structure,
@@ -418,6 +430,8 @@ pub(crate) fn coarse_carrier_hz(
     }
     let psd = welch_psd(iq, nfft);
     let bin_hz = rate_hz / nfft as f64;
+    let edge = rate_hz * 0.47;
+    let (lo, hi) = (lo_hz.max(-edge), hi_hz.min(edge));
 
     // Linear PSD at a signed frequency, nearest bin, wrapping natural FFT
     // order; `None` past the transform's own edge.
@@ -427,10 +441,10 @@ pub(crate) fn coarse_carrier_hz(
         (0..nfft as i64).contains(&k).then(|| psd[k as usize])
     };
     // Mean linear PSD over `c ± [lo, hi]`, both sides together.
-    let band_mean = |c: f64, lo: f64, hi: f64| -> Option<f32> {
+    let band_mean = |c: f64, blo: f64, bhi: f64| -> Option<f32> {
         let (mut sum, mut n) = (0.0f32, 0u32);
-        let mut d = lo;
-        while d <= hi {
+        let mut d = blo;
+        while d <= bhi {
             if let (Some(a), Some(b)) = (at(c + d), at(c - d)) {
                 sum += a + b;
                 n += 2;
@@ -440,15 +454,11 @@ pub(crate) fn coarse_carrier_hz(
         (n > 0).then(|| sum / n as f32)
     };
 
-    // Scan the whole captured span, not just ±search_half_width_hz — finding
-    // a beacon the configured width does not cover is half the point.
-    let reach = (search_half_width_hz + 1_500.0).min(rate_hz * 0.47);
-
-    // A robust noise floor for the SNR gate: the median across the span, which
-    // the beacon's own two lobes cannot lift far.
+    // A robust noise floor for the SNR gate: the median across the scanned
+    // band, which the beacon's own two lobes cannot lift far.
     let mut span: Vec<f32> = Vec::new();
-    let mut f = -reach;
-    while f <= reach {
+    let mut f = lo;
+    while f <= hi {
         if let Some(p) = at(f) {
             span.push(p);
         }
@@ -461,9 +471,9 @@ pub(crate) fn coarse_carrier_hz(
     let floor = span[span.len() / 2].max(1e-20);
     let db = |x: f32| 10.0 * (x.max(1e-20) as f64).log10();
 
-    let mut best: Option<(f64, f64)> = None; // (score, fc)
-    let mut fc = -reach;
-    while fc <= reach {
+    let mut best: Option<(f64, CarrierEstimate)> = None; // (score, est)
+    let mut fc = lo;
+    while fc <= hi {
         if let (Some(lobe), Some(notch), Some(outer)) = (
             band_mean(fc, 200.0, 600.0),
             band_mean(fc, 0.0, 60.0),
@@ -492,13 +502,36 @@ pub(crate) fn coarse_carrier_hz(
                 let score =
                     null_depth.min(12.0) + lobe_excess.min(12.0) + snr.min(12.0) + 8.0 * sym;
                 if best.is_none_or(|(s, _)| score > s) {
-                    best = Some((score, fc));
+                    best = Some((
+                        score,
+                        CarrierEstimate {
+                            hz: fc,
+                            null_depth_db: null_depth as f32,
+                            symmetry: sym as f32,
+                            snr_db: snr as f32,
+                        },
+                    ));
                 }
             }
         }
         fc += bin_hz;
     }
-    best.map(|(_, fc)| fc)
+    best.map(|(_, e)| e)
+}
+
+/// A coarse carrier estimate across `±search_half_width_hz` (plus a little), in
+/// Hz relative to the assumed centre — the seed [`acquire`] starts its CRC
+/// sweep from. `None` when nothing beacon-shaped is in range.
+pub(crate) fn coarse_carrier_hz(
+    iq: &[Complex32],
+    rate_hz: f64,
+    search_half_width_hz: f64,
+) -> Option<f64> {
+    if search_half_width_hz <= 0.0 {
+        return None;
+    }
+    let reach = (search_half_width_hz + 1_500.0).min(rate_hz * 0.47);
+    estimate_carrier(iq, rate_hz, -reach, reach).map(|e| e.hz)
 }
 
 /// Search `iq` (complex baseband, `rate_hz` samples/s, the beacon assumed to
@@ -577,6 +610,108 @@ pub fn acquire(
         }
     }
     None
+}
+
+/// How far the last [`acquire_debug`] pass got, for the operator's
+/// step-by-step decoder readout. None of it gates anything — pure
+/// instrumentation, so a missing stage points straight at where the chain
+/// breaks.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub(crate) struct DecodeProgress {
+    /// The pass had chip-rate structure to work on — a twin-lobe estimate
+    /// landed, or the sync correlator found something close.
+    pub carrier: bool,
+    /// The 32-bit AO-40 sync word matched within [`SYNC_MAX_ERRORS`] somewhere.
+    pub sync: bool,
+    /// Fewest sync-word bit errors found, 0..=32; [`u8::MAX`] if no bitstream
+    /// was run at all.
+    pub sync_bit_errors: u8,
+    /// A CRC-valid frame was decoded.
+    pub crc_ok: bool,
+}
+
+impl Default for DecodeProgress {
+    fn default() -> Self {
+        Self { carrier: false, sync: false, sync_bit_errors: u8::MAX, crc_ok: false }
+    }
+}
+
+/// Fewest bit errors between [`SYNC_WORD`] and any 32-bit window of `bits`.
+fn min_sync_distance(bits: &[bool]) -> Option<u8> {
+    if bits.len() < SYNC_LEN as usize {
+        return None;
+    }
+    let mut window: u32 = 0;
+    let mut best = SYNC_LEN;
+    for (i, &b) in bits.iter().enumerate() {
+        window = (window << 1) | b as u32;
+        if i + 1 >= SYNC_LEN as usize {
+            best = best.min((window ^ SYNC_WORD).count_ones());
+        }
+    }
+    Some(best as u8)
+}
+
+/// The fewest sync-word bit errors any chip-timing/parity combination of
+/// `iq` (already mixed to one candidate) gets down to — a "how close was
+/// this" that does not need a CRC pass to mean something.
+fn sync_probe(iq: &[Complex32], rate_hz: f64) -> Option<u8> {
+    let samples_per_chip = rate_hz / CHIP_RATE;
+    if samples_per_chip < 2.0 {
+        return None;
+    }
+    let phase_step = (samples_per_chip / TIMING_PHASES as f64).max(1.0);
+    let mut best: Option<u8> = None;
+    for p in 0..TIMING_PHASES {
+        let phase = (p as f64 * phase_step) as usize;
+        let chips = chip_samples(iq, samples_per_chip, phase);
+        if chips.len() < 3 {
+            continue;
+        }
+        let flips = chip_flips(&chips);
+        for parity in 0..2 {
+            if let Some(d) = min_sync_distance(&data_bits(&flips, parity)) {
+                best = Some(best.map_or(d, |b| b.min(d)));
+            }
+        }
+    }
+    best
+}
+
+/// [`acquire`], plus a [`DecodeProgress`] snapshot of how far the pass got.
+/// The lock result and every frequency it searches are identical to
+/// `acquire`; the only extra work is one sync probe on the seed candidate
+/// when nothing locked.
+pub(crate) fn acquire_debug(
+    iq: &[Complex32],
+    rate_hz: f64,
+    search_half_width_hz: f64,
+    freq_step_hz: f64,
+    demod_rate_hz: f64,
+    cancel: &std::sync::atomic::AtomicBool,
+) -> (Option<Qo100Lock>, DecodeProgress) {
+    let lock = acquire(iq, rate_hz, search_half_width_hz, freq_step_hz, demod_rate_hz, cancel);
+    if lock.is_some() {
+        return (
+            lock,
+            DecodeProgress { carrier: true, sync: true, sync_bit_errors: 0, crc_ok: true },
+        );
+    }
+    let mut progress = DecodeProgress::default();
+    if rate_hz > 0.0 && demod_rate_hz > 0.0 {
+        let deci = (rate_hz / demod_rate_hz).round().max(1.0) as usize;
+        let dr = rate_hz / deci as f64;
+        let seed = coarse_carrier_hz(iq, rate_hz, search_half_width_hz);
+        let mixed = mix_decimate(iq, rate_hz, seed.unwrap_or(0.0), deci);
+        let dist = sync_probe(&mixed, dr);
+        if let Some(d) = dist {
+            progress.sync_bit_errors = d;
+            progress.sync = u32::from(d) <= SYNC_MAX_ERRORS;
+        }
+        progress.carrier =
+            seed.is_some() || progress.sync || dist.is_some_and(|d| u32::from(d) <= 10);
+    }
+    (lock, progress)
 }
 
 // `pub(crate)` so `controller`'s own test module can build a real on-air frame
@@ -932,5 +1067,59 @@ pub(crate) mod tests {
         let lock = acq(&iq, TEST_RATE, 150.0).expect("still locks");
         assert!((lock.offset_hz - 91.0).abs() <= 1.0, "found {}", lock.offset_hz);
         assert!(lock.text.starts_with("SEEDED NARROW"));
+    }
+
+    #[test]
+    fn estimate_carrier_finds_a_beacon_parked_in_a_positive_window() {
+        // Beacon parked at +12 kHz; a +5..+20 kHz window must find it and
+        // report a healthy null and symmetry.
+        let iq = stacked("PARKED", 60_000.0, 12_000.0, 0.05, 3, 3);
+        let e =
+            estimate_carrier(&iq, 60_000.0, 5_000.0, 20_000.0).expect("twin lobes in the window");
+        assert!((e.hz - 12_000.0).abs() <= 250.0, "hz {}", e.hz);
+        assert!(e.null_depth_db >= 2.5 && e.symmetry >= 0.55 && e.snr_db >= 3.0, "{e:?}");
+    }
+
+    #[test]
+    fn estimate_carrier_ignores_a_beacon_outside_the_window() {
+        // A real beacon at +2 kHz, but the window starts at +6 kHz.
+        let iq = stacked("OUTSIDE", 60_000.0, 2_000.0, 0.02, 4, 3);
+        assert!(estimate_carrier(&iq, 60_000.0, 6_000.0, 20_000.0).is_none());
+    }
+
+    #[test]
+    fn acquire_debug_lights_every_stage_on_a_clean_frame() {
+        let iq = synth_signal("PROGRESS", TEST_RATE, 40.0, 0.0, 1);
+        let (lock, p) = acquire_debug(
+            &iq,
+            TEST_RATE,
+            300.0,
+            TEST_STEP,
+            crate::controller::DEMOD_RATE_HZ,
+            &std::sync::atomic::AtomicBool::new(false),
+        );
+        assert!(lock.is_some());
+        assert!(p.carrier && p.sync && p.crc_ok, "{p:?}");
+        assert_eq!(p.sync_bit_errors, 0);
+    }
+
+    #[test]
+    fn acquire_debug_on_noise_reports_no_crc_and_ran_a_probe() {
+        let mut rng = TestRng::new(9);
+        let n = (TEST_RATE * 12.0) as usize;
+        let noise: Vec<Complex32> = (0..n)
+            .map(|_| Complex32::new(rng.range(-1.0, 1.0) as f32, rng.range(-1.0, 1.0) as f32))
+            .collect();
+        let (lock, p) = acquire_debug(
+            &noise,
+            TEST_RATE,
+            300.0,
+            TEST_STEP,
+            crate::controller::DEMOD_RATE_HZ,
+            &std::sync::atomic::AtomicBool::new(false),
+        );
+        assert!(lock.is_none());
+        assert!(!p.crc_ok);
+        assert_ne!(p.sync_bit_errors, u8::MAX, "the sync probe should still have run");
     }
 }

--- a/crates/sdroxide-qo100/src/bpsk.rs
+++ b/crates/sdroxide-qo100/src/bpsk.rs
@@ -702,25 +702,76 @@ fn sync_probe(iq: &[Complex32], rate_hz: f64) -> Option<u8> {
     best
 }
 
-/// [`acquire`], plus a [`DecodeProgress`] snapshot of how far the pass got.
-/// The lock result and every frequency it searches are identical to
-/// `acquire`; the only extra work is one sync probe on the seed candidate
-/// when nothing locked.
+/// De-rotate a linear frequency drift of `hz_per_s` out of `iq` (sample rate
+/// `rate_hz`), pivoting on the centre sample so only the *slope* is removed —
+/// the mean offset is left for [`acquire`]'s own grid to find. This is what
+/// lets a frame decode on a station whose LNB (or SDR clock) is still walking
+/// a few Hz a second while it warms up: without it the carrier smears across
+/// the 10.36 s frame and the payload CRC never checks out even though the
+/// sync word matches.
+fn dechirp(iq: &[Complex32], rate_hz: f64, hz_per_s: f64) -> Vec<Complex32> {
+    if hz_per_s == 0.0 || rate_hz <= 0.0 {
+        return iq.to_vec();
+    }
+    // Instantaneous frequency `hz_per_s * t` integrates to phase
+    // `PI * hz_per_s * t^2`; `t = (n - n0) / rate`. Multiply by its conjugate.
+    let n0 = iq.len() as f64 / 2.0;
+    let k = -std::f64::consts::PI * hz_per_s / (rate_hz * rate_hz);
+    iq.iter()
+        .enumerate()
+        .map(|(n, &z)| {
+            let d = n as f64 - n0;
+            let ph = k * d * d;
+            z * Complex32::new(ph.cos() as f32, ph.sin() as f32)
+        })
+        .collect()
+}
+
+/// Half-width and step, in Hz/s, of the drift grid [`acquire_debug`] tries
+/// around the caller's estimate. Wide enough to bracket a warming LNB, fine
+/// enough that the residual chirp across a frame is a fraction of a bit.
+const DRIFT_GRID_HALF_HZ_S: f64 = 6.0;
+const DRIFT_GRID_STEP_HZ_S: f64 = 1.5;
+
+/// [`acquire`], plus a [`DecodeProgress`] snapshot of how far the pass got and
+/// a small **drift** search around `drift_hz_per_s`: the frame decoder needs
+/// the carrier coherent across a whole 10.36 s frame, which a drifting LNB
+/// breaks, so each drift candidate is de-rotated ([`dechirp`]) before the
+/// ordinary frequency sweep runs on it. `drift_hz_per_s` is the caller's own
+/// estimate (0.0 = "no idea"); the grid is centred on it so a good estimate
+/// keeps the search short.
 pub(crate) fn acquire_debug(
     iq: &[Complex32],
     rate_hz: f64,
     search_half_width_hz: f64,
     freq_step_hz: f64,
     demod_rate_hz: f64,
+    drift_hz_per_s: f64,
     cancel: &std::sync::atomic::AtomicBool,
 ) -> (Option<Qo100Lock>, DecodeProgress) {
-    let lock = acquire(iq, rate_hz, search_half_width_hz, freq_step_hz, demod_rate_hz, cancel);
-    if lock.is_some() {
-        return (
-            lock,
-            DecodeProgress { carrier: true, sync: true, sync_bit_errors: 0, crc_ok: true },
-        );
+    use std::sync::atomic::Ordering;
+
+    // Drift candidates, centre outward from the estimate.
+    let steps = (DRIFT_GRID_HALF_HZ_S / DRIFT_GRID_STEP_HZ_S).round() as i64;
+    for k in 0..=2 * steps {
+        if cancel.load(Ordering::Relaxed) {
+            break;
+        }
+        let d = if k % 2 == 0 { k / 2 } else { -(k / 2 + 1) };
+        let slope = drift_hz_per_s + d as f64 * DRIFT_GRID_STEP_HZ_S;
+        let buf = dechirp(iq, rate_hz, slope);
+        let lock =
+            acquire(&buf, rate_hz, search_half_width_hz, freq_step_hz, demod_rate_hz, cancel);
+        if lock.is_some() {
+            return (
+                lock,
+                DecodeProgress { carrier: true, sync: true, sync_bit_errors: 0, crc_ok: true },
+            );
+        }
     }
+
+    // Nothing decoded at any drift — probe the un-dechirped buffer for how far
+    // it got, so the readout still says something.
     let mut progress = DecodeProgress::default();
     if rate_hz > 0.0 && demod_rate_hz > 0.0 {
         let deci = (rate_hz / demod_rate_hz).round().max(1.0) as usize;
@@ -735,7 +786,7 @@ pub(crate) fn acquire_debug(
         progress.carrier =
             seed.is_some() || progress.sync || dist.is_some_and(|d| u32::from(d) <= 10);
     }
-    (lock, progress)
+    (None, progress)
 }
 
 // `pub(crate)` so `controller`'s own test module can build a real on-air frame
@@ -1120,11 +1171,68 @@ pub(crate) mod tests {
             300.0,
             TEST_STEP,
             crate::controller::DEMOD_RATE_HZ,
+            0.0,
             &std::sync::atomic::AtomicBool::new(false),
         );
         assert!(lock.is_some());
         assert!(p.carrier && p.sync && p.crc_ok, "{p:?}");
         assert_eq!(p.sync_bit_errors, 0);
+    }
+
+    /// Apply a linear chirp of `hz_per_s` to `iq` (the inverse of [`dechirp`]).
+    fn add_chirp(iq: &[Complex32], rate_hz: f64, hz_per_s: f64) -> Vec<Complex32> {
+        let n0 = iq.len() as f64 / 2.0;
+        let k = std::f64::consts::PI * hz_per_s / (rate_hz * rate_hz);
+        iq.iter()
+            .enumerate()
+            .map(|(n, &z)| {
+                let d = n as f64 - n0;
+                let ph = k * d * d;
+                z * Complex32::new(ph.cos() as f32, ph.sin() as f32)
+            })
+            .collect()
+    }
+
+    #[test]
+    fn a_chirped_frame_decodes_once_the_drift_is_de_rotated() {
+        // A carrier walking 60 Hz/s across the frame — a warming LNB. Far past
+        // what the straight chip detector tolerates, but with the tracker's
+        // drift estimate as the grid centre acquire_debug recovers it.
+        let rate = TEST_RATE;
+        let clean = synth_signal("CHIRP CASE", rate, 0.0, 0.0, 5);
+        let chirped = add_chirp(&clean, rate, 60.0);
+        let cancel = std::sync::atomic::AtomicBool::new(false);
+
+        assert!(
+            acquire(&chirped, rate, 300.0, TEST_STEP, crate::controller::DEMOD_RATE_HZ, &cancel)
+                .is_none(),
+            "a straight sweep cannot follow a 60 Hz/s chirp"
+        );
+
+        let (lock, p) = acquire_debug(
+            &chirped,
+            rate,
+            300.0,
+            TEST_STEP,
+            crate::controller::DEMOD_RATE_HZ,
+            60.0, // the tracker's drift estimate
+            &cancel,
+        );
+        assert!(lock.is_some() && p.crc_ok, "the drift grid should recover it: {p:?}");
+        assert!(lock.unwrap().text.starts_with("CHIRP CASE"));
+    }
+
+    #[test]
+    fn dechirp_is_the_inverse_of_a_chirp() {
+        let rate = TEST_RATE;
+        let clean = synth_signal("INVERSE", rate, 30.0, 0.0, 2);
+        let round_trip = dechirp(&add_chirp(&clean, rate, 12.0), rate, 12.0);
+        let cancel = std::sync::atomic::AtomicBool::new(false);
+        // The de-chirped copy decodes exactly like the original.
+        let lock =
+            acquire(&round_trip, rate, 300.0, TEST_STEP, crate::controller::DEMOD_RATE_HZ, &cancel)
+                .expect("round-tripped frame still decodes");
+        assert!((lock.offset_hz - 30.0).abs() <= 1.0, "offset {}", lock.offset_hz);
     }
 
     #[test]
@@ -1140,6 +1248,7 @@ pub(crate) mod tests {
             300.0,
             TEST_STEP,
             crate::controller::DEMOD_RATE_HZ,
+            0.0,
             &std::sync::atomic::AtomicBool::new(false),
         );
         assert!(lock.is_none());

--- a/crates/sdroxide-qo100/src/bpsk.rs
+++ b/crates/sdroxide-qo100/src/bpsk.rs
@@ -37,6 +37,15 @@
 //! *is* the calibration answer: its frequency offset is exactly how far the
 //! beacon sits from where it was assumed to be.
 //!
+//! Before that sweep, [`coarse_carrier_hz`] takes one look at the block's
+//! power spectrum for the beacon's give-away shape — two lobes with a null
+//! between them at the carrier and another near ±[`CHIP_RATE`] out, left/right
+//! symmetric. When it finds one, the sweep starts there instead of at DC and,
+//! if that estimate is further out than the configured half-width, reaches out
+//! to it — so a station whose LNB has never been calibrated is still found.
+//! The estimate never decides a lock: a wrong one only reorders the grid the
+//! CRC was going to be tried against anyway.
+//!
 //! The differential+Manchester combination is decoded in one pass, without
 //! ever resolving absolute carrier phase: comparing each chip against the one
 //! immediately before it (a delay-and-multiply, not a coherent reference)
@@ -47,6 +56,7 @@
 //! comparisons recovers the original data directly. See the derivation in
 //! this module's tests.
 
+use rustfft::FftPlanner;
 use sdroxide_dsp::Complex32;
 
 /// Chips per second on the air. Manchester encoding sends two of these per
@@ -341,6 +351,156 @@ fn mix_decimate(iq: &[Complex32], rate_hz: f64, shift_hz: f64, deci: usize) -> V
     out
 }
 
+/// A confident twin-lobe estimate ([`coarse_carrier_hz`]) is allowed to pull
+/// [`acquire`]'s sweep this far from the assumed centre even when
+/// `search_half_width_hz` is smaller — generous enough for any real LNB that
+/// has never been calibrated, and capped so a stray estimate can never send
+/// the sweep clear across the capture.
+const ACQ_RANGE_MAX_HZ: f64 = 60_000.0;
+/// Margin kept either side of a seed when it decides how far the sweep reaches.
+const SEED_MARGIN_HZ: f64 = 2_000.0;
+
+/// Welch power spectrum of `iq`: a Blackman–Harris window, 50 % overlap, the
+/// mean of every whole segment's periodogram, left in natural FFT order.
+fn welch_psd(iq: &[Complex32], nfft: usize) -> Vec<f32> {
+    let fft = FftPlanner::<f32>::new().plan_fft_forward(nfft);
+    let win = sdroxide_dsp::blackman_harris(nfft);
+    let mut acc = vec![0.0f32; nfft];
+    let mut seg = vec![Complex32::new(0.0, 0.0); nfft];
+    let hop = (nfft / 2).max(1);
+    let mut segments = 0u32;
+    let mut start = 0usize;
+    while start + nfft <= iq.len() {
+        for (s, (&x, &w)) in seg.iter_mut().zip(iq[start..start + nfft].iter().zip(&win)) {
+            *s = x * w;
+        }
+        fft.process(&mut seg);
+        for (a, s) in acc.iter_mut().zip(&seg) {
+            *a += s.norm_sqr();
+        }
+        segments += 1;
+        start += hop;
+    }
+    if segments > 0 {
+        let inv = 1.0 / segments as f32;
+        acc.iter_mut().for_each(|v| *v *= inv);
+    }
+    acc
+}
+
+/// A coarse estimate of where the beacon's carrier sits, in Hz relative to
+/// the assumed centre (DC) — or `None` when the spectrum holds nothing shaped
+/// like the beacon.
+///
+/// The beacon is DBPSK + Manchester at 400 baud, so it shows in a spectrum
+/// not as a carrier peak but as a *pair* of lobes with a null between them at
+/// the carrier and another null near ±[`CHIP_RATE`] Hz further out (see the
+/// module doc). This scores every candidate centre across the whole captured
+/// span by exactly that shape — two shoulders up, a notch in the middle,
+/// quiet past the outer nulls, left/right symmetric — and returns the best
+/// only if it clears every part of that test by a margin. A bare carrier, an
+/// SSB signal or noise all fail it, so a `Some` here is worth seeding
+/// [`acquire`] with; being wrong could at worst reorder candidates it would
+/// have tried anyway.
+pub(crate) fn coarse_carrier_hz(
+    iq: &[Complex32],
+    rate_hz: f64,
+    search_half_width_hz: f64,
+) -> Option<f64> {
+    if rate_hz <= 0.0 || search_half_width_hz <= 0.0 {
+        return None;
+    }
+    // ~15–25 Hz bins: fine enough to resolve the ±CHIP_RATE null structure,
+    // coarse enough that even a short buffer still averages many segments.
+    let nfft = ((rate_hz / 22.0).round() as usize).clamp(512, 32_768).next_power_of_two();
+    if iq.len() < nfft * 2 {
+        return None;
+    }
+    let psd = welch_psd(iq, nfft);
+    let bin_hz = rate_hz / nfft as f64;
+
+    // Linear PSD at a signed frequency, nearest bin, wrapping natural FFT
+    // order; `None` past the transform's own edge.
+    let at = |f: f64| -> Option<f32> {
+        let k = (f / bin_hz).round() as i64;
+        let k = if k < 0 { k + nfft as i64 } else { k };
+        (0..nfft as i64).contains(&k).then(|| psd[k as usize])
+    };
+    // Mean linear PSD over `c ± [lo, hi]`, both sides together.
+    let band_mean = |c: f64, lo: f64, hi: f64| -> Option<f32> {
+        let (mut sum, mut n) = (0.0f32, 0u32);
+        let mut d = lo;
+        while d <= hi {
+            if let (Some(a), Some(b)) = (at(c + d), at(c - d)) {
+                sum += a + b;
+                n += 2;
+            }
+            d += bin_hz;
+        }
+        (n > 0).then(|| sum / n as f32)
+    };
+
+    // Scan the whole captured span, not just ±search_half_width_hz — finding
+    // a beacon the configured width does not cover is half the point.
+    let reach = (search_half_width_hz + 1_500.0).min(rate_hz * 0.47);
+
+    // A robust noise floor for the SNR gate: the median across the span, which
+    // the beacon's own two lobes cannot lift far.
+    let mut span: Vec<f32> = Vec::new();
+    let mut f = -reach;
+    while f <= reach {
+        if let Some(p) = at(f) {
+            span.push(p);
+        }
+        f += bin_hz;
+    }
+    if span.len() < 32 {
+        return None;
+    }
+    span.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
+    let floor = span[span.len() / 2].max(1e-20);
+    let db = |x: f32| 10.0 * (x.max(1e-20) as f64).log10();
+
+    let mut best: Option<(f64, f64)> = None; // (score, fc)
+    let mut fc = -reach;
+    while fc <= reach {
+        if let (Some(lobe), Some(notch), Some(outer)) = (
+            band_mean(fc, 200.0, 600.0),
+            band_mean(fc, 0.0, 60.0),
+            band_mean(fc, CHIP_RATE + 200.0, CHIP_RATE + 700.0),
+        ) {
+            let null_depth = db(lobe) - db(notch);
+            let lobe_excess = db(lobe) - db(outer);
+            let snr = db(lobe) - db(floor);
+
+            // Left/right evenness across the lobe band, 1.0 = perfectly even.
+            let (mut asym, mut m) = (0.0f64, 0u32);
+            let mut d = 200.0;
+            while d <= 600.0 {
+                if let (Some(a), Some(b)) = (at(fc + d), at(fc - d)) {
+                    let (a, b) = (a as f64, b as f64);
+                    if a + b > 0.0 {
+                        asym += (a - b).abs() / (a + b);
+                        m += 1;
+                    }
+                }
+                d += bin_hz;
+            }
+            let sym = if m > 0 { 1.0 - asym / m as f64 } else { 0.0 };
+
+            if null_depth >= 2.5 && lobe_excess >= 3.0 && snr >= 3.0 && sym >= 0.55 {
+                let score =
+                    null_depth.min(12.0) + lobe_excess.min(12.0) + snr.min(12.0) + 8.0 * sym;
+                if best.is_none_or(|(s, _)| score > s) {
+                    best = Some((score, fc));
+                }
+            }
+        }
+        fc += bin_hz;
+    }
+    best.map(|(_, fc)| fc)
+}
+
 /// Search `iq` (complex baseband, `rate_hz` samples/s, the beacon assumed to
 /// sit somewhere within `±search_half_width_hz` of DC) for one CRC-valid
 /// AO-40 uncoded frame, stepping the candidate frequency by `freq_step_hz`.
@@ -356,11 +516,15 @@ fn mix_decimate(iq: &[Complex32], rate_hz: f64, shift_hz: f64, deci: usize) -> V
 /// search width, so the total grew with the *square* of the width and the
 /// widest settings ran many times slower than real time.
 ///
-/// Candidates are tried from the centre outward, so a beacon near the assumed
-/// frequency — the common case for a roughly-calibrated station — is found
-/// without walking the whole grid first. `cancel` is polled between
-/// candidates so the engine can drop the controller (turning the decoder off,
-/// or changing the search width) without waiting out a search in progress.
+/// Candidates are tried outward from [`coarse_carrier_hz`]'s spectral seed
+/// when it found one, else from the centre, so a beacon near where it is
+/// expected — the common case for a roughly-calibrated station — is found
+/// without walking the whole grid first. A seed past `search_half_width_hz`
+/// also widens the grid out to it (capped at [`ACQ_RANGE_MAX_HZ`] and
+/// Nyquist), which is what lets an uncalibrated station be found at all.
+/// `cancel` is polled between candidates so the engine can drop the
+/// controller (turning the decoder off, or changing the search width) without
+/// waiting out a search in progress.
 ///
 /// `iq` needs to span at least one whole frame (`FRAME_BITS` bits plus the
 /// sync word, [`BAUD`] bits/s) for a frame to have any chance of falling
@@ -381,10 +545,27 @@ pub fn acquire(
     }
     let deci = (rate_hz / demod_rate_hz).round().max(1.0) as usize;
     let dr = rate_hz / deci as f64;
-    let steps = (search_half_width_hz / freq_step_hz).round() as i64;
-    // 0, +1, -1, +2, -2, … — centre outward.
-    let order = (0..=2 * steps).map(|i| if i % 2 == 0 { i / 2 } else { -(i / 2 + 1) });
-    for step in order {
+
+    // The spectral seed, and how far it lets the grid reach: never narrower
+    // than the configured half-width, no wider than a confident seed needs
+    // (plus a margin), and never past a sane cap or Nyquist.
+    let seed_hz = coarse_carrier_hz(iq, rate_hz, search_half_width_hz);
+    let reach_hz = match seed_hz {
+        Some(s) => (s.abs() + SEED_MARGIN_HZ)
+            .min(ACQ_RANGE_MAX_HZ)
+            .min(rate_hz * 0.47)
+            .max(search_half_width_hz),
+        None => search_half_width_hz,
+    };
+    let steps = (reach_hz / freq_step_hz).round().max(0.0) as i64;
+    let seed_step = seed_hz.map(|s| (s / freq_step_hz).round() as i64).unwrap_or(0);
+
+    // Every grid point in range, ordered by distance from the seed step (ties
+    // to the high side, as the plain centre-out sweep did). With no seed this
+    // is exactly `0, +1, -1, +2, -2, …` from DC.
+    let mut cands: Vec<i64> = (-steps..=steps).collect();
+    cands.sort_by_key(|&s| ((s - seed_step).unsigned_abs(), s < seed_step));
+    for step in cands {
         if cancel.load(Ordering::Relaxed) {
             return None;
         }
@@ -667,5 +848,89 @@ pub(crate) mod tests {
     fn the_demod_tolerates_a_realistic_residual_frequency_error_unaided() {
         let iq = synth_signal("CAPTURE RANGE", TEST_RATE, 100.0, 0.0, 1);
         assert!(try_frequency(&iq, TEST_RATE).is_some());
+    }
+
+    /// Stack `copies` of one synthesized frame end to end — a longer buffer so
+    /// [`welch_psd`] has several segments to average, like the worker's
+    /// rolling window gives it.
+    fn stacked(
+        text: &str,
+        rate_hz: f64,
+        offset_hz: f64,
+        noise: f32,
+        seed: u64,
+        copies: usize,
+    ) -> Vec<Complex32> {
+        let one = synth_signal(text, rate_hz, offset_hz, noise, seed);
+        let mut out = Vec::with_capacity(one.len() * copies);
+        for _ in 0..copies {
+            out.extend_from_slice(&one);
+        }
+        out
+    }
+
+    #[test]
+    fn the_coarse_estimator_reads_the_carrier_off_the_twin_lobes() {
+        // A real Manchester beacon 4 kHz off centre, captured wide enough to
+        // see both lobes and a stretch of clean floor either side.
+        let iq = stacked("COARSE EST", 20_000.0, 4_000.0, 0.05, 7, 3);
+        let est = coarse_carrier_hz(&iq, 20_000.0, 8_000.0).expect("the twin lobes should be seen");
+        assert!((est - 4_000.0).abs() <= 200.0, "estimated {est}");
+    }
+
+    #[test]
+    fn the_coarse_estimator_declines_on_noise_and_on_a_bare_carrier() {
+        let n = (20_000.0f64 * 6.0) as usize;
+
+        let mut rng = TestRng::new(41);
+        let noise: Vec<Complex32> = (0..n)
+            .map(|_| Complex32::new(rng.range(-1.0, 1.0) as f32, rng.range(-1.0, 1.0) as f32))
+            .collect();
+        assert!(coarse_carrier_hz(&noise, 20_000.0, 8_000.0).is_none(), "noise is not a beacon");
+
+        // A plain unmodulated carrier 3 kHz off: a peak, not two lobes with a
+        // null — must be rejected, or it would seed the search wrong.
+        let tone: Vec<Complex32> = (0..n)
+            .map(|i| {
+                let ph = std::f64::consts::TAU * 3_000.0 * i as f64 / 20_000.0;
+                Complex32::new(ph.cos() as f32, ph.sin() as f32)
+            })
+            .collect();
+        assert!(
+            coarse_carrier_hz(&tone, 20_000.0, 8_000.0).is_none(),
+            "a bare carrier is not a beacon"
+        );
+    }
+
+    /// The acquisition-range win: a beacon sitting outside the configured
+    /// half-width is out of reach of the plain centre-out sweep, but the
+    /// spectral seed pulls the grid out to it and it still locks.
+    #[test]
+    fn a_seed_pulls_the_search_past_the_configured_half_width() {
+        // ±8 kHz width, captured 2.5× wide (the engine's rule); beacon at
+        // 9 kHz — 1 kHz beyond the width, well inside the capture.
+        let rate = 20_000.0;
+        let iq = stacked("OUT OF WIDTH", rate, 9_000.0, 0.02, 11, 3);
+        let lock = acq(&iq, rate, 8_000.0).expect("the seed should extend the reach to it");
+        assert!((lock.offset_hz - 9_000.0).abs() <= 2.0, "found {}", lock.offset_hz);
+        assert!(lock.text.starts_with("OUT OF WIDTH"), "{:?}", lock.text);
+    }
+
+    #[test]
+    fn the_coarse_estimator_needs_a_buffer_worth_averaging() {
+        // Fewer than two FFT segments' worth of samples: no estimate at all,
+        // so `acquire` just falls back to the plain centre-out sweep.
+        let short = synth_signal("TOO SHORT", TEST_RATE, 40.0, 0.0, 1);
+        assert!(coarse_carrier_hz(&short[..1024], TEST_RATE, 150.0).is_none());
+    }
+
+    /// A seed near the true offset must not cost the plain sweep its
+    /// precision: a narrow-width search still lands on the exact drift.
+    #[test]
+    fn a_seed_does_not_disturb_a_narrow_width_result() {
+        let iq = synth_signal("SEEDED NARROW", TEST_RATE, 91.0, 0.02, 2);
+        let lock = acq(&iq, TEST_RATE, 150.0).expect("still locks");
+        assert!((lock.offset_hz - 91.0).abs() <= 1.0, "found {}", lock.offset_hz);
+        assert!(lock.text.starts_with("SEEDED NARROW"));
     }
 }

--- a/crates/sdroxide-qo100/src/bpsk.rs
+++ b/crates/sdroxide-qo100/src/bpsk.rs
@@ -360,6 +360,13 @@ const ACQ_RANGE_MAX_HZ: f64 = 60_000.0;
 /// Margin kept either side of a seed when it decides how far the sweep reaches.
 const SEED_MARGIN_HZ: f64 = 2_000.0;
 
+/// The dense sub-grid tried right on the spectral seed before the coarse
+/// sweep: `±FINE_SPAN_HZ` in `FINE_STEP_HZ` steps. Fine enough that the
+/// residual carrier error is small next to what the payload CRC can survive,
+/// narrow enough to add only a dozen-odd candidates.
+const FINE_STEP_HZ: f64 = 25.0;
+const FINE_SPAN_HZ: f64 = 250.0;
+
 /// Welch power spectrum of `iq`: a Blackman–Harris window, 50 % overlap, the
 /// mean of every whole segment's periodogram, left in natural FFT order.
 fn welch_psd(iq: &[Complex32], nfft: usize) -> Vec<f32> {
@@ -593,16 +600,33 @@ pub fn acquire(
     let steps = (reach_hz / freq_step_hz).round().max(0.0) as i64;
     let seed_step = seed_hz.map(|s| (s / freq_step_hz).round() as i64).unwrap_or(0);
 
-    // Every grid point in range, ordered by distance from the seed step (ties
+    // The candidate mix-down frequencies, in order.
+    //
+    // First — when the spectrum gave a confident seed — a *dense* sweep right
+    // on it: the coarse `freq_step_hz` grid leaves a residual carrier error of
+    // up to half a step, which the chip detector tolerates for the sync word
+    // but which lifts the payload bit-error rate enough that the CRC over 514
+    // bytes almost never checks out. A few Hz of residual instead of ~75 is
+    // what turns "carrier + sync, no CRC" into a decode.
+    let mut freqs: Vec<f64> = Vec::new();
+    if let Some(s) = seed_hz {
+        let fine = (FINE_SPAN_HZ / FINE_STEP_HZ).round() as i64;
+        for k in 0..=2 * fine {
+            let d = if k % 2 == 0 { k / 2 } else { -(k / 2 + 1) };
+            freqs.push(s + d as f64 * FINE_STEP_HZ);
+        }
+    }
+    // Then the full coarse grid, ordered by distance from the seed step (ties
     // to the high side, as the plain centre-out sweep did). With no seed this
     // is exactly `0, +1, -1, +2, -2, …` from DC.
-    let mut cands: Vec<i64> = (-steps..=steps).collect();
-    cands.sort_by_key(|&s| ((s - seed_step).unsigned_abs(), s < seed_step));
-    for step in cands {
+    let mut coarse: Vec<i64> = (-steps..=steps).collect();
+    coarse.sort_by_key(|&s| ((s - seed_step).unsigned_abs(), s < seed_step));
+    freqs.extend(coarse.iter().map(|&s| s as f64 * freq_step_hz));
+
+    for coarse_hz in freqs {
         if cancel.load(Ordering::Relaxed) {
             return None;
         }
-        let coarse_hz = step as f64 * freq_step_hz;
         let mixed = mix_decimate(iq, rate_hz, coarse_hz, deci);
         if let Some(cm) = try_frequency(&mixed, dr) {
             let offset_hz = coarse_hz + refine_offset_hz(&mixed, dr, &cm);

--- a/crates/sdroxide-qo100/src/bpsk.rs
+++ b/crates/sdroxide-qo100/src/bpsk.rs
@@ -650,13 +650,27 @@ pub(crate) struct DecodeProgress {
     /// Fewest sync-word bit errors found, 0..=32; [`u8::MAX`] if no bitstream
     /// was run at all.
     pub sync_bit_errors: u8,
+    /// How many separate positions in the best chip-timing/parity bitstream
+    /// matched the sync word within [`SYNC_MAX_ERRORS`]. A real frame in the
+    /// window shows one or two, at very few errors; a 32-bit pattern matched
+    /// within 3 errors also turns up by chance roughly once every few windows
+    /// on noise, as a lone hit near the full error budget — so this is what
+    /// tells "sync lit, CRC dark" apart from a genuine frame alignment the
+    /// payload demod is then failing.
+    pub sync_matches: u8,
     /// A CRC-valid frame was decoded.
     pub crc_ok: bool,
 }
 
 impl Default for DecodeProgress {
     fn default() -> Self {
-        Self { carrier: false, sync: false, sync_bit_errors: u8::MAX, crc_ok: false }
+        Self {
+            carrier: false,
+            sync: false,
+            sync_bit_errors: u8::MAX,
+            sync_matches: 0,
+            crc_ok: false,
+        }
     }
 }
 
@@ -676,16 +690,42 @@ fn min_sync_distance(bits: &[bool]) -> Option<u8> {
     Some(best as u8)
 }
 
-/// The fewest sync-word bit errors any chip-timing/parity combination of
-/// `iq` (already mixed to one candidate) gets down to — a "how close was
-/// this" that does not need a CRC pass to mean something.
-fn sync_probe(iq: &[Complex32], rate_hz: f64) -> Option<u8> {
+/// Every bit offset in `bits` where [`SYNC_WORD`] matches within
+/// [`SYNC_MAX_ERRORS`], collapsing a run of near-adjacent hits (one real sync
+/// preamble can match at a couple of neighbouring offsets when a chip slips)
+/// into a single count — so the length of the result is "how many distinct
+/// frame alignments look present", the number [`DecodeProgress::sync_matches`]
+/// reports.
+fn sync_positions(bits: &[bool]) -> Vec<usize> {
+    let mut out: Vec<usize> = Vec::new();
+    if bits.len() < SYNC_LEN as usize {
+        return out;
+    }
+    let mut window: u32 = 0;
+    for (i, &b) in bits.iter().enumerate() {
+        window = (window << 1) | b as u32;
+        if i + 1 >= SYNC_LEN as usize && (window ^ SYNC_WORD).count_ones() <= SYNC_MAX_ERRORS {
+            let pos = i + 1 - SYNC_LEN as usize;
+            if out.last().is_none_or(|&p| pos - p > 4) {
+                out.push(pos);
+            }
+        }
+    }
+    out
+}
+
+/// Across every chip-timing phase and Manchester parity of `iq` (already mixed
+/// to one candidate): the fewest sync-word bit errors any of them reaches, and
+/// how many distinct sync matches the bitstream that reached it carries. A
+/// "how close was this, and is it one real frame or a chance hit" that does
+/// not need a CRC pass to mean something.
+fn sync_scan(iq: &[Complex32], rate_hz: f64) -> Option<(u8, u8)> {
     let samples_per_chip = rate_hz / CHIP_RATE;
     if samples_per_chip < 2.0 {
         return None;
     }
     let phase_step = (samples_per_chip / TIMING_PHASES as f64).max(1.0);
-    let mut best: Option<u8> = None;
+    let mut best: Option<(u8, u8)> = None;
     for p in 0..TIMING_PHASES {
         let phase = (p as f64 * phase_step) as usize;
         let chips = chip_samples(iq, samples_per_chip, phase);
@@ -694,52 +734,73 @@ fn sync_probe(iq: &[Complex32], rate_hz: f64) -> Option<u8> {
         }
         let flips = chip_flips(&chips);
         for parity in 0..2 {
-            if let Some(d) = min_sync_distance(&data_bits(&flips, parity)) {
-                best = Some(best.map_or(d, |b| b.min(d)));
+            let bits = data_bits(&flips, parity);
+            let Some(d) = min_sync_distance(&bits) else { continue };
+            if best.is_none_or(|(bd, _)| d < bd) {
+                let n = sync_positions(&bits).len().min(u8::MAX as usize) as u8;
+                best = Some((d, n));
             }
         }
     }
     best
 }
 
-/// De-rotate a linear frequency drift of `hz_per_s` out of `iq` (sample rate
-/// `rate_hz`), pivoting on the centre sample so only the *slope* is removed —
-/// the mean offset is left for [`acquire`]'s own grid to find. This is what
-/// lets a frame decode on a station whose LNB (or SDR clock) is still walking
-/// a few Hz a second while it warms up: without it the carrier smears across
-/// the 10.36 s frame and the payload CRC never checks out even though the
-/// sync word matches.
-fn dechirp(iq: &[Complex32], rate_hz: f64, hz_per_s: f64) -> Vec<Complex32> {
-    if hz_per_s == 0.0 || rate_hz <= 0.0 {
+/// De-rotate a frequency drift of `slope` Hz/s plus curvature `accel` Hz/s²
+/// out of `iq` (sample rate `rate_hz`), pivoting on the centre sample so only
+/// the *shape* of the walk is removed — the mean offset is left for
+/// [`acquire`]'s own grid to find. This is what lets a frame decode on a
+/// station whose LNB (or SDR clock) is still walking while it warms up:
+/// without it the carrier smears across the 10.36 s frame and the payload CRC
+/// never checks out even though the sync word matches.
+///
+/// A warming LNB's LO does not drift at a *constant* rate — it curves — so the
+/// `accel` term earns its place over a whole frame even when the last second
+/// of tracker estimates looked linear; a straight-line de-rotation leaves a
+/// residual chirp that is still enough to fail the payload CRC.
+fn dechirp(iq: &[Complex32], rate_hz: f64, slope: f64, accel: f64) -> Vec<Complex32> {
+    if (slope == 0.0 && accel == 0.0) || rate_hz <= 0.0 {
         return iq.to_vec();
     }
-    // Instantaneous frequency `hz_per_s * t` integrates to phase
-    // `PI * hz_per_s * t^2`; `t = (n - n0) / rate`. Multiply by its conjugate.
+    // Instantaneous frequency `slope * t + 0.5 * accel * t^2` integrates to
+    // phase `2*PI * (0.5 * slope * t^2 + accel * t^3 / 6)`; `t = (n - n0) /
+    // rate`. Multiply by its conjugate.
     let n0 = iq.len() as f64 / 2.0;
-    let k = -std::f64::consts::PI * hz_per_s / (rate_hz * rate_hz);
+    let ks = -std::f64::consts::PI * slope / (rate_hz * rate_hz);
+    let ka = -std::f64::consts::PI * accel / (3.0 * rate_hz * rate_hz * rate_hz);
     iq.iter()
         .enumerate()
         .map(|(n, &z)| {
             let d = n as f64 - n0;
-            let ph = k * d * d;
+            let ph = ks * d * d + ka * d * d * d;
             z * Complex32::new(ph.cos() as f32, ph.sin() as f32)
         })
         .collect()
 }
 
-/// Half-width and step, in Hz/s, of the drift grid [`acquire_debug`] tries
-/// around the caller's estimate. Wide enough to bracket a warming LNB, fine
-/// enough that the residual chirp across a frame is a fraction of a bit.
+/// Half-width and step, in Hz/s, of the drift-*rate* grid [`acquire_debug`]
+/// tries around the caller's estimate. Wide enough to bracket a warming LNB,
+/// fine enough that the residual chirp across a frame is a fraction of a bit.
 const DRIFT_GRID_HALF_HZ_S: f64 = 6.0;
 const DRIFT_GRID_STEP_HZ_S: f64 = 1.5;
 
+/// Half-width and step, in Hz/s², of the *curvature* grid tried around the
+/// caller's estimate. `0.0` is always tried first (centre-out), so a station
+/// whose drift really is linear pays exactly the sweep it did before this
+/// second-order term existed; widen the half-width here if a fast-warming LNB
+/// still will not decode and `DRIFT` shows a large curvature.
+const ACCEL_GRID_HALF_HZ_S2: f64 = 3.0;
+const ACCEL_GRID_STEP_HZ_S2: f64 = 3.0;
+
 /// [`acquire`], plus a [`DecodeProgress`] snapshot of how far the pass got and
-/// a small **drift** search around `drift_hz_per_s`: the frame decoder needs
-/// the carrier coherent across a whole 10.36 s frame, which a drifting LNB
-/// breaks, so each drift candidate is de-rotated ([`dechirp`]) before the
-/// ordinary frequency sweep runs on it. `drift_hz_per_s` is the caller's own
-/// estimate (0.0 = "no idea"); the grid is centred on it so a good estimate
-/// keeps the search short.
+/// a small **drift** search around `drift_hz_per_s` / `drift_accel_hz_s2`: the
+/// frame decoder needs the carrier coherent across a whole 10.36 s frame,
+/// which a drifting — and, as it warms, *accelerating* — LNB breaks, so each
+/// candidate is de-rotated ([`dechirp`]) with a trial drift rate and curvature
+/// before the ordinary frequency sweep runs on it. The two arguments are the
+/// caller's own estimates (0.0 = "no idea"); the grid is centred on them, with
+/// zero curvature tried first, so a good estimate keeps the search short and a
+/// linearly-drifting station pays what it did before the curvature term.
+#[allow(clippy::too_many_arguments)]
 pub(crate) fn acquire_debug(
     iq: &[Complex32],
     rate_hz: f64,
@@ -747,26 +808,39 @@ pub(crate) fn acquire_debug(
     freq_step_hz: f64,
     demod_rate_hz: f64,
     drift_hz_per_s: f64,
+    drift_accel_hz_s2: f64,
     cancel: &std::sync::atomic::AtomicBool,
 ) -> (Option<Qo100Lock>, DecodeProgress) {
     use std::sync::atomic::Ordering;
 
-    // Drift candidates, centre outward from the estimate.
-    let steps = (DRIFT_GRID_HALF_HZ_S / DRIFT_GRID_STEP_HZ_S).round() as i64;
-    for k in 0..=2 * steps {
-        if cancel.load(Ordering::Relaxed) {
-            break;
-        }
-        let d = if k % 2 == 0 { k / 2 } else { -(k / 2 + 1) };
-        let slope = drift_hz_per_s + d as f64 * DRIFT_GRID_STEP_HZ_S;
-        let buf = dechirp(iq, rate_hz, slope);
-        let lock =
-            acquire(&buf, rate_hz, search_half_width_hz, freq_step_hz, demod_rate_hz, cancel);
-        if lock.is_some() {
-            return (
-                lock,
-                DecodeProgress { carrier: true, sync: true, sync_bit_errors: 0, crc_ok: true },
-            );
+    // Curvature outer, drift-rate inner — both centre-outward from the
+    // estimate, so (zero curvature, best rate) is tried first.
+    let s_steps = (DRIFT_GRID_HALF_HZ_S / DRIFT_GRID_STEP_HZ_S).round() as i64;
+    let a_steps = (ACCEL_GRID_HALF_HZ_S2 / ACCEL_GRID_STEP_HZ_S2).round() as i64;
+    'grid: for ka in 0..=2 * a_steps {
+        let da = if ka % 2 == 0 { ka / 2 } else { -(ka / 2 + 1) };
+        let accel = drift_accel_hz_s2 + da as f64 * ACCEL_GRID_STEP_HZ_S2;
+        for ks in 0..=2 * s_steps {
+            if cancel.load(Ordering::Relaxed) {
+                break 'grid;
+            }
+            let ds = if ks % 2 == 0 { ks / 2 } else { -(ks / 2 + 1) };
+            let slope = drift_hz_per_s + ds as f64 * DRIFT_GRID_STEP_HZ_S;
+            let buf = dechirp(iq, rate_hz, slope, accel);
+            if let Some(lock) =
+                acquire(&buf, rate_hz, search_half_width_hz, freq_step_hz, demod_rate_hz, cancel)
+            {
+                return (
+                    Some(lock),
+                    DecodeProgress {
+                        carrier: true,
+                        sync: true,
+                        sync_bit_errors: 0,
+                        sync_matches: 1,
+                        crc_ok: true,
+                    },
+                );
+            }
         }
     }
 
@@ -778,13 +852,14 @@ pub(crate) fn acquire_debug(
         let dr = rate_hz / deci as f64;
         let seed = coarse_carrier_hz(iq, rate_hz, search_half_width_hz);
         let mixed = mix_decimate(iq, rate_hz, seed.unwrap_or(0.0), deci);
-        let dist = sync_probe(&mixed, dr);
-        if let Some(d) = dist {
+        if let Some((d, n)) = sync_scan(&mixed, dr) {
             progress.sync_bit_errors = d;
             progress.sync = u32::from(d) <= SYNC_MAX_ERRORS;
+            progress.sync_matches = n;
         }
-        progress.carrier =
-            seed.is_some() || progress.sync || dist.is_some_and(|d| u32::from(d) <= 10);
+        progress.carrier = seed.is_some()
+            || progress.sync
+            || (progress.sync_bit_errors != u8::MAX && progress.sync_bit_errors <= 10);
     }
     (None, progress)
 }
@@ -1172,6 +1247,7 @@ pub(crate) mod tests {
             TEST_STEP,
             crate::controller::DEMOD_RATE_HZ,
             0.0,
+            0.0,
             &std::sync::atomic::AtomicBool::new(false),
         );
         assert!(lock.is_some());
@@ -1179,15 +1255,17 @@ pub(crate) mod tests {
         assert_eq!(p.sync_bit_errors, 0);
     }
 
-    /// Apply a linear chirp of `hz_per_s` to `iq` (the inverse of [`dechirp`]).
-    fn add_chirp(iq: &[Complex32], rate_hz: f64, hz_per_s: f64) -> Vec<Complex32> {
+    /// Apply a frequency chirp of `slope` Hz/s plus curvature `accel` Hz/s² to
+    /// `iq` — the inverse of [`dechirp`].
+    fn add_chirp(iq: &[Complex32], rate_hz: f64, slope: f64, accel: f64) -> Vec<Complex32> {
         let n0 = iq.len() as f64 / 2.0;
-        let k = std::f64::consts::PI * hz_per_s / (rate_hz * rate_hz);
+        let ks = std::f64::consts::PI * slope / (rate_hz * rate_hz);
+        let ka = std::f64::consts::PI * accel / (3.0 * rate_hz * rate_hz * rate_hz);
         iq.iter()
             .enumerate()
             .map(|(n, &z)| {
                 let d = n as f64 - n0;
-                let ph = k * d * d;
+                let ph = ks * d * d + ka * d * d * d;
                 z * Complex32::new(ph.cos() as f32, ph.sin() as f32)
             })
             .collect()
@@ -1200,7 +1278,7 @@ pub(crate) mod tests {
         // drift estimate as the grid centre acquire_debug recovers it.
         let rate = TEST_RATE;
         let clean = synth_signal("CHIRP CASE", rate, 0.0, 0.0, 5);
-        let chirped = add_chirp(&clean, rate, 60.0);
+        let chirped = add_chirp(&clean, rate, 60.0, 0.0);
         let cancel = std::sync::atomic::AtomicBool::new(false);
 
         assert!(
@@ -1216,6 +1294,7 @@ pub(crate) mod tests {
             TEST_STEP,
             crate::controller::DEMOD_RATE_HZ,
             60.0, // the tracker's drift estimate
+            0.0,
             &cancel,
         );
         assert!(lock.is_some() && p.crc_ok, "the drift grid should recover it: {p:?}");
@@ -1223,10 +1302,49 @@ pub(crate) mod tests {
     }
 
     #[test]
+    fn a_curved_drift_decodes_once_the_curvature_is_de_rotated() {
+        // A carrier whose drift *rate* is itself moving — a warming LNB. Zero
+        // mean slope, pure curvature: near the buffer centre it looks almost
+        // stationary, but the ends smear hundreds of Hz, and a symmetric curve
+        // is exactly what no linear de-rotation or static offset can straighten.
+        // The rate is scaled up here so a single ~10 s synth buffer stands in
+        // for the decoder's real ~24 s window, where a few Hz/s² is enough.
+        let rate = TEST_RATE;
+        let clean = synth_signal("CURVED CASE", rate, 0.0, 0.0, 9);
+        let curved = add_chirp(&clean, rate, 0.0, 40.0);
+        let cancel = std::sync::atomic::AtomicBool::new(false);
+
+        let (no_curve, _) = acquire_debug(
+            &curved,
+            rate,
+            300.0,
+            TEST_STEP,
+            crate::controller::DEMOD_RATE_HZ,
+            0.0,
+            0.0, // the drift grid alone, no curvature — cannot follow it
+            &cancel,
+        );
+        assert!(no_curve.is_none(), "a rate-only grid cannot straighten a curved drift");
+
+        let (lock, p) = acquire_debug(
+            &curved,
+            rate,
+            300.0,
+            TEST_STEP,
+            crate::controller::DEMOD_RATE_HZ,
+            0.0,
+            40.0, // the tracker's curvature estimate
+            &cancel,
+        );
+        assert!(lock.is_some() && p.crc_ok, "the curvature grid should recover it: {p:?}");
+        assert!(lock.unwrap().text.starts_with("CURVED CASE"));
+    }
+
+    #[test]
     fn dechirp_is_the_inverse_of_a_chirp() {
         let rate = TEST_RATE;
         let clean = synth_signal("INVERSE", rate, 30.0, 0.0, 2);
-        let round_trip = dechirp(&add_chirp(&clean, rate, 12.0), rate, 12.0);
+        let round_trip = dechirp(&add_chirp(&clean, rate, 12.0, 4.0), rate, 12.0, 4.0);
         let cancel = std::sync::atomic::AtomicBool::new(false);
         // The de-chirped copy decodes exactly like the original.
         let lock =
@@ -1248,6 +1366,7 @@ pub(crate) mod tests {
             300.0,
             TEST_STEP,
             crate::controller::DEMOD_RATE_HZ,
+            0.0,
             0.0,
             &std::sync::atomic::AtomicBool::new(false),
         );

--- a/crates/sdroxide-qo100/src/controller.rs
+++ b/crates/sdroxide-qo100/src/controller.rs
@@ -174,6 +174,7 @@ impl Qo100Controller {
                     // drift-rate fit the frame decoder is handed.
                     let mut est_hist: VecDeque<(f64, f64)> = VecDeque::new();
                     let mut drift_hz_s = 0.0f64;
+                    let mut drift_accel = 0.0f64;
                     let mut progress = bpsk::DecodeProgress::default();
                     // Samples gathered since the last tracker pass.
                     let mut since_track = 0usize;
@@ -239,18 +240,21 @@ impl Qo100Controller {
                                                 {
                                                     est_hist.pop_front();
                                                 }
-                                                drift_hz_s = drift_slope(&est_hist);
+                                                let (s, a) = drift_fit(&est_hist);
+                                                drift_hz_s = s;
+                                                drift_accel = a;
                                             }
                                             None => {
                                                 est_misses += 1;
                                                 est_hist.clear();
                                                 drift_hz_s = 0.0;
+                                                drift_accel = 0.0;
                                             }
                                         }
                                         let _ = res_tx.send(status_snapshot(
                                             &cfg, tried, locked, est_updates, est_misses,
-                                            &last, &last_est, drift_hz_s, &progress, buf.len(),
-                                            frame_len, now,
+                                            &last, &last_est, drift_hz_s, drift_accel, &progress,
+                                            buf.len(), frame_len, now,
                                         ));
                                     }
 
@@ -269,6 +273,7 @@ impl Qo100Controller {
                                             FREQ_STEP_HZ,
                                             DEMOD_RATE_HZ,
                                             drift_hz_s,
+                                            drift_accel,
                                             &cancel,
                                         );
                                         progress = prog;
@@ -290,8 +295,8 @@ impl Qo100Controller {
                                     buf.drain(..start);
                                     let _ = res_tx.send(status_snapshot(
                                         &cfg, tried, locked, est_updates, est_misses,
-                                        &last, &last_est, drift_hz_s, &progress, buf.len(),
-                                        frame_len, now,
+                                        &last, &last_est, drift_hz_s, drift_accel, &progress,
+                                        buf.len(), frame_len, now,
                                     ));
                                 }
                                 Err(_) => break,
@@ -345,37 +350,74 @@ fn now_unix() -> i64 {
         .unwrap_or(0)
 }
 
-/// How long a stretch of tracker estimates the drift-rate fit uses.
+/// How long a stretch of tracker estimates the drift fit uses.
 const DRIFT_FIT_SECS: f64 = 12.0;
 
-/// Least-squares slope, in Hz/s, of `(t, hz)` samples — the beacon's drift
-/// rate the frame decoder is handed. `0.0` until there are enough points over
-/// a long enough span for the fit to mean anything, and clamped to a sane
-/// range so one wild estimate cannot send the decoder chasing a huge chirp.
-fn drift_slope(hist: &VecDeque<(f64, f64)>) -> f64 {
-    if hist.len() < 4 {
-        return 0.0;
+/// Least-squares fit of `hz ≈ a + b·t + c·t²` to the recent `(t, hz)` tracker
+/// estimates, returned as `(drift_rate, curvature)` in Hz/s and Hz/s² — what
+/// [`bpsk::acquire_debug`] de-rotates before it looks for a frame.
+///
+/// A warming LNB's local oscillator does not walk at a constant rate, so a
+/// straight-line fit leaves a residual chirp across the decoder's ~24 s window
+/// even when the last few seconds looked linear. The second-order term catches
+/// that. The drift rate is reported at the *middle* of the fit window, which
+/// is ≈ the centre of the decode buffer `dechirp` pivots on — so the value can
+/// be handed straight through without a further time shift.
+///
+/// `(0.0, 0.0)` until there are enough points over a long enough span for the
+/// fit to mean anything; each term clamped so one wild estimate cannot send
+/// the decoder chasing a huge chirp.
+fn drift_fit(hist: &VecDeque<(f64, f64)>) -> (f64, f64) {
+    if hist.len() < 5 {
+        return (0.0, 0.0);
     }
-    let n = hist.len() as f64;
-    let (mut st, mut sh) = (0.0, 0.0);
-    for &(t, h) in hist {
-        st += t;
-        sh += h;
-    }
-    let (tm, hm) = (st / n, sh / n);
     let span = hist.back().unwrap().0 - hist.front().unwrap().0;
     if span < 0.5 * DRIFT_FIT_SECS {
-        return 0.0;
+        return (0.0, 0.0);
     }
-    let (mut num, mut den) = (0.0, 0.0);
+    // Normal equations for [a, b, c] against 1, x, x² with x = t − mean(t);
+    // centring keeps the 3×3 well-conditioned for a dozen points over ~12 s.
+    let n = hist.len() as f64;
+    let tm = hist.iter().map(|&(t, _)| t).sum::<f64>() / n;
+    let (mut s1, mut s2, mut s3, mut s4) = (0.0, 0.0, 0.0, 0.0);
+    let (mut r0, mut r1, mut r2) = (0.0, 0.0, 0.0);
     for &(t, h) in hist {
-        num += (t - tm) * (h - hm);
-        den += (t - tm) * (t - tm);
+        let x = t - tm;
+        let (x2, x3, x4) = (x * x, x * x * x, x * x * x * x);
+        s1 += x;
+        s2 += x2;
+        s3 += x3;
+        s4 += x4;
+        r0 += h;
+        r1 += h * x;
+        r2 += h * x2;
     }
-    if den <= 0.0 {
-        return 0.0;
+    let Some([_, b, c]) = solve3([[n, s1, s2], [s1, s2, s3], [s2, s3, s4]], [r0, r1, r2]) else {
+        return (0.0, 0.0);
+    };
+    (b.clamp(-120.0, 120.0), (2.0 * c).clamp(-15.0, 15.0))
+}
+
+/// Cramer's rule for a 3×3 system; `None` when it is singular.
+fn solve3(m: [[f64; 3]; 3], v: [f64; 3]) -> Option<[f64; 3]> {
+    let det = |a: &[[f64; 3]; 3]| {
+        a[0][0] * (a[1][1] * a[2][2] - a[1][2] * a[2][1])
+            - a[0][1] * (a[1][0] * a[2][2] - a[1][2] * a[2][0])
+            + a[0][2] * (a[1][0] * a[2][1] - a[1][1] * a[2][0])
+    };
+    let d = det(&m);
+    if d.abs() < 1e-9 {
+        return None;
     }
-    (num / den).clamp(-40.0, 40.0)
+    let mut out = [0.0f64; 3];
+    for (i, o) in out.iter_mut().enumerate() {
+        let mut mi = m;
+        for row in 0..3 {
+            mi[row][i] = v[row];
+        }
+        *o = det(&mi) / d;
+    }
+    Some(out)
 }
 
 /// Build a full status snapshot from the worker's running counters — the one
@@ -391,6 +433,7 @@ fn status_snapshot(
     last: &Option<(f64, String, i64)>,
     last_est: &Option<(bpsk::CarrierEstimate, i64)>,
     drift_hz_s: f64,
+    drift_accel_hz_s2: f64,
     progress: &bpsk::DecodeProgress,
     buf_len: usize,
     frame_len: usize,
@@ -414,10 +457,12 @@ fn status_snapshot(
         est_updates,
         est_misses,
         est_drift_hz_s: if fresh.is_some() { drift_hz_s as f32 } else { 0.0 },
+        est_drift_accel_hz_s2: if fresh.is_some() { drift_accel_hz_s2 as f32 } else { 0.0 },
         decoding: cfg.decode_telemetry,
         carrier_seen: progress.carrier,
         sync_seen: progress.sync,
         sync_bit_errors: progress.sync_bit_errors,
+        sync_matches: progress.sync_matches,
         frame_fill: if frame_len > 0 { (buf_len as f32 / frame_len as f32).min(1.0) } else { 0.0 },
         crc_ok: progress.crc_ok,
         // The closed-loop fields are the engine's to fill in — the worker
@@ -467,23 +512,35 @@ mod tests {
     }
 
     #[test]
-    fn drift_slope_fits_a_steady_walk_and_ignores_a_short_or_flat_run() {
+    fn drift_fit_recovers_rate_and_curvature_and_ignores_a_short_or_flat_run() {
         // Too few points, or too short a span: no fit.
         let mut h: VecDeque<(f64, f64)> = [(0.0, 100.0), (1.0, 106.0), (2.0, 112.0)].into();
-        assert_eq!(drift_slope(&h), 0.0, "three points is not enough");
+        assert_eq!(drift_fit(&h), (0.0, 0.0), "three points is not enough");
 
-        // A clean 6 Hz/s walk over a full fit window.
+        // A clean 6 Hz/s straight walk over a full fit window: rate 6, no
+        // curvature. The rate is reported at the middle of the window, which
+        // for a straight line is the same everywhere.
         h = (0..=12).map(|i| (i as f64, 100.0 + 6.0 * i as f64)).collect();
-        assert!((drift_slope(&h) - 6.0).abs() < 0.01, "got {}", drift_slope(&h));
+        let (rate, accel) = drift_fit(&h);
+        assert!((rate - 6.0).abs() < 0.05 && accel.abs() < 0.05, "rate {rate}, accel {accel}");
 
-        // Flat: near zero.
+        // hz(t) = 100 + 2t + 0.5·t² → curvature 1.0 Hz/s², and rate at the
+        // window middle (t = 6) is 2 + 1·6 = 8 Hz/s.
+        h = (0..=12).map(|i| (i as f64, 100.0 + 2.0 * i as f64 + 0.5 * (i * i) as f64)).collect();
+        let (rate, accel) = drift_fit(&h);
+        assert!((accel - 1.0).abs() < 0.02, "curvature {accel}");
+        assert!((rate - 8.0).abs() < 0.05, "mid-window rate {rate}");
+
+        // Flat: both near zero.
         h = (0..=12).map(|i| (i as f64, 200.0)).collect();
-        assert!(drift_slope(&h).abs() < 0.01);
+        let (rate, accel) = drift_fit(&h);
+        assert!(rate.abs() < 0.01 && accel.abs() < 0.01);
 
-        // A single wild estimate cannot drag the fit past the clamp.
+        // A single wild estimate cannot drag either term past its clamp.
         h = (0..=12).map(|i| (i as f64, 0.0)).collect();
         h.push_back((12.5, 1_000_000.0));
-        assert!(drift_slope(&h).abs() <= 40.0);
+        let (rate, accel) = drift_fit(&h);
+        assert!(rate.abs() <= 120.0 && accel.abs() <= 15.0);
     }
 
     #[test]

--- a/crates/sdroxide-qo100/src/controller.rs
+++ b/crates/sdroxide-qo100/src/controller.rs
@@ -31,6 +31,7 @@
 //! Settings ride a separate unbounded channel: rare, and must never be
 //! dropped even while the IQ queue is backed up.
 
+use std::collections::VecDeque;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::thread::JoinHandle;
@@ -161,6 +162,7 @@ impl Qo100Controller {
             .spawn({
                 let cancel = Arc::clone(&cancel);
                 move || {
+                    let started = std::time::Instant::now();
                     let mut cfg = cfg;
                     let mut buf: Vec<Complex32> = Vec::with_capacity(window_len);
                     let (mut tried, mut locked) = (0u64, 0u64);
@@ -168,6 +170,10 @@ impl Qo100Controller {
                     let (mut est_updates, mut est_misses) = (0u64, 0u64);
                     // Newest tracker estimate and the unix second it landed.
                     let mut last_est: Option<(bpsk::CarrierEstimate, i64)> = None;
+                    // Recent (elapsed_secs, offset_hz) estimates, for the
+                    // drift-rate fit the frame decoder is handed.
+                    let mut est_hist: VecDeque<(f64, f64)> = VecDeque::new();
+                    let mut drift_hz_s = 0.0f64;
                     let mut progress = bpsk::DecodeProgress::default();
                     // Samples gathered since the last tracker pass.
                     let mut since_track = 0usize;
@@ -225,13 +231,26 @@ impl Qo100Controller {
                                             Some(e) => {
                                                 est_updates += 1;
                                                 last_est = Some((e, now));
+                                                let t = started.elapsed().as_secs_f64();
+                                                est_hist.push_back((t, e.hz));
+                                                while est_hist
+                                                    .front()
+                                                    .is_some_and(|&(t0, _)| t - t0 > DRIFT_FIT_SECS)
+                                                {
+                                                    est_hist.pop_front();
+                                                }
+                                                drift_hz_s = drift_slope(&est_hist);
                                             }
-                                            None => est_misses += 1,
+                                            None => {
+                                                est_misses += 1;
+                                                est_hist.clear();
+                                                drift_hz_s = 0.0;
+                                            }
                                         }
                                         let _ = res_tx.send(status_snapshot(
                                             &cfg, tried, locked, est_updates, est_misses,
-                                            &last, &last_est, &progress, buf.len(), frame_len,
-                                            now,
+                                            &last, &last_est, drift_hz_s, &progress, buf.len(),
+                                            frame_len, now,
                                         ));
                                     }
 
@@ -249,6 +268,7 @@ impl Qo100Controller {
                                             cfg.search_half_width_hz,
                                             FREQ_STEP_HZ,
                                             DEMOD_RATE_HZ,
+                                            drift_hz_s,
                                             &cancel,
                                         );
                                         progress = prog;
@@ -270,7 +290,8 @@ impl Qo100Controller {
                                     buf.drain(..start);
                                     let _ = res_tx.send(status_snapshot(
                                         &cfg, tried, locked, est_updates, est_misses,
-                                        &last, &last_est, &progress, buf.len(), frame_len, now,
+                                        &last, &last_est, drift_hz_s, &progress, buf.len(),
+                                        frame_len, now,
                                     ));
                                 }
                                 Err(_) => break,
@@ -324,6 +345,39 @@ fn now_unix() -> i64 {
         .unwrap_or(0)
 }
 
+/// How long a stretch of tracker estimates the drift-rate fit uses.
+const DRIFT_FIT_SECS: f64 = 12.0;
+
+/// Least-squares slope, in Hz/s, of `(t, hz)` samples — the beacon's drift
+/// rate the frame decoder is handed. `0.0` until there are enough points over
+/// a long enough span for the fit to mean anything, and clamped to a sane
+/// range so one wild estimate cannot send the decoder chasing a huge chirp.
+fn drift_slope(hist: &VecDeque<(f64, f64)>) -> f64 {
+    if hist.len() < 4 {
+        return 0.0;
+    }
+    let n = hist.len() as f64;
+    let (mut st, mut sh) = (0.0, 0.0);
+    for &(t, h) in hist {
+        st += t;
+        sh += h;
+    }
+    let (tm, hm) = (st / n, sh / n);
+    let span = hist.back().unwrap().0 - hist.front().unwrap().0;
+    if span < 0.5 * DRIFT_FIT_SECS {
+        return 0.0;
+    }
+    let (mut num, mut den) = (0.0, 0.0);
+    for &(t, h) in hist {
+        num += (t - tm) * (h - hm);
+        den += (t - tm) * (t - tm);
+    }
+    if den <= 0.0 {
+        return 0.0;
+    }
+    (num / den).clamp(-40.0, 40.0)
+}
+
 /// Build a full status snapshot from the worker's running counters — the one
 /// place the wire type is assembled, so the tracker pass and the decode pass
 /// cannot drift apart in what they report.
@@ -336,6 +390,7 @@ fn status_snapshot(
     est_misses: u64,
     last: &Option<(f64, String, i64)>,
     last_est: &Option<(bpsk::CarrierEstimate, i64)>,
+    drift_hz_s: f64,
     progress: &bpsk::DecodeProgress,
     buf_len: usize,
     frame_len: usize,
@@ -358,6 +413,7 @@ fn status_snapshot(
         est_snr_db: fresh.map(|(e, _)| e.snr_db).unwrap_or(0.0),
         est_updates,
         est_misses,
+        est_drift_hz_s: if fresh.is_some() { drift_hz_s as f32 } else { 0.0 },
         decoding: cfg.decode_telemetry,
         carrier_seen: progress.carrier,
         sync_seen: progress.sync,
@@ -408,6 +464,26 @@ mod tests {
             .duration_since(std::time::UNIX_EPOCH)
             .map(|d| d.as_secs() as i64)
             .unwrap_or(0)
+    }
+
+    #[test]
+    fn drift_slope_fits_a_steady_walk_and_ignores_a_short_or_flat_run() {
+        // Too few points, or too short a span: no fit.
+        let mut h: VecDeque<(f64, f64)> = [(0.0, 100.0), (1.0, 106.0), (2.0, 112.0)].into();
+        assert_eq!(drift_slope(&h), 0.0, "three points is not enough");
+
+        // A clean 6 Hz/s walk over a full fit window.
+        h = (0..=12).map(|i| (i as f64, 100.0 + 6.0 * i as f64)).collect();
+        assert!((drift_slope(&h) - 6.0).abs() < 0.01, "got {}", drift_slope(&h));
+
+        // Flat: near zero.
+        h = (0..=12).map(|i| (i as f64, 200.0)).collect();
+        assert!(drift_slope(&h).abs() < 0.01);
+
+        // A single wild estimate cannot drag the fit past the clamp.
+        h = (0..=12).map(|i| (i as f64, 0.0)).collect();
+        h.push_back((12.5, 1_000_000.0));
+        assert!(drift_slope(&h).abs() <= 40.0);
     }
 
     #[test]

--- a/crates/sdroxide-qo100/src/controller.rs
+++ b/crates/sdroxide-qo100/src/controller.rs
@@ -73,6 +73,24 @@ fn keep_seconds() -> f64 {
     FRAME_SECONDS * 1.15
 }
 
+/// The spectral tracker's own short window — long enough for a stable Welch
+/// average of the beacon's twin-lobe shape, short enough to follow an LNB
+/// still drifting as it warms up. Independent of the frame decoder's much
+/// longer window: the tracker reads the beacon's *shape*, not its bits.
+fn track_seconds() -> f64 {
+    3.0
+}
+
+/// How much fresh IQ to gather between tracker passes — a new estimate on the
+/// screen about once a second.
+fn track_hop_seconds() -> f64 {
+    1.0
+}
+
+/// How long a tracker estimate stays on the status as current before it is
+/// dropped to `None` — a couple of tracker windows.
+const EST_FRESH_SECS: i64 = 12;
+
 /// Coarse frequency-grid step the search tries, in Hz. The delay-and-multiply
 /// chip detector `bpsk::acquire` runs at each candidate tolerates a residual
 /// carrier error of well over 100 Hz (its own tests decode an uncorrected
@@ -130,6 +148,9 @@ impl Qo100Controller {
         let cancel = Arc::new(AtomicBool::new(false));
         let window_len = (rate_hz * window_seconds()).round() as usize;
         let keep_len = (rate_hz * keep_seconds()).round() as usize;
+        let track_len = (rate_hz * track_seconds()).round().max(1.0) as usize;
+        let track_hop = (rate_hz * track_hop_seconds()).round().max(1.0) as usize;
+        let frame_len = (rate_hz * FRAME_SECONDS).round().max(1.0) as usize;
         let worker = std::thread::Builder::new()
             .name("sdroxide-qo100".into())
             .spawn({
@@ -139,6 +160,12 @@ impl Qo100Controller {
                     let mut buf: Vec<Complex32> = Vec::with_capacity(window_len);
                     let (mut tried, mut locked) = (0u64, 0u64);
                     let mut last: Option<(f64, String, i64)> = None; // offset, text, unix
+                    let (mut est_updates, mut est_misses) = (0u64, 0u64);
+                    // Newest tracker estimate and the unix second it landed.
+                    let mut last_est: Option<(bpsk::CarrierEstimate, i64)> = None;
+                    let mut progress = bpsk::DecodeProgress::default();
+                    // Samples gathered since the last tracker pass.
+                    let mut since_track = 0usize;
                     // The `seq` the next contiguous block would carry; `None`
                     // before the first one has arrived.
                     let mut want_seq: Option<u64> = None;
@@ -152,29 +179,69 @@ impl Qo100Controller {
                                 Ok(Iq { seq, samples }) => {
                                     if !continues_run(want_seq, seq) {
                                         buf.clear();
+                                        since_track = 0;
                                     }
                                     want_seq = Some(seq.wrapping_add(1));
                                     buf.extend_from_slice(&samples);
+                                    since_track += samples.len();
+                                    let now = now_unix();
+
+                                    // Fast tracker: the newest `track_len`
+                                    // samples, about once a second, scanning
+                                    // only the parking window for the beacon's
+                                    // twin-lobe shape. Anything in that window
+                                    // that is not two symmetric lobes simply
+                                    // does not win.
+                                    if cfg.enabled
+                                        && since_track >= track_hop
+                                        && buf.len() >= track_len
+                                    {
+                                        since_track = 0;
+                                        let tail = &buf[buf.len() - track_len..];
+                                        match bpsk::estimate_carrier(
+                                            tail,
+                                            rate_hz,
+                                            cfg.park_lo_hz,
+                                            cfg.park_hi_hz,
+                                        ) {
+                                            Some(e) => {
+                                                est_updates += 1;
+                                                last_est = Some((e, now));
+                                            }
+                                            None => est_misses += 1,
+                                        }
+                                        let _ = res_tx.send(status_snapshot(
+                                            &cfg, tried, locked, est_updates, est_misses,
+                                            &last, &last_est, &progress, buf.len(), frame_len,
+                                            now,
+                                        ));
+                                    }
+
                                     if buf.len() < window_len {
                                         continue;
                                     }
-                                    tried += 1;
-                                    let lock = bpsk::acquire(
-                                        &buf,
-                                        rate_hz,
-                                        cfg.search_half_width_hz,
-                                        FREQ_STEP_HZ,
-                                        DEMOD_RATE_HZ,
-                                        &cancel,
-                                    );
-                                    if let Some(l) = lock {
-                                        locked += 1;
-                                        let unix = std::time::SystemTime::now()
-                                            .duration_since(std::time::UNIX_EPOCH)
-                                            .map(|d| d.as_secs() as i64)
-                                            .unwrap_or(0);
-                                        last = Some((l.offset_hz, l.text, unix));
+
+                                    // Frame decoder: a whole window, only when
+                                    // the operator asked for the telemetry.
+                                    if cfg.decode_telemetry {
+                                        tried += 1;
+                                        let (lock, prog) = bpsk::acquire_debug(
+                                            &buf,
+                                            rate_hz,
+                                            cfg.search_half_width_hz,
+                                            FREQ_STEP_HZ,
+                                            DEMOD_RATE_HZ,
+                                            &cancel,
+                                        );
+                                        progress = prog;
+                                        if let Some(l) = lock {
+                                            locked += 1;
+                                            last = Some((l.offset_hz, l.text, now));
+                                        }
+                                    } else {
+                                        progress = bpsk::DecodeProgress::default();
                                     }
+
                                     // Keep the newest slice — enough overlap
                                     // that no frame can fall in the gap —
                                     // rather than clearing outright, so a
@@ -183,17 +250,10 @@ impl Qo100Controller {
                                     // being thrown away twice.
                                     let start = buf.len().saturating_sub(keep_len);
                                     buf.drain(..start);
-                                    let (offset_hz, text, locked_unix) =
-                                        last.clone().unwrap_or_default();
-                                    let _ = res_tx.send(sdroxide_types::Qo100Status {
-                                        running: true,
-                                        locked: lock_is_fresh(locked_unix),
-                                        offset_hz,
-                                        text,
-                                        locked_unix,
-                                        blocks_tried: tried,
-                                        blocks_locked: locked,
-                                    });
+                                    let _ = res_tx.send(status_snapshot(
+                                        &cfg, tried, locked, est_updates, est_misses,
+                                        &last, &last_est, &progress, buf.len(), frame_len, now,
+                                    ));
                                 }
                                 Err(_) => break,
                             },
@@ -236,6 +296,56 @@ impl Qo100Controller {
             out = Some(s);
         }
         out
+    }
+}
+
+fn now_unix() -> i64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs() as i64)
+        .unwrap_or(0)
+}
+
+/// Build a full status snapshot from the worker's running counters — the one
+/// place the wire type is assembled, so the tracker pass and the decode pass
+/// cannot drift apart in what they report.
+#[allow(clippy::too_many_arguments)]
+fn status_snapshot(
+    cfg: &Qo100Settings,
+    tried: u64,
+    locked: u64,
+    est_updates: u64,
+    est_misses: u64,
+    last: &Option<(f64, String, i64)>,
+    last_est: &Option<(bpsk::CarrierEstimate, i64)>,
+    progress: &bpsk::DecodeProgress,
+    buf_len: usize,
+    frame_len: usize,
+    now: i64,
+) -> sdroxide_types::Qo100Status {
+    let (offset_hz, text, locked_unix) = last.clone().unwrap_or_default();
+    let fresh = last_est.as_ref().filter(|(_, t)| now - t <= EST_FRESH_SECS);
+    sdroxide_types::Qo100Status {
+        running: cfg.enabled || cfg.decode_telemetry,
+        locked: lock_is_fresh(locked_unix),
+        offset_hz,
+        text,
+        locked_unix,
+        blocks_tried: tried,
+        blocks_locked: locked,
+        tracking: cfg.enabled,
+        est_offset_hz: fresh.map(|(e, _)| e.hz),
+        est_null_depth_db: fresh.map(|(e, _)| e.null_depth_db).unwrap_or(0.0),
+        est_symmetry: fresh.map(|(e, _)| e.symmetry).unwrap_or(0.0),
+        est_snr_db: fresh.map(|(e, _)| e.snr_db).unwrap_or(0.0),
+        est_updates,
+        est_misses,
+        decoding: cfg.decode_telemetry,
+        carrier_seen: progress.carrier,
+        sync_seen: progress.sync,
+        sync_bit_errors: progress.sync_bit_errors,
+        frame_fill: if frame_len > 0 { (buf_len as f32 / frame_len as f32).min(1.0) } else { 0.0 },
+        crc_ok: progress.crc_ok,
     }
 }
 
@@ -347,7 +457,12 @@ mod tests {
         let rate = 16_000.0;
         let c = Qo100Controller::new(
             rate,
-            Qo100Settings { enabled: true, search_half_width_hz: 300.0 },
+            Qo100Settings {
+                enabled: true,
+                decode_telemetry: true,
+                search_half_width_hz: 300.0,
+                ..Default::default()
+            },
         );
         let n = (rate * FRAME_SECONDS * 2.4) as usize; // a hair over one window
         let noise: Vec<Complex32> = (0..n)
@@ -372,7 +487,12 @@ mod tests {
         let rate = 16_000.0;
         let c = Qo100Controller::new(
             rate,
-            Qo100Settings { enabled: true, search_half_width_hz: 300.0 },
+            Qo100Settings {
+                enabled: true,
+                decode_telemetry: true,
+                search_half_width_hz: 300.0,
+                ..Default::default()
+            },
         );
         // One synth frame is ~10 s of signal and a window is ~24 s, so stack
         // three; the frame in the first copy lands wholly inside the buffer.
@@ -383,5 +503,33 @@ mod tests {
         assert!(s.locked);
         assert!((s.offset_hz - 150.0).abs() <= 3.0, "offset {}", s.offset_hz);
         assert!(s.text.starts_with("CONTROLLER E2E"), "{:?}", s.text);
+    }
+
+    /// The fast tracker reports where the beacon sits from its spectral shape
+    /// alone, with the telemetry decoder switched off — the split the QO-100
+    /// page is built around.
+    #[test]
+    fn the_tracker_places_the_beacon_without_decoding_telemetry() {
+        let rate = 60_000.0;
+        let c = Qo100Controller::new(
+            rate,
+            Qo100Settings {
+                enabled: true,
+                decode_telemetry: false,
+                park_lo_hz: 5_000.0,
+                park_hi_hz: 20_000.0,
+                ..Default::default()
+            },
+        );
+        // A few seconds of the beacon parked at +12 kHz.
+        let one = crate::bpsk::tests::synth_signal("TRACKED", rate, 12_000.0, 0.05, 3);
+        c.on_rx_iq(&one);
+        let s = wait_for(&c, |s| s.est_offset_hz.is_some())
+            .expect("the tracker should place the beacon");
+        assert!(s.tracking);
+        assert_eq!(s.blocks_locked, 0, "the telemetry decoder was off");
+        let est = s.est_offset_hz.unwrap();
+        assert!((est - 12_000.0).abs() <= 350.0, "est {est}");
+        assert!(s.est_updates >= 1 && s.est_null_depth_db >= 2.5, "{s:?}");
     }
 }

--- a/crates/sdroxide-qo100/src/controller.rs
+++ b/crates/sdroxide-qo100/src/controller.rs
@@ -91,6 +91,11 @@ fn track_hop_seconds() -> f64 {
 /// dropped to `None` — a couple of tracker windows.
 const EST_FRESH_SECS: i64 = 12;
 
+/// Half-width of the band the tracker scans once it has the beacon and it is
+/// no longer out in the parking window — wide enough to hold both lobes plus
+/// context and to not lose a beacon drifting a few hundred Hz between passes.
+const TRACK_BAND_HZ: f64 = 3_000.0;
+
 /// Coarse frequency-grid step the search tries, in Hz. The delay-and-multiply
 /// chip detector `bpsk::acquire` runs at each candidate tolerates a residual
 /// carrier error of well over 100 Hz (its own tests decode an uncorrected
@@ -187,23 +192,36 @@ impl Qo100Controller {
                                     let now = now_unix();
 
                                     // Fast tracker: the newest `track_len`
-                                    // samples, about once a second, scanning
-                                    // only the parking window for the beacon's
-                                    // twin-lobe shape. Anything in that window
-                                    // that is not two symmetric lobes simply
-                                    // does not win.
+                                    // samples, about once a second.
+                                    //
+                                    // Band: a narrow window around the last
+                                    // fresh estimate when there is one, so the
+                                    // tracker follows the beacon wherever it
+                                    // last sat — including down toward centre
+                                    // after the closed loop has corrected. On
+                                    // a cold start or after losing it: the
+                                    // operator's parking window, unless
+                                    // auto-correct is armed, in which case the
+                                    // loop's target is 0 so the sweep has to
+                                    // reach down there too. Anything that is
+                                    // not two symmetric lobes still does not
+                                    // win.
                                     if cfg.enabled
                                         && since_track >= track_hop
                                         && buf.len() >= track_len
                                     {
                                         since_track = 0;
                                         let tail = &buf[buf.len() - track_len..];
-                                        match bpsk::estimate_carrier(
-                                            tail,
-                                            rate_hz,
-                                            cfg.park_lo_hz,
-                                            cfg.park_hi_hz,
-                                        ) {
+                                        let (lo, hi) = match last_est {
+                                            Some((e, t)) if now - t <= EST_FRESH_SECS => {
+                                                (e.hz - TRACK_BAND_HZ, e.hz + TRACK_BAND_HZ)
+                                            }
+                                            _ if cfg.auto_apply => {
+                                                (-TRACK_BAND_HZ, cfg.park_hi_hz)
+                                            }
+                                            _ => (cfg.park_lo_hz, cfg.park_hi_hz),
+                                        };
+                                        match bpsk::estimate_carrier(tail, rate_hz, lo, hi) {
                                             Some(e) => {
                                                 est_updates += 1;
                                                 last_est = Some((e, now));
@@ -346,6 +364,9 @@ fn status_snapshot(
         sync_bit_errors: progress.sync_bit_errors,
         frame_fill: if frame_len > 0 { (buf_len as f32 / frame_len as f32).min(1.0) } else { 0.0 },
         crc_ok: progress.crc_ok,
+        // The closed-loop fields are the engine's to fill in — the worker
+        // only measures, it does not touch the converter offset.
+        ..Default::default()
     }
 }
 

--- a/crates/sdroxide-radio/src/engine.rs
+++ b/crates/sdroxide-radio/src/engine.rs
@@ -2717,8 +2717,8 @@ fn skim_center_for(
 /// The QO-100 beacon decoder's down-converter output rate for a search
 /// half-width of `half_width_hz`: about 2.5× the search so the requested span
 /// fits under Nyquist with margin — see `sdroxide_qo100::bpsk` for why the
-/// decoder wants that oversampling — and floored at 16 kHz so the default
-/// (±5 kHz) and any narrower width still land on a sane, cheap rate. Widening
+/// decoder wants that oversampling — and floored at 16 kHz so the narrow
+/// widths (±5 kHz and near it) still land on a sane, cheap rate. Widening
 /// the search really does widen the capture the decoder is handed; the
 /// demodulator inside it always runs at a fixed rate regardless
 /// (`sdroxide_qo100`'s `DEMOD_RATE_HZ`), which is what keeps the search cost
@@ -15246,10 +15246,10 @@ mod skim_window_tests {
 mod qo100_rate_tests {
     use super::qo100_capture_rate_for;
 
-    /// The engine default (±5 kHz) and anything narrower sit on the 16 kHz
+    /// The narrowest width (±5 kHz) and anything down to it sit on the 16 kHz
     /// floor — ×2.5 does not reach it until ±6.4 kHz.
     #[test]
-    fn the_default_and_narrow_widths_sit_on_the_16_khz_floor() {
+    fn the_narrowest_widths_sit_on_the_16_khz_floor() {
         assert_eq!(qo100_capture_rate_for(5_000.0), 16_000.0);
         assert_eq!(qo100_capture_rate_for(0.0), 16_000.0);
         assert_eq!(qo100_capture_rate_for(6_400.0), 16_000.0);

--- a/crates/sdroxide-radio/src/engine.rs
+++ b/crates/sdroxide-radio/src/engine.rs
@@ -2727,6 +2727,18 @@ fn qo100_capture_rate_for(half_width_hz: f64) -> f64 {
     (half_width_hz * 2.5).max(16_000.0)
 }
 
+/// [`qo100_capture_rate_for`] folded together with the spectral tracker's
+/// parking window: while the tracker is on, the beacon the operator parked
+/// near `park_hi_hz` has to be inside what the receiver hands over too, not
+/// just whatever the telemetry search width asks for.
+fn qo100_rate_for_cfg(cfg: &sdroxide_types::Qo100Settings) -> f64 {
+    let mut w = cfg.search_half_width_hz;
+    if cfg.enabled {
+        w = w.max(cfg.park_hi_hz.max(cfg.park_lo_hz).max(0.0));
+    }
+    qo100_capture_rate_for(w)
+}
+
 /// How soon after noticing a disconnected front-end the first reconnect attempt
 /// runs, and the ceiling the spacing doubles up to while attempts keep failing.
 const RETRY_FIRST: Duration = Duration::from_secs(1);
@@ -8592,7 +8604,13 @@ impl Engine {
     /// the skimmer ask for, so it costs the engine almost nothing at the
     /// default width.
     fn qo100_target_rate_hz(&self) -> f64 {
-        qo100_capture_rate_for(self.state.qo100.search_half_width_hz)
+        qo100_rate_for_cfg(&self.state.qo100)
+    }
+
+    /// Whether the QO-100 worker should be running at all: the spectral
+    /// tracker or the telemetry decoder (or both) is switched on.
+    fn qo100_wanted(&self) -> bool {
+        self.state.qo100.enabled || self.state.qo100.decode_telemetry
     }
 
     /// Construct or tear down the QO-100 beacon decoder, mirroring
@@ -8607,8 +8625,9 @@ impl Engine {
         // downconverter from.
         if self.audio_mode {
             self.state.qo100.enabled = false;
+            self.state.qo100.decode_telemetry = false;
         }
-        match (self.state.qo100.enabled, self.qo100.is_some()) {
+        match (self.qo100_wanted(), self.qo100.is_some()) {
             (true, false) => {
                 let mut ddc = Ddc::new(self.state.sample_rate, self.qo100_target_rate_hz());
                 ddc.set_offset_hz(sdroxide_types::QO100_BEACON_HZ - self.state.center_hz);
@@ -15244,7 +15263,25 @@ mod skim_window_tests {
 
 #[cfg(test)]
 mod qo100_rate_tests {
-    use super::qo100_capture_rate_for;
+    use super::{qo100_capture_rate_for, qo100_rate_for_cfg};
+    use sdroxide_types::Qo100Settings;
+
+    #[test]
+    fn the_tracker_parking_window_widens_the_capture_but_only_while_enabled() {
+        // Telemetry-only: capture follows the search width alone.
+        let decode_only = Qo100Settings {
+            enabled: false,
+            decode_telemetry: true,
+            search_half_width_hz: 5_000.0,
+            park_hi_hz: 25_000.0,
+            ..Default::default()
+        };
+        assert_eq!(qo100_rate_for_cfg(&decode_only), 16_000.0);
+
+        // Tracker on: the beacon parked at +25 kHz has to fit under Nyquist.
+        let tracking = Qo100Settings { enabled: true, ..decode_only };
+        assert_eq!(qo100_rate_for_cfg(&tracking), qo100_capture_rate_for(25_000.0));
+    }
 
     /// The narrowest width (±5 kHz) and anything down to it sit on the 16 kHz
     /// floor — ×2.5 does not reach it until ±6.4 kHz.

--- a/crates/sdroxide-radio/src/engine.rs
+++ b/crates/sdroxide-radio/src/engine.rs
@@ -2330,6 +2330,10 @@ struct Engine {
     /// turns it on again. Not persisted to disk — there is nothing here worth
     /// surviving a restart.
     qo100_cfg: sdroxide_types::Qo100Settings,
+    /// The QO-100 spectral tracker's closed loop: what it has done to
+    /// `RadioConfig::converter_offset_hz` since the tracker was switched on.
+    /// Only live while `state.qo100.auto_apply` is set.
+    qo100_auto: Qo100Auto,
     /// Open capture file for `--record-iq`, and the interleaving scratch it is
     /// written from.
     iq_rec: Option<std::io::BufWriter<std::fs::File>>,
@@ -2737,6 +2741,81 @@ fn qo100_rate_for_cfg(cfg: &sdroxide_types::Qo100Settings) -> f64 {
         w = w.max(cfg.park_hi_hz.max(cfg.park_lo_hz).max(0.0));
     }
     qo100_capture_rate_for(w)
+}
+
+/// The QO-100 spectral tracker's closed loop, engine side. The worker reports
+/// where the beacon sits; this decides — slowly, and only on a clean, steady
+/// estimate — whether to nudge `RadioConfig::converter_offset_hz` so the
+/// beacon (and the receiver behind it) lands back on 10489.750 MHz.
+#[derive(Default)]
+struct Qo100Auto {
+    /// When the last correction was written, for the rate limit.
+    last_apply: Option<Instant>,
+    /// The previous estimate that passed the quality bar, so a correction
+    /// needs two clean cycles that agree, not one.
+    pending_hz: Option<f64>,
+    /// Signed Hz written into the converter offset since the tracker came on,
+    /// and how many writes that took — shown on the QO-100 page.
+    total_hz: f64,
+    applies: u64,
+    /// The last single correction, and the unix second it happened.
+    last_hz: f64,
+    last_unix: i64,
+}
+
+/// The tracker's estimate must clear all of these before its correction is
+/// written: a convincing twin-lobe shape, not a marginal one.
+const QO100_AUTO_NULL_DB: f32 = 5.0;
+const QO100_AUTO_SYM: f32 = 0.7;
+const QO100_AUTO_SNR_DB: f32 = 4.0;
+/// Two consecutive clean estimates must agree within this for a correction to
+/// go out — one good cycle alone does not move a running receiver.
+const QO100_AUTO_AGREE_HZ: f64 = 300.0;
+/// Corrections smaller than this are left alone: below it the reopen is not
+/// worth the interruption, and the residual is already within a hair of a
+/// hertz of the beacon.
+const QO100_AUTO_DEADBAND_HZ: f64 = 150.0;
+/// The soonest a second correction can follow the first — the LNB drifts over
+/// minutes, not seconds, so this only ever bites on a bad run.
+const QO100_AUTO_MIN_INTERVAL: Duration = Duration::from_secs(12);
+
+/// What one pass of the tracker's closed loop decided.
+struct Qo100AutoOutcome {
+    /// Hz to add to the converter offset now — `None` means "not this cycle".
+    correction: Option<f64>,
+    /// What the "previous clean estimate" slot should hold going forward.
+    pending_hz: Option<f64>,
+}
+
+/// The closed loop's decision, pure so it can be tested without an engine: a
+/// correction goes out only on a *clean* estimate (a convincing twin-lobe
+/// shape) that a previous clean cycle *agreed with*, that clears the
+/// deadband, and only if the last correction has had time to settle.
+/// `since_last` is `None` before the loop has ever acted.
+fn qo100_auto_correction(
+    est_offset_hz: Option<f64>,
+    null_db: f32,
+    sym: f32,
+    snr_db: f32,
+    pending_hz: Option<f64>,
+    since_last: Option<Duration>,
+) -> Qo100AutoOutcome {
+    let none = |pending| Qo100AutoOutcome { correction: None, pending_hz: pending };
+
+    let Some(off) = est_offset_hz else { return none(None) };
+    let clean =
+        null_db >= QO100_AUTO_NULL_DB && sym >= QO100_AUTO_SYM && snr_db >= QO100_AUTO_SNR_DB;
+    if !clean {
+        return none(None);
+    }
+    if !pending_hz.is_some_and(|p| (p - off).abs() <= QO100_AUTO_AGREE_HZ) {
+        return none(Some(off)); // first clean cycle — wait for a second that agrees
+    }
+    let cooled = since_last.is_none_or(|d| d >= QO100_AUTO_MIN_INTERVAL);
+    if !cooled || off.abs() < QO100_AUTO_DEADBAND_HZ {
+        return none(Some(off));
+    }
+    Qo100AutoOutcome { correction: Some(off), pending_hz: None }
 }
 
 /// How soon after noticing a disconnected front-end the first reconnect attempt
@@ -3280,6 +3359,7 @@ fn engine_thread(
         // Session-scoped only, unlike `skim_cfg`/`ism_cfg` — see
         // `sync_qo100`'s doc for why this one is not read back from disk.
         qo100_cfg: sdroxide_types::Qo100Settings::default(),
+        qo100_auto: Qo100Auto::default(),
         iq_rec,
         iq_rec_buf: Vec::new(),
         iq_wav: None,
@@ -8684,12 +8764,68 @@ impl Engine {
         ddc.set_offset_hz(sdroxide_types::QO100_BEACON_HZ - self.state.center_hz);
     }
 
-    /// Drain the QO-100 beacon decoder's latest status and forward it.
+    /// Drain the QO-100 beacon decoder's latest status, run the tracker's
+    /// closed loop against it, and forward it.
     fn poll_qo100(&mut self) {
         let Some(c) = self.qo100.as_ref() else { return };
-        if let Some(status) = c.poll() {
-            let _ = self.event_tx.send(RadioEvent::Qo100Status(status));
+        let Some(mut status) = c.poll() else { return };
+
+        let armed = self.state.qo100.enabled && self.state.qo100.auto_apply;
+        if !armed {
+            // Turning the loop off (or the whole tracker off) starts the
+            // running totals fresh next time.
+            self.qo100_auto = Qo100Auto::default();
+        } else {
+            self.qo100_auto_step(&status);
+            status.auto_applying = true;
+            status.auto_total_hz = self.qo100_auto.total_hz;
+            status.auto_applies = self.qo100_auto.applies;
+            status.auto_last_hz = self.qo100_auto.last_hz;
+            status.auto_last_unix = self.qo100_auto.last_unix;
         }
+
+        let _ = self.event_tx.send(RadioEvent::Qo100Status(status));
+    }
+
+    /// One pass of the tracker's closed loop: decide whether this estimate is
+    /// clean and steady enough to write into the converter offset, and if so
+    /// do it. Deadband + rate-limit + a two-cycle agreement check keep it
+    /// from yanking a running receiver on a single bad reading — the
+    /// "deadband + rare reopen" approach the QO-100 page is built around.
+    fn qo100_auto_step(&mut self, status: &sdroxide_types::Qo100Status) {
+        let out = qo100_auto_correction(
+            status.est_offset_hz,
+            status.est_null_depth_db,
+            status.est_symmetry,
+            status.est_snr_db,
+            self.qo100_auto.pending_hz,
+            self.qo100_auto.last_apply.map(|t| t.elapsed()),
+        );
+        self.qo100_auto.pending_hz = out.pending_hz;
+        let Some(off) = out.correction else { return };
+
+        // `hardware_hz = dial_hz + offset`, so moving the beacon from where it
+        // reads (`target + off`) back onto `target` means adding `off` to the
+        // converter offset — the same maths the page's APPLY button uses.
+        let mut cfg = self.store.load_radio_config();
+        cfg.converter_offset_hz += off;
+        if let Err(e) = self.store.save_radio_config(&cfg) {
+            warn!("qo100 auto-apply: saving radio config: {e}");
+            return;
+        }
+        self.emit_radio_config();
+        self.reopen_source();
+
+        self.qo100_auto.last_apply = Some(Instant::now());
+        self.qo100_auto.total_hz += off;
+        self.qo100_auto.applies += 1;
+        self.qo100_auto.last_hz = off;
+        self.qo100_auto.last_unix = unix_now_f64() as i64;
+        info!(
+            correction_hz = off,
+            total_hz = self.qo100_auto.total_hz,
+            "QO-100 tracker corrected the converter offset"
+        );
     }
 
     /// Drain the ISM decoder's device table and status and forward them.
@@ -15265,6 +15401,63 @@ mod skim_window_tests {
 mod qo100_rate_tests {
     use super::{qo100_capture_rate_for, qo100_rate_for_cfg};
     use sdroxide_types::Qo100Settings;
+
+    use super::{QO100_AUTO_MIN_INTERVAL, qo100_auto_correction};
+    use std::time::Duration;
+
+    // A twin-lobe shape clean enough for the loop to act on.
+    const CLEAN: (f32, f32, f32) = (7.0, 0.85, 6.0);
+
+    #[test]
+    fn the_loop_needs_two_agreeing_clean_cycles_before_it_corrects() {
+        let (n, s, r) = CLEAN;
+        // First clean cycle: nothing applied, estimate remembered.
+        let a = qo100_auto_correction(Some(400.0), n, s, r, None, None);
+        assert_eq!(a.correction, None);
+        assert_eq!(a.pending_hz, Some(400.0));
+        // Second clean cycle that agrees: correction goes out.
+        let b = qo100_auto_correction(Some(390.0), n, s, r, a.pending_hz, None);
+        assert_eq!(b.correction, Some(390.0));
+        assert_eq!(b.pending_hz, None);
+    }
+
+    #[test]
+    fn a_marginal_shape_never_corrects_and_forgets_the_pending_estimate() {
+        // null-depth below the bar, even with a pending estimate that agrees.
+        let out = qo100_auto_correction(Some(400.0), 3.0, 0.85, 6.0, Some(400.0), None);
+        assert_eq!(out.correction, None);
+        assert_eq!(out.pending_hz, None, "a bad cycle clears the agreement chain");
+    }
+
+    #[test]
+    fn two_clean_cycles_that_disagree_do_not_correct() {
+        let (n, s, r) = CLEAN;
+        let out = qo100_auto_correction(Some(400.0), n, s, r, Some(-400.0), None);
+        assert_eq!(out.correction, None);
+        assert_eq!(out.pending_hz, Some(400.0), "the newer estimate becomes the pending one");
+    }
+
+    #[test]
+    fn inside_the_deadband_nothing_is_written() {
+        let (n, s, r) = CLEAN;
+        let out = qo100_auto_correction(Some(90.0), n, s, r, Some(95.0), None);
+        assert_eq!(out.correction, None);
+    }
+
+    #[test]
+    fn a_recent_correction_holds_the_next_one_off() {
+        let (n, s, r) = CLEAN;
+        let just_now = Some(Duration::from_secs(2));
+        assert_eq!(
+            qo100_auto_correction(Some(400.0), n, s, r, Some(400.0), just_now).correction,
+            None
+        );
+        let settled = Some(QO100_AUTO_MIN_INTERVAL + Duration::from_secs(1));
+        assert_eq!(
+            qo100_auto_correction(Some(400.0), n, s, r, Some(400.0), settled).correction,
+            Some(400.0)
+        );
+    }
 
     #[test]
     fn the_tracker_parking_window_widens_the_capture_but_only_while_enabled() {

--- a/crates/sdroxide-radio/src/engine.rs
+++ b/crates/sdroxide-radio/src/engine.rs
@@ -2731,16 +2731,26 @@ fn qo100_capture_rate_for(half_width_hz: f64) -> f64 {
     (half_width_hz * 2.5).max(16_000.0)
 }
 
-/// [`qo100_capture_rate_for`] folded together with the spectral tracker's
-/// parking window: while the tracker is on, the beacon the operator parked
-/// near `park_hi_hz` has to be inside what the receiver hands over too, not
-/// just whatever the telemetry search width asks for.
+/// The capture rate the QO-100 worker needs for `cfg`.
+///
+/// The frame decoder wants [`qo100_capture_rate_for`]'s ~2.5× oversampling of
+/// its search width (see `sdroxide_qo100::bpsk`). The spectral tracker is much
+/// cheaper to feed: it only needs the parking window plus a lobe's worth of
+/// margin under Nyquist, so when it is running *without* the decoder the rate
+/// is just `park_hi + margin` — a third of what 2.5×25 kHz would ask for, and
+/// the difference is real load on a marginal receiver.
 fn qo100_rate_for_cfg(cfg: &sdroxide_types::Qo100Settings) -> f64 {
-    let mut w = cfg.search_half_width_hz;
-    if cfg.enabled {
-        w = w.max(cfg.park_hi_hz.max(cfg.park_lo_hz).max(0.0));
-    }
-    qo100_capture_rate_for(w)
+    let park = if cfg.enabled { cfg.park_hi_hz.max(cfg.park_lo_hz).max(0.0) } else { 0.0 };
+    let decoder = if cfg.decode_telemetry {
+        qo100_capture_rate_for(cfg.search_half_width_hz.max(park))
+    } else {
+        0.0
+    };
+    // Tracker-only: enough to hold the parked beacon's upper lobe (~800 Hz
+    // above the carrier) under Nyquist with room, and no more — a smaller
+    // parking window is a lighter receiver.
+    let tracker = if cfg.enabled { (park + 2_000.0) * 2.2 } else { 0.0 };
+    decoder.max(tracker).max(16_000.0)
 }
 
 /// The QO-100 spectral tracker's closed loop, engine side. The worker reports
@@ -2751,9 +2761,12 @@ fn qo100_rate_for_cfg(cfg: &sdroxide_types::Qo100Settings) -> f64 {
 struct Qo100Auto {
     /// When the last correction was written, for the rate limit.
     last_apply: Option<Instant>,
-    /// The previous estimate that passed the quality bar, so a correction
-    /// needs two clean cycles that agree, not one.
-    pending_hz: Option<f64>,
+    /// The most recent clean estimate, and how many clean estimates in a row
+    /// (this one included) have agreed with it — a correction needs
+    /// [`QO100_AUTO_AGREE_RUN`] before it will move a running receiver, so one
+    /// or two stray readings never reopen the front end.
+    agree_ref_hz: Option<f64>,
+    agree_run: u8,
     /// Signed Hz written into the converter offset since the tracker came on,
     /// and how many writes that took — shown on the QO-100 page.
     total_hz: f64,
@@ -2768,28 +2781,34 @@ struct Qo100Auto {
 const QO100_AUTO_NULL_DB: f32 = 5.0;
 const QO100_AUTO_SYM: f32 = 0.7;
 const QO100_AUTO_SNR_DB: f32 = 4.0;
-/// Two consecutive clean estimates must agree within this for a correction to
-/// go out — one good cycle alone does not move a running receiver.
-const QO100_AUTO_AGREE_HZ: f64 = 300.0;
+/// Consecutive clean estimates must agree within this to count toward the run.
+const QO100_AUTO_AGREE_HZ: f64 = 250.0;
+/// How many agreeing clean estimates in a row it takes before a correction
+/// goes out — a drifting LNB gives a long steady run; a noisy estimate that
+/// jumps around never builds one.
+const QO100_AUTO_AGREE_RUN: u8 = 3;
 /// Corrections smaller than this are left alone: below it the reopen is not
-/// worth the interruption, and the residual is already within a hair of a
-/// hertz of the beacon.
-const QO100_AUTO_DEADBAND_HZ: f64 = 150.0;
+/// worth the interruption, and the residual is already close enough that the
+/// receiver behind the beacon is calibrated.
+const QO100_AUTO_DEADBAND_HZ: f64 = 200.0;
 /// The soonest a second correction can follow the first — the LNB drifts over
-/// minutes, not seconds, so this only ever bites on a bad run.
-const QO100_AUTO_MIN_INTERVAL: Duration = Duration::from_secs(12);
+/// minutes, not seconds, so this only ever bites on a bad run, and it keeps
+/// the front-end reopen each correction costs to at most one every half a
+/// minute.
+const QO100_AUTO_MIN_INTERVAL: Duration = Duration::from_secs(30);
 
 /// What one pass of the tracker's closed loop decided.
 struct Qo100AutoOutcome {
     /// Hz to add to the converter offset now — `None` means "not this cycle".
     correction: Option<f64>,
-    /// What the "previous clean estimate" slot should hold going forward.
-    pending_hz: Option<f64>,
+    /// The agreement reference and run length to carry forward.
+    agree_ref_hz: Option<f64>,
+    agree_run: u8,
 }
 
 /// The closed loop's decision, pure so it can be tested without an engine: a
-/// correction goes out only on a *clean* estimate (a convincing twin-lobe
-/// shape) that a previous clean cycle *agreed with*, that clears the
+/// correction goes out only after [`QO100_AUTO_AGREE_RUN`] *clean* estimates
+/// (a convincing twin-lobe shape) in a row that all agree, that clears the
 /// deadband, and only if the last correction has had time to settle.
 /// `since_last` is `None` before the loop has ever acted.
 fn qo100_auto_correction(
@@ -2797,25 +2816,38 @@ fn qo100_auto_correction(
     null_db: f32,
     sym: f32,
     snr_db: f32,
-    pending_hz: Option<f64>,
+    agree_ref_hz: Option<f64>,
+    agree_run: u8,
     since_last: Option<Duration>,
 ) -> Qo100AutoOutcome {
-    let none = |pending| Qo100AutoOutcome { correction: None, pending_hz: pending };
+    let hold = |r, n| Qo100AutoOutcome { correction: None, agree_ref_hz: r, agree_run: n };
 
-    let Some(off) = est_offset_hz else { return none(None) };
+    let Some(off) = est_offset_hz else { return hold(None, 0) };
     let clean =
         null_db >= QO100_AUTO_NULL_DB && sym >= QO100_AUTO_SYM && snr_db >= QO100_AUTO_SNR_DB;
     if !clean {
-        return none(None);
+        return hold(None, 0); // a bad cycle breaks the run
     }
-    if !pending_hz.is_some_and(|p| (p - off).abs() <= QO100_AUTO_AGREE_HZ) {
-        return none(Some(off)); // first clean cycle — wait for a second that agrees
+
+    // Extend the run if this estimate agrees with the reference (and has the
+    // same sign — a drift keeps one sign, an oscillation flips), else restart.
+    let run = match agree_ref_hz {
+        Some(r) if (r - off).abs() <= QO100_AUTO_AGREE_HZ && r.signum() == off.signum() => {
+            agree_run.saturating_add(1)
+        }
+        _ => 1,
+    };
+    if run < QO100_AUTO_AGREE_RUN {
+        return hold(Some(off), run);
     }
+
     let cooled = since_last.is_none_or(|d| d >= QO100_AUTO_MIN_INTERVAL);
     if !cooled || off.abs() < QO100_AUTO_DEADBAND_HZ {
-        return none(Some(off));
+        return hold(Some(off), run);
     }
-    Qo100AutoOutcome { correction: Some(off), pending_hz: None }
+    // Correction written: start a fresh run so the next one needs its own
+    // steady stretch of agreeing estimates.
+    Qo100AutoOutcome { correction: Some(off), agree_ref_hz: None, agree_run: 0 }
 }
 
 /// How soon after noticing a disconnected front-end the first reconnect attempt
@@ -8798,10 +8830,12 @@ impl Engine {
             status.est_null_depth_db,
             status.est_symmetry,
             status.est_snr_db,
-            self.qo100_auto.pending_hz,
+            self.qo100_auto.agree_ref_hz,
+            self.qo100_auto.agree_run,
             self.qo100_auto.last_apply.map(|t| t.elapsed()),
         );
-        self.qo100_auto.pending_hz = out.pending_hz;
+        self.qo100_auto.agree_ref_hz = out.agree_ref_hz;
+        self.qo100_auto.agree_run = out.agree_run;
         let Some(off) = out.correction else { return };
 
         // `hardware_hz = dial_hz + offset`, so moving the beacon from where it
@@ -15402,78 +15436,104 @@ mod qo100_rate_tests {
     use super::{qo100_capture_rate_for, qo100_rate_for_cfg};
     use sdroxide_types::Qo100Settings;
 
-    use super::{QO100_AUTO_MIN_INTERVAL, qo100_auto_correction};
+    use super::{QO100_AUTO_AGREE_RUN, QO100_AUTO_MIN_INTERVAL, qo100_auto_correction};
     use std::time::Duration;
 
     // A twin-lobe shape clean enough for the loop to act on.
     const CLEAN: (f32, f32, f32) = (7.0, 0.85, 6.0);
 
-    #[test]
-    fn the_loop_needs_two_agreeing_clean_cycles_before_it_corrects() {
+    /// Feed `off` through as a run of agreeing clean cycles and return the
+    /// final outcome — `since_last` says how long ago the last correction was.
+    fn run(off: f64, cycles: u8, since_last: Option<Duration>) -> super::Qo100AutoOutcome {
         let (n, s, r) = CLEAN;
-        // First clean cycle: nothing applied, estimate remembered.
-        let a = qo100_auto_correction(Some(400.0), n, s, r, None, None);
-        assert_eq!(a.correction, None);
-        assert_eq!(a.pending_hz, Some(400.0));
-        // Second clean cycle that agrees: correction goes out.
-        let b = qo100_auto_correction(Some(390.0), n, s, r, a.pending_hz, None);
-        assert_eq!(b.correction, Some(390.0));
-        assert_eq!(b.pending_hz, None);
+        let mut ref_hz = None;
+        let mut run = 0u8;
+        let mut out = qo100_auto_correction(Some(off), n, s, r, ref_hz, run, since_last);
+        for _ in 1..cycles {
+            ref_hz = out.agree_ref_hz;
+            run = out.agree_run;
+            out = qo100_auto_correction(Some(off), n, s, r, ref_hz, run, since_last);
+        }
+        out
     }
 
     #[test]
-    fn a_marginal_shape_never_corrects_and_forgets_the_pending_estimate() {
-        // null-depth below the bar, even with a pending estimate that agrees.
-        let out = qo100_auto_correction(Some(400.0), 3.0, 0.85, 6.0, Some(400.0), None);
-        assert_eq!(out.correction, None);
-        assert_eq!(out.pending_hz, None, "a bad cycle clears the agreement chain");
+    fn the_loop_needs_a_run_of_agreeing_clean_cycles_before_it_corrects() {
+        // One short of the run: still nothing.
+        let held = run(400.0, QO100_AUTO_AGREE_RUN - 1, None);
+        assert_eq!(held.correction, None);
+        // The run completed: correction goes out and the run resets.
+        let fired = run(400.0, QO100_AUTO_AGREE_RUN, None);
+        assert_eq!(fired.correction, Some(400.0));
+        assert_eq!(fired.agree_run, 0);
+        assert_eq!(fired.agree_ref_hz, None);
     }
 
     #[test]
-    fn two_clean_cycles_that_disagree_do_not_correct() {
-        let (n, s, r) = CLEAN;
-        let out = qo100_auto_correction(Some(400.0), n, s, r, Some(-400.0), None);
+    fn a_marginal_shape_breaks_the_run() {
+        let (_, s, r) = CLEAN;
+        // A full run's worth of agreeing estimates, but the shape is marginal.
+        let out = qo100_auto_correction(Some(400.0), 3.0, s, r, Some(400.0), 9, None);
         assert_eq!(out.correction, None);
-        assert_eq!(out.pending_hz, Some(400.0), "the newer estimate becomes the pending one");
+        assert_eq!(out.agree_run, 0, "a bad cycle resets the run");
+    }
+
+    #[test]
+    fn an_estimate_that_flips_sign_restarts_the_run() {
+        let (n, s, r) = CLEAN;
+        let out = qo100_auto_correction(Some(400.0), n, s, r, Some(-400.0), 9, None);
+        assert_eq!(out.correction, None);
+        assert_eq!(out.agree_run, 1, "an oscillation never builds a run");
     }
 
     #[test]
     fn inside_the_deadband_nothing_is_written() {
-        let (n, s, r) = CLEAN;
-        let out = qo100_auto_correction(Some(90.0), n, s, r, Some(95.0), None);
+        let out = run(120.0, QO100_AUTO_AGREE_RUN + 2, None);
         assert_eq!(out.correction, None);
     }
 
     #[test]
     fn a_recent_correction_holds_the_next_one_off() {
-        let (n, s, r) = CLEAN;
-        let just_now = Some(Duration::from_secs(2));
         assert_eq!(
-            qo100_auto_correction(Some(400.0), n, s, r, Some(400.0), just_now).correction,
+            run(400.0, QO100_AUTO_AGREE_RUN + 2, Some(Duration::from_secs(2))).correction,
             None
         );
         let settled = Some(QO100_AUTO_MIN_INTERVAL + Duration::from_secs(1));
-        assert_eq!(
-            qo100_auto_correction(Some(400.0), n, s, r, Some(400.0), settled).correction,
-            Some(400.0)
+        assert_eq!(run(400.0, QO100_AUTO_AGREE_RUN, settled).correction, Some(400.0));
+    }
+
+    #[test]
+    fn the_tracker_only_capture_just_covers_the_parking_window() {
+        // Decoder off: with the tracker off too, the floor.
+        let off = Qo100Settings {
+            enabled: false,
+            decode_telemetry: false,
+            park_hi_hz: 12_000.0,
+            ..Default::default()
+        };
+        assert_eq!(qo100_rate_for_cfg(&off), 16_000.0);
+
+        // Tracker on, decoder off: enough to hold the top of the parking
+        // window under Nyquist, and much less than the decoder's 2.5x.
+        let tracking = Qo100Settings { enabled: true, search_half_width_hz: 25_000.0, ..off };
+        let r = qo100_rate_for_cfg(&tracking);
+        assert!(r / 2.0 > 12_000.0 + 800.0, "beacon at +12 kHz must be under Nyquist: {r}");
+        assert!(
+            r < 0.6 * qo100_capture_rate_for(25_000.0),
+            "much lighter than what the decoder would ask for the same station: {r}"
         );
     }
 
     #[test]
-    fn the_tracker_parking_window_widens_the_capture_but_only_while_enabled() {
-        // Telemetry-only: capture follows the search width alone.
-        let decode_only = Qo100Settings {
-            enabled: false,
+    fn the_decoder_path_still_gets_its_full_oversampling() {
+        let decode = Qo100Settings {
+            enabled: true,
             decode_telemetry: true,
-            search_half_width_hz: 5_000.0,
-            park_hi_hz: 25_000.0,
+            search_half_width_hz: 25_000.0,
+            park_hi_hz: 12_000.0,
             ..Default::default()
         };
-        assert_eq!(qo100_rate_for_cfg(&decode_only), 16_000.0);
-
-        // Tracker on: the beacon parked at +25 kHz has to fit under Nyquist.
-        let tracking = Qo100Settings { enabled: true, ..decode_only };
-        assert_eq!(qo100_rate_for_cfg(&tracking), qo100_capture_rate_for(25_000.0));
+        assert_eq!(qo100_rate_for_cfg(&decode), qo100_capture_rate_for(25_000.0));
     }
 
     /// The narrowest width (±5 kHz) and anything down to it sit on the 16 kHz

--- a/crates/sdroxide-types/src/qo100.rs
+++ b/crates/sdroxide-types/src/qo100.rs
@@ -15,22 +15,42 @@ pub const QO100_BEACON_HZ: f64 = 10_489_750_000.0;
 /// What the operator asks the beacon decoder to do.
 #[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
 pub struct Qo100Settings {
-    /// Whether the decoder runs at all. Off by default: it is a calibration
-    /// tool reached for occasionally, not something every station pays a
-    /// downconverter and a worker thread for by default.
+    /// Whether the spectral tracker runs at all. Off by default: it is a
+    /// calibration tool reached for occasionally, not something every station
+    /// pays a downconverter and a worker thread for by default. When on, the
+    /// engine watches the parking window ([`Self::park_lo_hz`]..
+    /// [`Self::park_hi_hz`]) for the beacon's twin-lobe shape and reports
+    /// where it sits, cycle after cycle.
     pub enabled: bool,
-    /// Half the width, in Hz, of the frequency range searched around
-    /// [`QO100_BEACON_HZ`] — set from the QO-100 window's own width buttons.
-    /// Starts at 25 kHz: this is a first-run calibration tool, and an
-    /// uncalibrated LNB's LO can sit tens of kHz off, so the opening search is
-    /// wide enough to catch that in one pass. Once a correction has been
-    /// applied the operator can narrow it right down.
+    /// Half the width, in Hz, of the frequency range the *telemetry* decoder
+    /// ([`Self::decode_telemetry`]) sweeps around [`QO100_BEACON_HZ`]. The
+    /// tracker does not use this — it searches the parking window instead.
     pub search_half_width_hz: f64,
+    /// The low and high edge, in Hz above [`QO100_BEACON_HZ`], of the window
+    /// the operator parks the beacon in before switching the tracker on. A
+    /// positive lane clear of the DC spike and of most transponder activity:
+    /// the operator nudges the dial until the beacon's two lobes sit inside
+    /// it, so the tracker is confirming a shape already on screen rather than
+    /// hunting blind. Default +5 kHz..+25 kHz.
+    pub park_lo_hz: f64,
+    pub park_hi_hz: f64,
+    /// Whether to also run the AO-40 uncoded frame decoder (sync word + CRC +
+    /// telemetry text). Separate from [`Self::enabled`]: the tracker keeps the
+    /// dial honest continuously off the beacon's *shape*, while decoding the
+    /// telemetry itself is a heavier, once-in-a-while thing the operator asks
+    /// for explicitly.
+    pub decode_telemetry: bool,
 }
 
 impl Default for Qo100Settings {
     fn default() -> Self {
-        Self { enabled: false, search_half_width_hz: 25_000.0 }
+        Self {
+            enabled: false,
+            search_half_width_hz: 25_000.0,
+            park_lo_hz: 5_000.0,
+            park_hi_hz: 25_000.0,
+            decode_telemetry: false,
+        }
     }
 }
 
@@ -63,4 +83,43 @@ pub struct Qo100Status {
     /// been found yet, rather than looking merely idle.
     pub blocks_tried: u64,
     pub blocks_locked: u64,
+
+    // --- spectral tracker (fast loop, off the beacon's twin-lobe shape) ---
+    /// Whether the tracker loop is running its short-window spectrum checks.
+    pub tracking: bool,
+    /// The tracker's current estimate of how far the beacon sits from
+    /// [`QO100_BEACON_HZ`], in Hz — `None` when the last cycle saw nothing
+    /// twin-lobe-shaped in the parking window.
+    pub est_offset_hz: Option<f64>,
+    /// Depth of the central null between the two lobes, in dB — how
+    /// convincingly the last estimate looked like the beacon rather than a
+    /// plain carrier.
+    pub est_null_depth_db: f32,
+    /// Left/right evenness of the two lobes, 0..1 (1 = perfectly symmetric).
+    pub est_symmetry: f32,
+    /// Lobe level over the parking-window noise floor, in dB.
+    pub est_snr_db: f32,
+    /// Tracker cycles that produced an estimate, and cycles that found
+    /// nothing, since the tracker was switched on.
+    pub est_updates: u64,
+    pub est_misses: u64,
+
+    // --- AO-40 uncoded decoder progress (only while `decoding`) ---
+    /// Whether [`Qo100Settings::decode_telemetry`] is on and the decoder is
+    /// actually being run.
+    pub decoding: bool,
+    /// The last decode pass found chip-rate energy to work on.
+    pub carrier_seen: bool,
+    /// The last decode pass matched the 32-bit AO-40 sync word somewhere
+    /// (within the error threshold).
+    pub sync_seen: bool,
+    /// Fewest sync-word bit errors seen in the last decode pass, 0..=32;
+    /// [`u8::MAX`] when the pass ran no bit stream at all.
+    pub sync_bit_errors: u8,
+    /// How much of one whole AO-40 frame the rolling buffer currently spans,
+    /// 0..1 — the decoder needs a full frame inside one window to have any
+    /// chance, and this says how close it is.
+    pub frame_fill: f32,
+    /// The last decode pass's CRC check result.
+    pub crc_ok: bool,
 }

--- a/crates/sdroxide-types/src/qo100.rs
+++ b/crates/sdroxide-types/src/qo100.rs
@@ -21,12 +21,16 @@ pub struct Qo100Settings {
     pub enabled: bool,
     /// Half the width, in Hz, of the frequency range searched around
     /// [`QO100_BEACON_HZ`] — set from the QO-100 window's own width buttons.
+    /// Starts at 25 kHz: this is a first-run calibration tool, and an
+    /// uncalibrated LNB's LO can sit tens of kHz off, so the opening search is
+    /// wide enough to catch that in one pass. Once a correction has been
+    /// applied the operator can narrow it right down.
     pub search_half_width_hz: f64,
 }
 
 impl Default for Qo100Settings {
     fn default() -> Self {
-        Self { enabled: false, search_half_width_hz: 5_000.0 }
+        Self { enabled: false, search_half_width_hz: 25_000.0 }
     }
 }
 

--- a/crates/sdroxide-types/src/qo100.rs
+++ b/crates/sdroxide-types/src/qo100.rs
@@ -40,6 +40,13 @@ pub struct Qo100Settings {
     /// telemetry itself is a heavier, once-in-a-while thing the operator asks
     /// for explicitly.
     pub decode_telemetry: bool,
+    /// Whether the tracker corrects `RadioConfig::converter_offset_hz` by
+    /// itself: a slow closed loop that, on a clean and steady estimate,
+    /// nudges the offset so the beacon (and the receiver behind it) lands
+    /// back on [`QO100_BEACON_HZ`], then holds it there as the LNB drifts
+    /// with temperature. Off by default — it reopens the front end each time
+    /// it acts.
+    pub auto_apply: bool,
 }
 
 impl Default for Qo100Settings {
@@ -50,6 +57,7 @@ impl Default for Qo100Settings {
             park_lo_hz: 5_000.0,
             park_hi_hz: 25_000.0,
             decode_telemetry: false,
+            auto_apply: false,
         }
     }
 }
@@ -122,4 +130,16 @@ pub struct Qo100Status {
     pub frame_fill: f32,
     /// The last decode pass's CRC check result.
     pub crc_ok: bool,
+
+    // --- closed loop (only while `Qo100Settings::auto_apply`) ---
+    /// The tracker's closed loop is armed and watching the estimate.
+    pub auto_applying: bool,
+    /// Signed Hz the loop has written into the converter offset since the
+    /// tracker came on, and how many separate corrections that took.
+    pub auto_total_hz: f64,
+    pub auto_applies: u64,
+    /// The most recent single correction, and the unix second it was made
+    /// (0 if the loop has not acted yet).
+    pub auto_last_hz: f64,
+    pub auto_last_unix: i64,
 }

--- a/crates/sdroxide-types/src/qo100.rs
+++ b/crates/sdroxide-types/src/qo100.rs
@@ -31,7 +31,10 @@ pub struct Qo100Settings {
     /// positive lane clear of the DC spike and of most transponder activity:
     /// the operator nudges the dial until the beacon's two lobes sit inside
     /// it, so the tracker is confirming a shape already on screen rather than
-    /// hunting blind. Default +5 kHz..+25 kHz.
+    /// hunting blind. Default +5 kHz..+12 kHz — kept modest because the
+    /// receiver has to sample fast enough to see the top of it, and a wider
+    /// window is real load. Raise it only if the LNB is far enough off that
+    /// the beacon will not sit inside the default.
     pub park_lo_hz: f64,
     pub park_hi_hz: f64,
     /// Whether to also run the AO-40 uncoded frame decoder (sync word + CRC +
@@ -55,7 +58,7 @@ impl Default for Qo100Settings {
             enabled: false,
             search_half_width_hz: 25_000.0,
             park_lo_hz: 5_000.0,
-            park_hi_hz: 25_000.0,
+            park_hi_hz: 12_000.0,
             decode_telemetry: false,
             auto_apply: false,
         }

--- a/crates/sdroxide-types/src/qo100.rs
+++ b/crates/sdroxide-types/src/qo100.rs
@@ -114,6 +114,10 @@ pub struct Qo100Status {
     /// nothing, since the tracker was switched on.
     pub est_updates: u64,
     pub est_misses: u64,
+    /// Least-squares drift rate of the last stretch of estimates, in Hz/s —
+    /// what the frame decoder de-rotates before looking for a frame. 0 until
+    /// there is a long enough run of estimates to fit.
+    pub est_drift_hz_s: f32,
 
     // --- AO-40 uncoded decoder progress (only while `decoding`) ---
     /// Whether [`Qo100Settings::decode_telemetry`] is on and the decoder is

--- a/crates/sdroxide-types/src/qo100.rs
+++ b/crates/sdroxide-types/src/qo100.rs
@@ -116,8 +116,14 @@ pub struct Qo100Status {
     pub est_misses: u64,
     /// Least-squares drift rate of the last stretch of estimates, in Hz/s —
     /// what the frame decoder de-rotates before looking for a frame. 0 until
-    /// there is a long enough run of estimates to fit.
+    /// there is a long enough run of estimates to fit. Reported at the middle
+    /// of the fit window, so it lines up with the decode buffer's own centre.
     pub est_drift_hz_s: f32,
+    /// Curvature of that same fit, in Hz/s² — a warming LNB's drift rate is
+    /// not constant, and this second-order term is de-rotated on top of
+    /// [`Self::est_drift_hz_s`]. 0 until the fit is long enough to mean
+    /// anything.
+    pub est_drift_accel_hz_s2: f32,
 
     // --- AO-40 uncoded decoder progress (only while `decoding`) ---
     /// Whether [`Qo100Settings::decode_telemetry`] is on and the decoder is
@@ -131,6 +137,12 @@ pub struct Qo100Status {
     /// Fewest sync-word bit errors seen in the last decode pass, 0..=32;
     /// [`u8::MAX`] when the pass ran no bit stream at all.
     pub sync_bit_errors: u8,
+    /// How many separate sync-word matches (within the error threshold) the
+    /// last pass's best bitstream carried. One or two, at very few errors, is
+    /// a real frame the payload demod is then failing; a lone match near the
+    /// full error budget is the chance hit a 32-bit pattern makes in a buffer
+    /// this long — which is how "sync lit, CRC dark" should be read.
+    pub sync_matches: u8,
     /// How much of one whole AO-40 frame the rolling buffer currently spans,
     /// 0..1 — the decoder needs a full frame inside one window to have any
     /// chance, and this says how close it is.

--- a/crates/sdroxide-ui/src/app/qo100.rs
+++ b/crates/sdroxide-ui/src/app/qo100.rs
@@ -10,12 +10,21 @@
 //! is a 400 baud differential+Manchester BPSK telemetry signal (AO-40
 //! "uncoded" framing), which is why a magnitude peak search has no purpose
 //! here — Manchester encoding leaves a *null* at the carrier frequency, not a
-//! peak. The actual demodulator lives engine-side, in `sdroxide_qo100`
-//! (raw IQ and real phase information, neither of which the UI has); this
-//! page is a thin front end onto [`sdroxide_types::Qo100Settings`] (ON/OFF,
-//! search width) and [`sdroxide_types::Qo100Status`] (lock, measured
-//! frequency, decoded text) — the same split the ISM window keeps with
-//! [`sdroxide_types::IsmSettings`]/[`sdroxide_types::IsmStatus`].
+//! peak. The actual DSP lives engine-side, in `sdroxide_qo100` (raw IQ and
+//! real phase information, neither of which the UI has); this page is a thin
+//! front end onto [`sdroxide_types::Qo100Settings`] and
+//! [`sdroxide_types::Qo100Status`] — the same split the ISM window keeps.
+//!
+//! Two jobs, split apart:
+//! * **ON** runs the fast spectral tracker. Every second it looks in the
+//!   operator's parking window (`+park_lo..+park_hi kHz`, shaded on the
+//!   strip) for the beacon's two symmetric lobes with the null between them,
+//!   and reports where the carrier sits — `null`, `sym` and `snr` say how
+//!   convincing the shape was. It reads the beacon's *shape*, never its bits,
+//!   so it works where the decoder cannot lock.
+//! * **decode AO-40 telemetry** additionally runs the sync-word + CRC frame
+//!   decoder, with a step-by-step readout (`carrier` → `sync` → `CRC`) of how
+//!   far each pass got and how full the frame buffer is.
 //!
 //! When the decoder locks, the frequency it had to assume for the sync word
 //! and CRC to check out *is* the station's whole frequency error — the LNB's
@@ -63,6 +72,17 @@ const WIDTH_STEP_HZ: f64 = 5_000.0;
 const MIN_HALF_WIDTH_HZ: f64 = WIDTH_STEP_HZ;
 const MAX_HALF_WIDTH_HZ: f64 = 50_000.0;
 
+/// The parking-window steppers' step and the ends they clamp to. The spectral
+/// tracker searches only `+park_lo_hz..+park_hi_hz` for the beacon's twin-lobe
+/// shape, so the operator parks the beacon in a positive lane clear of the DC
+/// spike before switching the tracker on.
+const PARK_STEP_HZ: f64 = 1_000.0;
+const PARK_MIN_HZ: f64 = 1_000.0;
+const PARK_MAX_HZ: f64 = 40_000.0;
+/// Smallest span the parking window is allowed to close to — the tracker needs
+/// room for both lobes plus a stretch of floor either side.
+const PARK_MIN_SPAN_HZ: f64 = 3_000.0;
+
 /// Everything the window remembers between frames that is not a setting the
 /// engine already tracks — purely the mini waterfall's own drawing state,
 /// and the last correction actually applied.
@@ -93,6 +113,17 @@ pub(in crate::app) struct Qo100WinState {
 
 fn fmt_hz_signed(hz: f64) -> String {
     if hz.abs() >= 1000.0 { format!("{:+.2} kHz", hz / 1000.0) } else { format!("{hz:+.0} Hz") }
+}
+
+/// A small round status light plus its label — lit green when `on`, a dim
+/// grey dot otherwise. Used for the AO-40 decoder's stage readout.
+fn led(ui: &mut egui::Ui, label: &str, on: bool) {
+    let (dot, text) =
+        if on { (theme::GREEN(), theme::TEXT()) } else { (theme::gray(70), theme::CYAN_DIM()) };
+    let (rect, _) = ui.allocate_exact_size(Vec2::splat(10.0), Sense::hover());
+    ui.painter().circle_filled(rect.center(), 4.0, dot);
+    ui.label(RichText::new(label).size(9.5).color(text));
+    ui.add_space(4.0);
 }
 
 /// New [`sdroxide_types::RadioConfig::converter_offset_hz`] that puts the
@@ -199,6 +230,7 @@ fn texture<'a>(
 /// the module doc for why a peak search never worked on this signal) — but a
 /// double-click *is* read back, in [`Qo100WinState::manual_hz`], as a
 /// deliberate "the beacon is here" for DRIFT and APPLY to act on.
+#[allow(clippy::too_many_arguments)]
 fn paint_strip(
     ui: &mut egui::Ui,
     win: &mut Qo100WinState,
@@ -207,6 +239,11 @@ fn paint_strip(
     lo: f64,
     hi: f64,
     measured_hz: Option<f64>,
+    // `park`: the parking window in dial Hz, shaded so the operator can see
+    // where to put the beacon before switching the tracker on.
+    // `est_hz`: the spectral tracker's current estimate, in dial Hz.
+    park: Option<(f64, f64)>,
+    est_hz: Option<f64>,
 ) {
     let (rect, resp) =
         ui.allocate_exact_size(Vec2::new(ui.available_width(), STRIP_H), Sense::click());
@@ -243,6 +280,23 @@ fn paint_strip(
     let x_of = |hz: f64| -> f32 {
         rect.left() + ((hz - lo) / (hi - lo)).clamp(0.0, 1.0) as f32 * rect.width()
     };
+    // The parking window: shade it so "put the beacon in here" is literal.
+    if let Some((plo, phi)) = park {
+        let (xa, xb) = (x_of(plo), x_of(phi));
+        if xb > xa {
+            painter.rect_filled(
+                Rect::from_min_max(Pos2::new(xa, rect.top()), Pos2::new(xb, rect.bottom())),
+                0.0,
+                Color32::from_rgba_unmultiplied(0, 200, 255, 22),
+            );
+            for x in [xa, xb] {
+                painter.line_segment(
+                    [Pos2::new(x, rect.top()), Pos2::new(x, rect.bottom())],
+                    Stroke::new(1.0, Color32::from_white_alpha(40)),
+                );
+            }
+        }
+    }
     // The target: where the beacon belongs.
     let tx = x_of(QO100_BEACON_HZ);
     painter.line_segment(
@@ -257,6 +311,23 @@ fn paint_strip(
         painter.line_segment(
             [Pos2::new(mx, rect.top()), Pos2::new(mx, rect.bottom())],
             Stroke::new(1.6, theme::GREEN()),
+        );
+    }
+    // The spectral tracker's live estimate.
+    if let Some(m) = est_hz
+        && (lo..=hi).contains(&m)
+    {
+        let mx = x_of(m);
+        painter.line_segment(
+            [Pos2::new(mx, rect.top()), Pos2::new(mx, rect.bottom())],
+            Stroke::new(1.4, theme::YELLOW()),
+        );
+        painter.text(
+            Pos2::new((mx + 3.0).min(rect.right() - 2.0), rect.top() + 12.0),
+            egui::Align2::LEFT_TOP,
+            "tracker",
+            egui::FontId::monospace(8.0),
+            theme::YELLOW(),
         );
     }
     // The hand-placed mark, if the operator has double-clicked one in.
@@ -314,9 +385,13 @@ impl SdroxideApp {
         // the ISM window follows for `IsmSettings` — the engine persists this
         // and echoes it back, so there is no separate apply step.
         let mut cfg = self.state.qo100;
+        // The strip spans the telemetry search width either side of the
+        // beacon, and — while the tracker is on — out far enough on the high
+        // side to show the whole parking window too.
+        let hw = cfg.search_half_width_hz;
         let (lo, hi) = (
-            QO100_BEACON_HZ - cfg.search_half_width_hz,
-            QO100_BEACON_HZ + cfg.search_half_width_hz,
+            QO100_BEACON_HZ - hw,
+            QO100_BEACON_HZ + if cfg.enabled { hw.max(cfg.park_hi_hz + 2_000.0) } else { hw },
         );
         // Whether whatever the receiver is *actually* capturing right now
         // reaches anywhere near the beacon at all — as against `reachable`,
@@ -341,7 +416,7 @@ impl SdroxideApp {
             );
             if run.clicked() {
                 cfg.enabled = !cfg.enabled;
-                // The main dial is left exactly where it is: the decoder mixes
+                // The main dial is left exactly where it is: the tracker mixes
                 // its own downconversion onto the beacon out of the raw IQ, so
                 // as long as 10489.750 MHz is inside what the hardware is
                 // already capturing there is nothing to retune. An operator
@@ -355,10 +430,23 @@ impl SdroxideApp {
                 );
             } else {
                 run.on_hover_text(
-                    "Demodulate the beacon's own BPSK-400 telemetry and measure exactly how far \
-                     it sits from 10489.750 MHz",
+                    "Run the fast spectral tracker: every second, look in the parking window for \
+                     the beacon's two symmetric lobes and report where the carrier sits",
                 );
             }
+
+            ui.add_space(6.0);
+            let tel = ui.add_enabled_ui(reachable, |ui| {
+                ui.selectable_label(cfg.decode_telemetry, "decode AO-40 telemetry")
+            });
+            let tel = tel.inner;
+            if tel.clicked() {
+                cfg.decode_telemetry = !cfg.decode_telemetry;
+            }
+            tel.on_hover_text(
+                "Also run the AO-40 uncoded frame decoder — sync word, CRC and the telemetry \
+                 text — with a step-by-step readout of how far each pass gets",
+            );
 
             ui.add_space(8.0);
             ui.label(RichText::new("width").size(10.0).color(theme::CYAN_DIM()));
@@ -394,6 +482,48 @@ impl SdroxideApp {
                 }
             }
         });
+
+        // The parking window the spectral tracker searches. Two steppers in
+        // 1 kHz clicks; the low edge cannot cross within PARK_MIN_SPAN of the
+        // high one, or the tracker loses the room it needs for both lobes.
+        ui.horizontal(|ui| {
+            ui.label(RichText::new("park").size(10.0).color(theme::CYAN_DIM()));
+            if ui.small_button("lo −").clicked() {
+                cfg.park_lo_hz = (cfg.park_lo_hz - PARK_STEP_HZ).max(PARK_MIN_HZ);
+            }
+            if ui.small_button("lo +").clicked() {
+                cfg.park_lo_hz =
+                    (cfg.park_lo_hz + PARK_STEP_HZ).min(cfg.park_hi_hz - PARK_MIN_SPAN_HZ);
+            }
+            ui.label(
+                RichText::new(format!(
+                    "+{:.0} … +{:.0} kHz",
+                    cfg.park_lo_hz / 1000.0,
+                    cfg.park_hi_hz / 1000.0
+                ))
+                .size(11.0)
+                .monospace(),
+            );
+            if ui.small_button("hi −").clicked() {
+                cfg.park_hi_hz =
+                    (cfg.park_hi_hz - PARK_STEP_HZ).max(cfg.park_lo_hz + PARK_MIN_SPAN_HZ);
+            }
+            if ui.small_button("hi +").clicked() {
+                cfg.park_hi_hz = (cfg.park_hi_hz + PARK_STEP_HZ).min(PARK_MAX_HZ);
+            }
+        });
+        if !cfg.enabled {
+            ui.label(
+                RichText::new(format!(
+                    "Before switching ON: tune so the beacon's two lobes sit between +{:.0} and \
+                     +{:.0} kHz in the strip (the shaded lane).",
+                    cfg.park_lo_hz / 1000.0,
+                    cfg.park_hi_hz / 1000.0
+                ))
+                .size(9.0)
+                .color(theme::CYAN_DIM()),
+            );
+        }
 
         // Unmissable, not just a hover: a fresh station has no converter set
         // up yet, so ON stays disabled and the strip would otherwise sit
@@ -456,6 +586,8 @@ impl SdroxideApp {
 
         ui.add_space(4.0);
         let measured_hz = locked_freq(status.as_ref());
+        let tracker_dial_hz =
+            status.as_ref().and_then(|s| s.est_offset_hz).map(|o| QO100_BEACON_HZ + o);
         paint_strip(
             ui,
             win,
@@ -464,13 +596,16 @@ impl SdroxideApp {
             lo,
             hi,
             measured_hz,
+            Some((QO100_BEACON_HZ + cfg.park_lo_hz, QO100_BEACON_HZ + cfg.park_hi_hz)),
+            tracker_dial_hz,
         );
 
         // `paint_strip` may have just planted or cleared the hand-placed
-        // mark; from here on DRIFT and APPLY act on whichever of the two
-        // readings [`effective_measurement`] picks.
+        // mark; from here on DRIFT and APPLY act on whichever reading
+        // [`effective_measurement`] picks.
         let confirmed = apply_is_confirmed(status.as_ref());
-        let effective = effective_measurement(measured_hz, confirmed, win.manual_hz);
+        let effective =
+            effective_measurement(measured_hz, confirmed, win.manual_hz, tracker_dial_hz);
 
         ui.add_space(6.0);
         ui.label(
@@ -490,6 +625,62 @@ impl SdroxideApp {
                 .size(9.0)
                 .color(theme::CYAN_DIM()),
             );
+        }
+
+        // The spectral tracker's live readout — one line per cycle, so a
+        // parked beacon that the tracker cannot see is obvious immediately.
+        if let Some(s) = status.as_ref().filter(|s| s.tracking) {
+            ui.add_space(4.0);
+            egui::Grid::new("qo100-tracker").num_columns(2).spacing([16.0, 2.0]).show(ui, |ui| {
+                let dim = |t: &str| RichText::new(t).size(9.5).color(theme::CYAN_DIM());
+                ui.label(dim("TRACKER"));
+                match s.est_offset_hz {
+                    Some(o) => {
+                        let good = s.est_null_depth_db >= 5.0 && s.est_symmetry >= 0.7;
+                        ui.label(
+                            RichText::new(format!(
+                                "{}  →  {:.6} MHz",
+                                fmt_hz_signed(o),
+                                (QO100_BEACON_HZ + o) / 1e6
+                            ))
+                            .size(11.0)
+                            .monospace()
+                            .color(if good {
+                                theme::GREEN()
+                            } else {
+                                theme::YELLOW()
+                            }),
+                        );
+                    }
+                    None => {
+                        ui.label(
+                            RichText::new("no twin-lobe shape in the parking window")
+                                .size(10.0)
+                                .color(theme::YELLOW()),
+                        );
+                    }
+                }
+                ui.end_row();
+
+                ui.label(dim("SHAPE"));
+                ui.label(
+                    RichText::new(format!(
+                        "null {:.1} dB   sym {:.2}   snr {:.1} dB",
+                        s.est_null_depth_db, s.est_symmetry, s.est_snr_db
+                    ))
+                    .size(10.0)
+                    .monospace(),
+                );
+                ui.end_row();
+
+                ui.label(dim("CYCLES"));
+                ui.label(
+                    RichText::new(format!("{} found, {} empty", s.est_updates, s.est_misses))
+                        .size(10.0)
+                        .monospace(),
+                );
+                ui.end_row();
+            });
         }
 
         let radio_cfg = self.ctrl.radio_config();
@@ -517,15 +708,18 @@ impl SdroxideApp {
 
             ui.label(dim("MEASURED"));
             match effective {
-                Some((hz, from_manual)) => {
-                    let mut t = RichText::new(format!(
-                        "{:.6} MHz{}",
-                        hz / 1e6,
-                        if from_manual { "  (clicked)" } else { "" }
-                    ))
-                    .size(12.0)
-                    .monospace();
-                    t = if from_manual { t.color(theme::PINK()) } else { t.strong() };
+                Some((hz, src)) => {
+                    let (tag, colour) = match src {
+                        MeasSource::Lock => ("", None),
+                        MeasSource::Manual => ("  (clicked)", Some(theme::PINK())),
+                        MeasSource::Tracker => ("  (tracker)", Some(theme::YELLOW())),
+                    };
+                    let mut t =
+                        RichText::new(format!("{:.6} MHz{tag}", hz / 1e6)).size(12.0).monospace();
+                    t = match colour {
+                        Some(c) => t.color(c),
+                        None => t.strong(),
+                    };
                     ui.label(t)
                 }
                 None => ui.label(
@@ -558,6 +752,36 @@ impl SdroxideApp {
             ui.end_row();
         });
 
+        // The AO-40 decoder's step-by-step readout: which stage the last pass
+        // reached, and how full the buffer is toward the whole frame it needs.
+        if let Some(s) = status.as_ref().filter(|s| s.decoding) {
+            ui.add_space(4.0);
+            ui.horizontal(|ui| {
+                ui.label(RichText::new("DECODE").size(9.5).color(theme::CYAN_DIM()));
+                led(ui, "carrier", s.carrier_seen);
+                led(ui, "sync", s.sync_seen);
+                led(ui, "CRC", s.crc_ok);
+                if s.sync_bit_errors != u8::MAX && !s.sync_seen {
+                    ui.label(
+                        RichText::new(format!("closest sync: {} bit errors", s.sync_bit_errors))
+                            .size(9.0)
+                            .color(theme::CYAN_DIM()),
+                    );
+                }
+            });
+            ui.add(egui::ProgressBar::new(s.frame_fill).desired_height(6.0).text(
+                RichText::new(format!("frame buffer {:.0}%", s.frame_fill * 100.0)).size(8.0),
+            ));
+            ui.label(
+                RichText::new(format!(
+                    "{} blocks tried, {} decoded",
+                    s.blocks_tried, s.blocks_locked
+                ))
+                .size(9.0)
+                .color(theme::CYAN_DIM()),
+            );
+        }
+
         // The decoded telemetry text — the beacon's own status report, shown
         // for its own sake and as independent confirmation the decode is
         // real: garbage here despite a "locked" CRC would be a red flag no
@@ -577,13 +801,13 @@ impl SdroxideApp {
 
         ui.add_space(6.0);
         ui.horizontal(|ui| {
-            // A hand-placed mark is a deliberate operator action, so it needs
-            // no second-frame confirmation; a decoder lock still does (see
-            // `apply_is_confirmed`).
+            // A hand-placed mark or the tracker's estimate is a deliberate
+            // operator action, so it needs no second-frame confirmation; a
+            // bare decoder lock still does (see `apply_is_confirmed`).
             let can_apply = radio_cfg.is_some()
                 && match effective {
-                    Some((_, true)) => true,
-                    Some((_, false)) => confirmed,
+                    Some((_, MeasSource::Lock)) => confirmed,
+                    Some((_, MeasSource::Manual | MeasSource::Tracker)) => true,
                     None => false,
                 };
             let apply = ui.add_enabled(
@@ -591,12 +815,17 @@ impl SdroxideApp {
                 egui::Button::new(RichText::new(" APPLY CORRECTION ").strong()),
             );
             let apply = apply.on_hover_text(match effective {
-                Some((_, true)) => {
+                Some((_, MeasSource::Manual)) => {
                     "Write the converter/LNB offset that puts the beacon where you clicked onto \
                      10489.750 MHz, and reopen the receiver — the same brief interruption \
                      Settings ▸ Radio ▸ Apply makes"
                 }
-                Some((_, false)) if !confirmed => {
+                Some((_, MeasSource::Tracker)) => {
+                    "Write the converter/LNB offset that puts the tracker's estimate onto \
+                     10489.750 MHz, and reopen the receiver — the same brief interruption \
+                     Settings ▸ Radio ▸ Apply makes"
+                }
+                Some((_, MeasSource::Lock)) if !confirmed => {
                     "Waiting for a second CRC-valid frame before offering to write this — one lock \
                      alone could be a chance match"
                 }
@@ -646,26 +875,35 @@ fn locked_freq(status: Option<&Qo100Status>) -> Option<f64> {
     status.filter(|s| s.locked).map(|s| QO100_BEACON_HZ + s.offset_hz)
 }
 
-/// The frequency DRIFT and APPLY act on, and whether it is the operator's
-/// hand-placed mark rather than a decoder lock.
+/// Where a DRIFT / APPLY figure came from.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(in crate::app) enum MeasSource {
+    /// A CRC-valid AO-40 frame decode.
+    Lock,
+    /// The frequency the operator double-clicked on the strip.
+    Manual,
+    /// The spectral tracker's twin-lobe estimate.
+    Tracker,
+}
+
+/// The frequency DRIFT and APPLY act on, and where it came from.
 ///
 /// A *confirmed* decoder lock always wins — it is a phase measurement off the
-/// raw IQ, not an eyeballed line on a magnitude strip. But the case this mark
-/// exists for is the decoder reporting a lock it cannot turn into telemetry
-/// ("locks but won't decode"): that is `locked_hz` set with `confirmed`
-/// false, and there the operator's double-click takes precedence so APPLY has
-/// something to act on. An unconfirmed lock with no mark still shows in
-/// DRIFT, it just cannot be applied (see `apply_is_confirmed`).
+/// raw IQ. Then the operator's hand-placed mark, then the spectral tracker's
+/// estimate, then — last, and never applied — an unconfirmed lock, which
+/// still shows in DRIFT but cannot be written (see `apply_is_confirmed`).
 fn effective_measurement(
     locked_hz: Option<f64>,
     confirmed: bool,
     manual_hz: Option<f64>,
-) -> Option<(f64, bool)> {
-    match (locked_hz, manual_hz) {
-        (Some(hz), _) if confirmed => Some((hz, false)),
-        (_, Some(hz)) => Some((hz, true)),
-        (Some(hz), None) => Some((hz, false)),
-        (None, None) => None,
+    tracker_hz: Option<f64>,
+) -> Option<(f64, MeasSource)> {
+    match (locked_hz, manual_hz, tracker_hz) {
+        (Some(hz), _, _) if confirmed => Some((hz, MeasSource::Lock)),
+        (_, Some(hz), _) => Some((hz, MeasSource::Manual)),
+        (_, _, Some(hz)) => Some((hz, MeasSource::Tracker)),
+        (Some(hz), _, _) => Some((hz, MeasSource::Lock)),
+        (None, None, None) => None,
     }
 }
 
@@ -793,53 +1031,50 @@ mod tests {
     }
 
     #[test]
-    fn effective_measurement_prefers_a_confirmed_lock_over_a_hand_placed_mark() {
+    fn effective_measurement_prefers_a_confirmed_lock_over_everything_else() {
         let m = effective_measurement(
             Some(QO100_BEACON_HZ + 100.0),
             true,
             Some(QO100_BEACON_HZ + 9_000.0),
+            Some(QO100_BEACON_HZ + 14_000.0),
         );
-        assert_eq!(m, Some((QO100_BEACON_HZ + 100.0, false)));
+        assert_eq!(m, Some((QO100_BEACON_HZ + 100.0, MeasSource::Lock)));
     }
 
     #[test]
     fn effective_measurement_lets_the_mark_win_over_a_lock_that_will_not_decode() {
-        // "Locks but won't decode": locked_hz set, but not confirmed — the
-        // operator's click is what APPLY should act on.
         let m = effective_measurement(
             Some(QO100_BEACON_HZ + 100.0),
             false,
             Some(QO100_BEACON_HZ + 9_000.0),
+            Some(QO100_BEACON_HZ + 14_000.0),
         );
-        assert_eq!(m, Some((QO100_BEACON_HZ + 9_000.0, true)));
+        assert_eq!(m, Some((QO100_BEACON_HZ + 9_000.0, MeasSource::Manual)));
     }
 
     #[test]
-    fn effective_measurement_falls_back_to_the_mark_when_the_decoder_has_not_locked() {
-        let m = effective_measurement(None, false, Some(QO100_BEACON_HZ + 9_000.0));
-        assert_eq!(m, Some((QO100_BEACON_HZ + 9_000.0, true)));
+    fn effective_measurement_uses_the_tracker_when_there_is_no_lock_or_mark() {
+        let m = effective_measurement(None, false, None, Some(QO100_BEACON_HZ + 14_000.0));
+        assert_eq!(m, Some((QO100_BEACON_HZ + 14_000.0, MeasSource::Tracker)));
     }
 
     #[test]
-    fn effective_measurement_shows_an_unconfirmed_lock_when_there_is_no_mark() {
-        let m = effective_measurement(Some(QO100_BEACON_HZ + 100.0), false, None);
-        assert_eq!(m, Some((QO100_BEACON_HZ + 100.0, false)));
+    fn effective_measurement_shows_an_unconfirmed_lock_as_a_last_resort() {
+        let m = effective_measurement(Some(QO100_BEACON_HZ + 100.0), false, None, None);
+        assert_eq!(m, Some((QO100_BEACON_HZ + 100.0, MeasSource::Lock)));
     }
 
     #[test]
-    fn effective_measurement_is_none_with_neither_a_lock_nor_a_mark() {
-        assert_eq!(effective_measurement(None, false, None), None);
+    fn effective_measurement_is_none_with_no_source_at_all() {
+        assert_eq!(effective_measurement(None, false, None, None), None);
     }
 
     #[test]
     fn a_hand_placed_mark_feeds_the_same_offset_maths_as_a_lock() {
-        // Operator clicks the beacon 9 kHz above target: APPLY must raise the
-        // converter offset by exactly that, the same as if the decoder had
-        // measured it.
         let old = -9_750_000_000.0;
-        let (clicked, from_manual) =
-            effective_measurement(None, false, Some(QO100_BEACON_HZ + 9_000.0)).unwrap();
-        assert!(from_manual);
+        let (clicked, src) =
+            effective_measurement(None, false, Some(QO100_BEACON_HZ + 9_000.0), None).unwrap();
+        assert_eq!(src, MeasSource::Manual);
         assert_eq!(corrected_offset_hz(old, clicked, QO100_BEACON_HZ), old + 9_000.0);
     }
 

--- a/crates/sdroxide-ui/src/app/qo100.rs
+++ b/crates/sdroxide-ui/src/app/qo100.rs
@@ -439,31 +439,28 @@ impl SdroxideApp {
                 );
             }
 
-            ui.add_space(6.0);
-            let tel = ui.add_enabled_ui(reachable, |ui| {
-                ui.selectable_label(cfg.decode_telemetry, "decode AO-40 telemetry")
-            });
-            let tel = tel.inner;
+            ui.add_space(8.0);
+            let tel = crate::chrome::chip_enabled(ui, reachable, cfg.decode_telemetry, "TELEMETRY");
             if tel.clicked() {
                 cfg.decode_telemetry = !cfg.decode_telemetry;
             }
             tel.on_hover_text(
                 "Also run the AO-40 uncoded frame decoder — sync word, CRC and the telemetry \
-                 text — with a step-by-step readout of how far each pass gets",
+                 text — with a step-by-step readout (carrier → sync → CRC) of how far each pass \
+                 gets",
             );
 
-            ui.add_space(6.0);
-            let auto = ui.add_enabled_ui(reachable && cfg.enabled, |ui| {
-                ui.selectable_label(cfg.auto_apply, "auto-correct")
-            });
-            let auto = auto.inner;
+            ui.add_space(4.0);
+            let auto =
+                crate::chrome::chip_enabled(ui, reachable && cfg.enabled, cfg.auto_apply, "AUTO");
             if auto.clicked() {
                 cfg.auto_apply = !cfg.auto_apply;
             }
             auto.on_hover_text(
-                "Let the tracker correct the converter/LNB offset by itself: a slow closed loop \
-                 that, on a clean and steady estimate, nudges the beacon back onto 10489.750 MHz \
-                 and holds it there as the LNB drifts. Reopens the front end each time it acts.",
+                "Auto-correct: let the tracker adjust the converter/LNB offset by itself — a slow \
+                 closed loop that, on a clean and steady estimate, nudges the beacon back onto \
+                 10489.750 MHz and holds it there as the LNB drifts. Reopens the front end each \
+                 time it acts.",
             );
 
             ui.add_space(8.0);
@@ -691,6 +688,23 @@ impl SdroxideApp {
                 );
                 ui.end_row();
 
+                ui.label(dim("DRIFT"));
+                ui.label(
+                    RichText::new(if s.est_drift_hz_s.abs() >= 0.05 {
+                        format!("{:+.1} Hz/s  (de-rotated before decode)", s.est_drift_hz_s)
+                    } else {
+                        "— (need a longer run of estimates)".to_string()
+                    })
+                    .size(10.0)
+                    .monospace()
+                    .color(if s.est_drift_hz_s.abs() > 15.0 {
+                        theme::YELLOW()
+                    } else {
+                        theme::TEXT()
+                    }),
+                );
+                ui.end_row();
+
                 ui.label(dim("CYCLES"));
                 ui.label(
                     RichText::new(format!("{} found, {} empty", s.est_updates, s.est_misses))
@@ -827,6 +841,24 @@ impl SdroxideApp {
                     "{} blocks tried, {} decoded",
                     s.blocks_tried, s.blocks_locked
                 ))
+                .size(9.0)
+                .color(theme::CYAN_DIM()),
+            );
+        } else if cfg.decode_telemetry {
+            // Toggled on but no status back yet — the first ~24 s window.
+            ui.add_space(4.0);
+            ui.label(
+                RichText::new("DECODE — filling the first frame buffer…")
+                    .size(9.5)
+                    .color(theme::CYAN_DIM()),
+            );
+        } else {
+            ui.add_space(4.0);
+            ui.label(
+                RichText::new(
+                    "DECODE — off. Turn on the TELEMETRY chip (top row) for the \
+                              carrier → sync → CRC readout.",
+                )
                 .size(9.0)
                 .color(theme::CYAN_DIM()),
             );

--- a/crates/sdroxide-ui/src/app/qo100.rs
+++ b/crates/sdroxide-ui/src/app/qo100.rs
@@ -26,11 +26,15 @@
 //! than doing it silently on every lock, so a bad reading never yanks a
 //! running receiver.
 //!
-//! The mini waterfall is visual context only now, not a measurement: it reads
-//! the same [`sdroxide_types::SpectrumFrame`] everything else on screen
+//! The mini waterfall is visual context, not an automatic measurement: it
+//! reads the same [`sdroxide_types::SpectrumFrame`] everything else on screen
 //! already gets, cropped to a window around the beacon, so the operator can
 //! see the Manchester null (and the search width buttons' effect) even
-//! though nothing here measures anything off it.
+//! though nothing here hunts a peak in it. It does take one deliberate read
+//! back, though — a double-click on the strip plants a "the beacon is here"
+//! mark ([`Qo100WinState::manual_hz`]) that drives DRIFT and APPLY exactly as
+//! a decoder lock would, for the case the null is plainly visible but the
+//! demodulator will not lock.
 
 use std::collections::VecDeque;
 
@@ -78,6 +82,13 @@ pub(in crate::app) struct Qo100WinState {
     /// wall-clock second it was applied, so the operator sees what happened
     /// even after the numbers above have moved on.
     applied: Option<(f64, f64, i64)>,
+    /// A dial-domain frequency the operator double-clicked on the strip to
+    /// say "the beacon is *here*" — for when its Manchester null is plainly
+    /// visible but the decoder will not lock or decode. Drives DRIFT and
+    /// APPLY exactly as a real lock would (see [`effective_measurement`]);
+    /// cleared by the button that appears while it is set, by a real decoder
+    /// lock superseding it, or once APPLY has written it.
+    manual_hz: Option<f64>,
 }
 
 fn fmt_hz_signed(hz: f64) -> String {
@@ -182,10 +193,12 @@ fn texture<'a>(
     win.tex.as_ref()
 }
 
-/// Draw the strip: the target line, and — while the decoder has a lock —
-/// where it actually found the beacon. Purely visual; nothing here is read
-/// back, unlike the version of this window that used to hunt a magnitude
-/// peak in it (see the module doc for why that never worked on this signal).
+/// Draw the strip: the target line, where the decoder locked (if it has),
+/// and any frequency the operator double-clicked to mark the beacon by hand.
+/// The magnitude picture is visual only — nothing is read back off it (see
+/// the module doc for why a peak search never worked on this signal) — but a
+/// double-click *is* read back, in [`Qo100WinState::manual_hz`], as a
+/// deliberate "the beacon is here" for DRIFT and APPLY to act on.
 fn paint_strip(
     ui: &mut egui::Ui,
     win: &mut Qo100WinState,
@@ -196,9 +209,20 @@ fn paint_strip(
     measured_hz: Option<f64>,
 ) {
     let (rect, resp) =
-        ui.allocate_exact_size(Vec2::new(ui.available_width(), STRIP_H), Sense::hover());
+        ui.allocate_exact_size(Vec2::new(ui.available_width(), STRIP_H), Sense::click());
     if !ui.is_rect_visible(rect) {
         return;
+    }
+    if resp.hovered() {
+        ui.ctx().set_cursor_icon(egui::CursorIcon::Crosshair);
+    }
+    // A double-click plants the hand-placed beacon mark at the frequency
+    // under the pointer — the strip's x axis is a straight `lo..hi` ramp.
+    if resp.double_clicked()
+        && let Some(p) = resp.interact_pointer_pos()
+    {
+        let t = ((p.x - rect.left()) / rect.width()).clamp(0.0, 1.0) as f64;
+        win.manual_hz = Some(lo + t * (hi - lo));
     }
     let painter = ui.painter_at(rect);
     painter.rect_filled(rect, 2.0, Color32::BLACK);
@@ -235,6 +259,23 @@ fn paint_strip(
             Stroke::new(1.6, theme::GREEN()),
         );
     }
+    // The hand-placed mark, if the operator has double-clicked one in.
+    if let Some(m) = win.manual_hz
+        && (lo..=hi).contains(&m)
+    {
+        let mx = x_of(m);
+        painter.line_segment(
+            [Pos2::new(mx, rect.top()), Pos2::new(mx, rect.bottom())],
+            Stroke::new(1.4, theme::PINK()),
+        );
+        painter.text(
+            Pos2::new((mx + 3.0).min(rect.right() - 2.0), rect.bottom() - 11.0),
+            egui::Align2::LEFT_BOTTOM,
+            "clicked",
+            egui::FontId::monospace(8.0),
+            theme::PINK(),
+        );
+    }
 
     let font = egui::FontId::monospace(9.0);
     let dim = Color32::from_white_alpha(200);
@@ -253,7 +294,6 @@ fn paint_strip(
         dim,
     );
     crate::chrome::paint_cut_border(&painter, rect, theme::LINE_LIT(), theme::PANEL());
-    let _ = resp; // hover-only; kept so `ui.allocate_exact_size` reserves layout the usual way
 }
 
 impl SdroxideApp {
@@ -340,6 +380,19 @@ impl SdroxideApp {
                 cfg.search_half_width_hz =
                     (cfg.search_half_width_hz + WIDTH_STEP_HZ).min(MAX_HALF_WIDTH_HZ);
             }
+
+            if win.manual_hz.is_some() {
+                ui.add_space(8.0);
+                if ui
+                    .small_button("clear mark")
+                    .on_hover_text(
+                        "Drop the hand-placed beacon mark and go back to the decoder's own reading",
+                    )
+                    .clicked()
+                {
+                    win.manual_hz = None;
+                }
+            }
         });
 
         // Unmissable, not just a hover: a fresh station has no converter set
@@ -413,12 +466,31 @@ impl SdroxideApp {
             measured_hz,
         );
 
+        // `paint_strip` may have just planted or cleared the hand-placed
+        // mark; from here on DRIFT and APPLY act on whichever of the two
+        // readings [`effective_measurement`] picks.
+        let confirmed = apply_is_confirmed(status.as_ref());
+        let effective = effective_measurement(measured_hz, confirmed, win.manual_hz);
+
         ui.add_space(6.0);
         ui.label(
             RichText::new(status_line(cfg.enabled, status.as_ref(), self.ctrl.engine_is_remote()))
                 .size(9.5)
                 .color(theme::CYAN_DIM()),
         );
+        // Discoverability: a stalled search or a lock that never decodes is
+        // exactly when double-click matters, so say so — but only while it
+        // would actually do something new (no confirmed decode, no mark yet).
+        if cfg.enabled && !confirmed && win.manual_hz.is_none() {
+            ui.label(
+                RichText::new(
+                    "tip: if you can see the beacon in the strip but it won't lock, double-click \
+                     it — that marks it as 10489.750 MHz and lets APPLY correct to it",
+                )
+                .size(9.0)
+                .color(theme::CYAN_DIM()),
+            );
+        }
 
         let radio_cfg = self.ctrl.radio_config();
         let old_offset = radio_cfg.as_ref().map(|c| c.converter_offset_hz).unwrap_or(0.0);
@@ -444,10 +516,18 @@ impl SdroxideApp {
             ui.end_row();
 
             ui.label(dim("MEASURED"));
-            match measured_hz {
-                Some(hz) => ui.label(
-                    RichText::new(format!("{:.6} MHz", hz / 1e6)).size(12.0).monospace().strong(),
-                ),
+            match effective {
+                Some((hz, from_manual)) => {
+                    let mut t = RichText::new(format!(
+                        "{:.6} MHz{}",
+                        hz / 1e6,
+                        if from_manual { "  (clicked)" } else { "" }
+                    ))
+                    .size(12.0)
+                    .monospace();
+                    t = if from_manual { t.color(theme::PINK()) } else { t.strong() };
+                    ui.label(t)
+                }
                 None => ui.label(
                     RichText::new(if cfg.enabled { "not locked yet" } else { "—" })
                         .size(11.0)
@@ -457,8 +537,8 @@ impl SdroxideApp {
             ui.end_row();
 
             ui.label(dim("DRIFT"));
-            match measured_hz {
-                Some(hz) => {
+            match effective {
+                Some((hz, _)) => {
                     let err = hz - QO100_BEACON_HZ;
                     let colour = if err.abs() < 200.0 {
                         theme::GREEN()
@@ -497,21 +577,36 @@ impl SdroxideApp {
 
         ui.add_space(6.0);
         ui.horizontal(|ui| {
-            let confirmed = apply_is_confirmed(status.as_ref());
-            let can_apply = measured_hz.is_some() && radio_cfg.is_some() && confirmed;
+            // A hand-placed mark is a deliberate operator action, so it needs
+            // no second-frame confirmation; a decoder lock still does (see
+            // `apply_is_confirmed`).
+            let can_apply = radio_cfg.is_some()
+                && match effective {
+                    Some((_, true)) => true,
+                    Some((_, false)) => confirmed,
+                    None => false,
+                };
             let apply = ui.add_enabled(
                 can_apply,
                 egui::Button::new(RichText::new(" APPLY CORRECTION ").strong()),
             );
-            let apply = apply.on_hover_text(if measured_hz.is_some() && !confirmed {
-                "Waiting for a second CRC-valid frame before offering to write this — one lock \
-                 alone could be a chance match"
-            } else {
-                "Write the corrected converter/LNB offset and reopen the receiver — a brief \
-                 interruption, the same one Settings ▸ Radio ▸ Apply makes"
+            let apply = apply.on_hover_text(match effective {
+                Some((_, true)) => {
+                    "Write the converter/LNB offset that puts the beacon where you clicked onto \
+                     10489.750 MHz, and reopen the receiver — the same brief interruption \
+                     Settings ▸ Radio ▸ Apply makes"
+                }
+                Some((_, false)) if !confirmed => {
+                    "Waiting for a second CRC-valid frame before offering to write this — one lock \
+                     alone could be a chance match"
+                }
+                _ => {
+                    "Write the corrected converter/LNB offset and reopen the receiver — a brief \
+                     interruption, the same one Settings ▸ Radio ▸ Apply makes"
+                }
             });
             if apply.clicked()
-                && let (Some(mut c), Some(measured)) = (radio_cfg.clone(), measured_hz)
+                && let (Some(mut c), Some((measured, _))) = (radio_cfg.clone(), effective)
             {
                 let new_offset =
                     corrected_offset_hz(c.converter_offset_hz, measured, QO100_BEACON_HZ);
@@ -520,6 +615,9 @@ impl SdroxideApp {
                 self.ctrl.reopen_source();
                 self.radio_cfg = Some(c);
                 win.applied = Some((old_offset, new_offset, crate::time::now_unix()));
+                // The correction now lives in the offset and the beacon should
+                // land near centre next sweep; a stale mark would only mislead.
+                win.manual_hz = None;
             }
             if let Some((old, new, at)) = win.applied {
                 let ago = crate::time::now_unix() - at;
@@ -546,6 +644,29 @@ impl SdroxideApp {
 /// period is) or if the decoder has never locked at all.
 fn locked_freq(status: Option<&Qo100Status>) -> Option<f64> {
     status.filter(|s| s.locked).map(|s| QO100_BEACON_HZ + s.offset_hz)
+}
+
+/// The frequency DRIFT and APPLY act on, and whether it is the operator's
+/// hand-placed mark rather than a decoder lock.
+///
+/// A *confirmed* decoder lock always wins — it is a phase measurement off the
+/// raw IQ, not an eyeballed line on a magnitude strip. But the case this mark
+/// exists for is the decoder reporting a lock it cannot turn into telemetry
+/// ("locks but won't decode"): that is `locked_hz` set with `confirmed`
+/// false, and there the operator's double-click takes precedence so APPLY has
+/// something to act on. An unconfirmed lock with no mark still shows in
+/// DRIFT, it just cannot be applied (see `apply_is_confirmed`).
+fn effective_measurement(
+    locked_hz: Option<f64>,
+    confirmed: bool,
+    manual_hz: Option<f64>,
+) -> Option<(f64, bool)> {
+    match (locked_hz, manual_hz) {
+        (Some(hz), _) if confirmed => Some((hz, false)),
+        (_, Some(hz)) => Some((hz, true)),
+        (Some(hz), None) => Some((hz, false)),
+        (None, None) => None,
+    }
 }
 
 /// Whether a measured offset is safe to offer for `APPLY CORRECTION`, which
@@ -669,6 +790,57 @@ mod tests {
     fn locked_freq_is_none_when_not_locked_or_absent() {
         assert_eq!(locked_freq(None), None);
         assert_eq!(locked_freq(Some(&status(false, 0.0))), None);
+    }
+
+    #[test]
+    fn effective_measurement_prefers_a_confirmed_lock_over_a_hand_placed_mark() {
+        let m = effective_measurement(
+            Some(QO100_BEACON_HZ + 100.0),
+            true,
+            Some(QO100_BEACON_HZ + 9_000.0),
+        );
+        assert_eq!(m, Some((QO100_BEACON_HZ + 100.0, false)));
+    }
+
+    #[test]
+    fn effective_measurement_lets_the_mark_win_over_a_lock_that_will_not_decode() {
+        // "Locks but won't decode": locked_hz set, but not confirmed — the
+        // operator's click is what APPLY should act on.
+        let m = effective_measurement(
+            Some(QO100_BEACON_HZ + 100.0),
+            false,
+            Some(QO100_BEACON_HZ + 9_000.0),
+        );
+        assert_eq!(m, Some((QO100_BEACON_HZ + 9_000.0, true)));
+    }
+
+    #[test]
+    fn effective_measurement_falls_back_to_the_mark_when_the_decoder_has_not_locked() {
+        let m = effective_measurement(None, false, Some(QO100_BEACON_HZ + 9_000.0));
+        assert_eq!(m, Some((QO100_BEACON_HZ + 9_000.0, true)));
+    }
+
+    #[test]
+    fn effective_measurement_shows_an_unconfirmed_lock_when_there_is_no_mark() {
+        let m = effective_measurement(Some(QO100_BEACON_HZ + 100.0), false, None);
+        assert_eq!(m, Some((QO100_BEACON_HZ + 100.0, false)));
+    }
+
+    #[test]
+    fn effective_measurement_is_none_with_neither_a_lock_nor_a_mark() {
+        assert_eq!(effective_measurement(None, false, None), None);
+    }
+
+    #[test]
+    fn a_hand_placed_mark_feeds_the_same_offset_maths_as_a_lock() {
+        // Operator clicks the beacon 9 kHz above target: APPLY must raise the
+        // converter offset by exactly that, the same as if the decoder had
+        // measured it.
+        let old = -9_750_000_000.0;
+        let (clicked, from_manual) =
+            effective_measurement(None, false, Some(QO100_BEACON_HZ + 9_000.0)).unwrap();
+        assert!(from_manual);
+        assert_eq!(corrected_offset_hz(old, clicked, QO100_BEACON_HZ), old + 9_000.0);
     }
 
     #[test]

--- a/crates/sdroxide-ui/src/app/qo100.rs
+++ b/crates/sdroxide-ui/src/app/qo100.rs
@@ -804,11 +804,18 @@ impl SdroxideApp {
                 led(ui, "carrier", s.carrier_seen);
                 led(ui, "sync", s.sync_seen);
                 led(ui, "CRC", s.crc_ok);
-                if s.sync_bit_errors != u8::MAX && !s.sync_seen {
+                if s.sync_bit_errors != u8::MAX {
+                    // Always shown: sync passing (≤3) but CRC never lighting
+                    // means the demod is marginal — the closer this is to 0,
+                    // the more of the payload is decoding right.
                     ui.label(
-                        RichText::new(format!("closest sync: {} bit errors", s.sync_bit_errors))
+                        RichText::new(format!("sync {} / 32 err", s.sync_bit_errors))
                             .size(9.0)
-                            .color(theme::CYAN_DIM()),
+                            .color(if s.sync_bit_errors <= 3 {
+                                theme::CYAN_DIM()
+                            } else {
+                                theme::YELLOW()
+                            }),
                     );
                 }
             });

--- a/crates/sdroxide-ui/src/app/qo100.rs
+++ b/crates/sdroxide-ui/src/app/qo100.rs
@@ -301,13 +301,12 @@ impl SdroxideApp {
             );
             if run.clicked() {
                 cfg.enabled = !cfg.enabled;
-                if cfg.enabled {
-                    // Visual convenience only — the decoder reads raw IQ
-                    // straight off the hardware and works regardless of
-                    // where the main dial happens to be, as long as the
-                    // beacon is inside what the hardware actually captures.
-                    cmds.push(Command::SetVfo { vfo: Vfo::A, hz: QO100_BEACON_HZ });
-                }
+                // The main dial is left exactly where it is: the decoder mixes
+                // its own downconversion onto the beacon out of the raw IQ, so
+                // as long as 10489.750 MHz is inside what the hardware is
+                // already capturing there is nothing to retune. An operator
+                // whose capture does not reach the beacon still has the
+                // explicit "Tune to 10489.750 MHz" button below.
             }
             if !reachable {
                 run.on_hover_text(

--- a/crates/sdroxide-ui/src/app/qo100.rs
+++ b/crates/sdroxide-ui/src/app/qo100.rs
@@ -21,7 +21,11 @@
 //!   strip) for the beacon's two symmetric lobes with the null between them,
 //!   and reports where the carrier sits — `null`, `sym` and `snr` say how
 //!   convincing the shape was. It reads the beacon's *shape*, never its bits,
-//!   so it works where the decoder cannot lock.
+//!   so it works where the decoder cannot lock. **auto-correct** then closes
+//!   the loop engine-side: on a clean, steady estimate it nudges
+//!   `converter_offset_hz` so the beacon lands back on 10489.750 MHz and
+//!   holds it there as the LNB drifts, deadbanded and rate-limited so a bad
+//!   reading never yanks the receiver.
 //! * **decode AO-40 telemetry** additionally runs the sync-word + CRC frame
 //!   decoder, with a step-by-step readout (`carrier` → `sync` → `CRC`) of how
 //!   far each pass got and how full the frame buffer is.
@@ -448,6 +452,20 @@ impl SdroxideApp {
                  text — with a step-by-step readout of how far each pass gets",
             );
 
+            ui.add_space(6.0);
+            let auto = ui.add_enabled_ui(reachable && cfg.enabled, |ui| {
+                ui.selectable_label(cfg.auto_apply, "auto-correct")
+            });
+            let auto = auto.inner;
+            if auto.clicked() {
+                cfg.auto_apply = !cfg.auto_apply;
+            }
+            auto.on_hover_text(
+                "Let the tracker correct the converter/LNB offset by itself: a slow closed loop \
+                 that, on a clean and steady estimate, nudges the beacon back onto 10489.750 MHz \
+                 and holds it there as the LNB drifts. Reopens the front end each time it acts.",
+            );
+
             ui.add_space(8.0);
             ui.label(RichText::new("width").size(10.0).color(theme::CYAN_DIM()));
             if ui.small_button("−").on_hover_text("Narrower — search a smaller slice").clicked()
@@ -680,6 +698,31 @@ impl SdroxideApp {
                         .monospace(),
                 );
                 ui.end_row();
+
+                if s.auto_applying {
+                    ui.label(dim("AUTO"));
+                    let last = if s.auto_last_unix > 0 {
+                        format!(
+                            "   last {} ({}s ago)",
+                            fmt_hz_signed(s.auto_last_hz),
+                            (crate::time::now_unix() - s.auto_last_unix).max(0)
+                        )
+                    } else {
+                        String::new()
+                    };
+                    ui.label(
+                        RichText::new(format!(
+                            "{} over {} correction{}{last}",
+                            fmt_hz_signed(s.auto_total_hz),
+                            s.auto_applies,
+                            if s.auto_applies == 1 { "" } else { "s" },
+                        ))
+                        .size(10.0)
+                        .monospace()
+                        .color(theme::GREEN()),
+                    );
+                    ui.end_row();
+                }
             });
         }
 

--- a/crates/sdroxide-ui/src/app/qo100.rs
+++ b/crates/sdroxide-ui/src/app/qo100.rs
@@ -691,13 +691,20 @@ impl SdroxideApp {
                 ui.label(dim("DRIFT"));
                 ui.label(
                     RichText::new(if s.est_drift_hz_s.abs() >= 0.05 {
-                        format!("{:+.1} Hz/s  (de-rotated before decode)", s.est_drift_hz_s)
+                        if s.est_drift_accel_hz_s2.abs() >= 0.05 {
+                            format!(
+                                "{:+.1} Hz/s   {:+.2} Hz/s²  (de-rotated before decode)",
+                                s.est_drift_hz_s, s.est_drift_accel_hz_s2
+                            )
+                        } else {
+                            format!("{:+.1} Hz/s  (de-rotated before decode)", s.est_drift_hz_s)
+                        }
                     } else {
                         "— (need a longer run of estimates)".to_string()
                     })
                     .size(10.0)
                     .monospace()
-                    .color(if s.est_drift_hz_s.abs() > 15.0 {
+                    .color(if s.est_drift_hz_s.abs() > 15.0 || s.est_drift_accel_hz_s2.abs() > 3.0 {
                         theme::YELLOW()
                     } else {
                         theme::TEXT()
@@ -821,15 +828,24 @@ impl SdroxideApp {
                 if s.sync_bit_errors != u8::MAX {
                     // Always shown: sync passing (≤3) but CRC never lighting
                     // means the demod is marginal — the closer this is to 0,
-                    // the more of the payload is decoding right.
+                    // the more of the payload is decoding right. The ×N is how
+                    // many distinct sync alignments the best bitstream held: a
+                    // real frame shows ×1–2 at very few errors, a lone chance
+                    // hit shows ×1 near 3 errors.
+                    let real = s.sync_bit_errors <= 1 && s.sync_matches >= 1;
                     ui.label(
-                        RichText::new(format!("sync {} / 32 err", s.sync_bit_errors))
-                            .size(9.0)
-                            .color(if s.sync_bit_errors <= 3 {
-                                theme::CYAN_DIM()
-                            } else {
-                                theme::YELLOW()
-                            }),
+                        RichText::new(format!(
+                            "sync {} / 32 err  ×{}",
+                            s.sync_bit_errors, s.sync_matches
+                        ))
+                        .size(9.0)
+                        .color(if real {
+                            theme::GREEN()
+                        } else if s.sync_bit_errors <= 3 {
+                            theme::CYAN_DIM()
+                        } else {
+                            theme::YELLOW()
+                        }),
                     );
                 }
             });

--- a/docs/USER_MANUAL.md
+++ b/docs/USER_MANUAL.md
@@ -15,7 +15,7 @@ or connects to a remote sdroxide server.
 
 1. [Feature overview](#1-feature-overview)
 2. [Basic operation](#2-basic-operation)
-    - [2.21 QO-100 beacon calibration](#221-qo-100-beacon-calibration)
+    - [2.21 QO-100 beacon plugin](#221-qo-100-beacon-plugin)
 3. [Digital modes (FT8, FT4, FT2, PSK31, RTTY, Olivia, THOR, FSQ, Hellschreiber, SSTV, RIFP, weather fax, JS8, RF Paint, WSPR, packet, APRS, ADS-B, NAVTEX, VDL2)](#3-digital-modes)
 4. [Skimmers (CW, PSK, RTTY)](#4-skimmers)
 5. [ISM band decoder (315 / 345 / 433 / 868 / 915 MHz devices)](#5-ism-band-decoder)
@@ -118,9 +118,10 @@ or connects to a remote sdroxide server.
   spectrum as well as its I/Q (a KiwiSDR, a SpyServer, an RX-888), the main
   panadapter keeps widening past the streamed passband and draws those spans
   from the full-band bins. See [§2.8](#28-the-display-and-fft-controls).
-- **QO-100 beacon calibration** — decodes the 10489.750 MHz narrowband beacon,
-  measures how far your LNB has drifted, and writes the converter offset for
-  you. In the **SAT** window's QO-100 tab; see [§2.21](#221-qo-100-beacon-calibration).
+- **QO-100 beacon plugin** — tracks the 10489.750 MHz narrowband beacon,
+  measures how far your LNB is off, and (with AUTO) keeps correcting the
+  converter offset as it drifts. In the **SAT** window's QO-100 tab; see
+  [§2.21](#221-qo-100-beacon-plugin).
 - **Many radio backends:** SoapySDR devices, OpenHPSDR (Hermes/Metis) Ethernet
   SDRs, a TCI server (ExpertSDR3/Thetis), a SmartSDR radio (FlexRadio
   FLEX-6000/8000), RTL-SDR, RX-888, Airspy HF+ and SDRplay RSP receivers over
@@ -1725,7 +1726,7 @@ the correction keeps being applied whether or not the window is open.
 
 The window has two tabs. **SATELLITES** is the picker and the live lock
 described below. **QO-100** is the beacon calibration
-([2.21](#221-qo-100-beacon-calibration)) — a geostationary bird needs no
+([2.21](#221-qo-100-beacon-plugin)) — a geostationary bird needs no
 Doppler, but it does need its LNB offset measured, and that is the whole of
 working it. Either tab carries a dot while its own work is running, and the
 **SAT** button glows for both.
@@ -2446,97 +2447,159 @@ This is the same data `--record-iq` ([12](#12-command-line-reference)) writes,
 in a container other programs can open — `--record-iq` writes the bare samples
 and starts with the program, which is what a headless capture wants.
 
-### 2.21 QO-100 beacon calibration
+### 2.21 QO-100 beacon plugin
 
 The QO-100 (Es'hail-2) narrowband transponder carries a beacon on its lower
-edge, at **10489.750 MHz**, that transmits AO-40 telemetry as 400 baud
-Manchester BPSK. Every ground station receives that beacon through an LNB, whose
-local oscillator is only roughly on frequency and drifts with temperature — so
-the dial and the signal disagree by a few kHz, and by different amounts on a
-cold morning and a warm afternoon. The **QO-100** tab of the **SAT** window
-([2.16](#216-satellite-operation-sat)) decodes the beacon, measures exactly how
-far it is from 10489.750 MHz, and offers to write that figure into the
-converter/LNB offset in one click. It lives there because QO-100 is a
-satellite — a geostationary one, which is why it needs no Doppler correction
-and why its calibration is the only thing it does need.
+edge, at **10489.750 MHz**, transmitted as 400 baud Manchester BPSK. Every
+ground station receives it through an LNB whose local oscillator is only roughly
+on frequency and drifts with temperature — so the dial and the signal disagree
+by a few kHz, and by different amounts on a cold morning and a warm afternoon.
+The **QO-100** tab of the **SAT** window
+([2.16](#216-satellite-operation-sat)) measures exactly where the beacon really
+is, corrects the converter/LNB offset so the dial and the signal agree, and then
+keeps correcting it as the LNB drifts. It lives in the SAT window because
+QO-100 is a satellite — a geostationary one, which is why it needs no Doppler
+correction and why keeping its LNB calibrated is the whole of working it.
 
-**In brief.** With an LNB or converter offset set up in the receiver for the
-QO-100 (Es'hail-2) geostationary satellite, the decoder searches ±25 kHz either
-side of 10489.750 MHz — without moving the main dial, since it works off the raw
-IQ the hardware is already delivering — locks onto the beacon there, and decodes
-its AO-40 telemetry. From the frequency it actually found the beacon on it works
-out how far the LNB or receiver offset is in error, and **APPLY CORRECTION**
-writes the corrected figure back; the receiver reopens on the new offset and the
-decoder re-centres itself on the now-corrected dial. This is the same task the
-QO-100 beacon plugin performs in SDR Console.
+Everything runs off the raw IQ the hardware is already delivering, so **the main
+dial is never moved** and the plugin keeps working with the receiver parked
+anywhere the beacon is still inside the captured span.
 
 > **Note:** like the skimmers and the ISM decoder, this is a wideband feature.
 > It needs a true IQ source and is unavailable when a CAT radio is feeding
 > demodulated audio.
 
-#### What the page shows
+#### How it works: ON and AUTO
 
-- **ON / OFF** starts the decoder. It reads the raw IQ straight from the
-  hardware, so it works regardless of where the main dial is pointed, as long as
-  the beacon is inside the span the receiver is delivering — **the main dial is
-  left exactly where it is**. If your capture does not reach 10489.750 MHz, the
-  page offers an explicit **Tune to 10489.750 MHz** button. Like SCAN and a
-  satellite lock, the **SAT** chip stays lit whenever the decoder is running,
-  window open or not, and the QO-100 tab carries a dot — so a hunt in progress
-  is visible from the other tab as well as from outside the window.
-  It is greyed out only if the receiver's own configuration says 10489.750 MHz
-  is unreachable — the usual cause is that no converter/LNB offset has been set
-  up yet (**Settings ▸ Radio ▸ Converter**).
-- **width ± / −** sets how far either side of 10489.750 MHz the search looks, in
-  5 kHz steps from ±5 to ±50 kHz. It opens at **±25 kHz** — wide enough to catch
-  an uncalibrated LNB, whose LO can be tens of kHz off, on the first pass — and
-  is narrowed right down once a correction has been applied. A wider search asks
-  the receiver for a wider capture and takes longer to sweep, so it is not free.
-  The demodulator itself always runs at a fixed rate whatever the capture, which
-  keeps that in hand up to a point: ±5 kHz sweeps in a fraction of a second and
-  the ±25 kHz it opens at in a few seconds, both comfortably inside the window
-  they are searching. ±50 kHz takes longer than the window does to fill, so at
-  the widest setting the decoder runs a core flat out and gets through fewer
-  windows than it receives. Widen it to ±50 kHz only if the beacon is not found,
-  then bring it back down.
-- The **mini waterfall** draws the slice of spectrum being searched, with the
-  measured beacon frequency marked once the decoder locks. It is only a picture:
-  if the receiver is parked on another band the strip is blank and the window
-  says so, but the decoder keeps working.
-- **RECEIVER / TARGET / MEASURED / DRIFT** are the dial frequency now, the
-  10489.750 MHz target, the frequency the beacon was actually found on, and the
-  difference. DRIFT is green within ±200 Hz, amber to ±3 kHz.
-- **TELEMETRY** shows the beacon's own decoded status text. It is there for its
-  own sake and as an independent check: a lock with a valid CRC but garbled text
-  is a warning that no number above would catch.
-- The status line under the strip is the honest measure, the same
-  "attempted vs. succeeded" idea as the ISM decoder's bursts/decoded line: the
-  first search window fills after about 24 seconds, then repeats (a wide search
-  sweeps each window more slowly), and a search that is running but has not
-  found the beacon reads differently from one that never started.
+- **ON** starts the *spectral tracker*. Once a second it looks in the shaded
+  **park** lane of the strip for the beacon's give-away shape — two symmetric
+  lobes with a null between them — and works out where the carrier sits and how
+  far that is from 10489.750 MHz. It reads the beacon's *shape*, never its bits,
+  so it keeps a measurement even where the telemetry will not decode. Nothing is
+  changed yet: ON only measures.
+- **AUTO** closes the loop. With it lit, every clean, steady measurement the
+  tracker makes is applied — a slow, deadbanded, rate-limited nudge to the
+  converter/LNB offset that pulls the beacon back onto 10489.750 MHz and holds
+  it there as the LNB warms up and drifts. A single noisy reading never yanks
+  the receiver; it takes a run of agreeing measurements to move the offset.
+- **TELEMETRY** (optional) additionally runs the AO-40 frame decoder, with a
+  `carrier → sync → CRC` readout of how far each pass got. It is an independent
+  check and shows the beacon's own status text when it locks; it is not needed
+  for calibration and depends heavily on LNB phase-noise — a clean twin-lobe
+  shape can track perfectly while the bits never decode.
 
-#### Applying the correction
+#### Recommended procedure
+
+1. **Get the beacon roughly onto frequency first.** In **Settings ▸ Radio**,
+   set the converter/LNB offset for your own LNB and get it as close as you can,
+   so the beacon lands somewhere near **10489.750 MHz** on the dial. The plugin
+   corrects a residual error of a few kHz to tens of kHz — not a wild guess.
+2. Open the **SAT** window and switch to the **QO-100** tab.
+3. Press **ON**. For a fast first approach, step the **width** value at the top
+   (`−` / `+`, in ±5 kHz clicks up to ±50 kHz) until you can clearly see the
+   beacon's two lobes in the strip. Widen only as far as you need to find it.
+4. **Double-click the middle of the beacon** in the strip. That plants a "the
+   beacon is here" mark — the two lobes with the null between them, centred on
+   the null. Then press **APPLY CORRECTION** at the bottom. The receiver reopens
+   on the corrected offset and the beacon jumps toward the centre.
+5. **Narrow the width back down** (toward **±5 kHz**), double-click the middle of
+   the beacon once more to centre it precisely, and **APPLY CORRECTION** again.
+   Two passes — a coarse one wide, a fine one narrow — get it within a few
+   hundred Hz.
+6. Press **AUTO**. From now on the offset is corrected continuously as the LNB
+   drifts. You can shrink the window to the corner and leave it running in the
+   background — the correction keeps going with the window closed, and the
+   **SAT** chip stays lit and the QO-100 tab keeps its dot while it does.
+
+#### The panel
+
+```
+┌─ SAT ─────────────────────────────────────────────────────────┐
+│  [ SATELLITES • ]  [ QO-100 • ]                               │
+│                                                               │
+│  [ ON ]  [ TELEMETRY ]  [ AUTO ]     width [−] ±25 kHz [+]     │
+│  park [lo −][lo +] +5 … +20 kHz [hi −][hi +]                   │
+│  ┌─────────────────────────────────────────────────────────┐  │
+│  │  mini waterfall — shaded = park lane,                    │  │
+│  │  dashed line = 10489.750 MHz target,                     │  │
+│  │  double-click the beacon's centre to mark it             │  │
+│  └─────────────────────────────────────────────────────────┘  │
+│  searching / locked — N blocks tried, M locked                │
+│                                                               │
+│  TRACKER   +1.2 kHz   (null 12 dB  sym 0.94  snr 15 dB)       │
+│  DRIFT     -6 Hz/s  -0.4 Hz/s²                                 │
+│  AUTO      -3.19 kHz over 4 corrections   last +80 Hz (7s)     │
+│  RECEIVER  10489.750000 MHz                                    │
+│  TARGET    10489.750000 MHz                                    │
+│  MEASURED  10489.751200 MHz  (tracker)                        │
+│  DRIFT     +1.2 kHz                                            │
+│  CONVERTER OFFSET  -9749920000 Hz                             │
+│  DECODE    ● carrier  ○ sync  ○ CRC    sync 4/32 err ×0       │
+│  TELEMETRY <beacon status text, when the decoder locks>       │
+│                                                               │
+│                 [  APPLY CORRECTION  ]                         │
+└───────────────────────────────────────────────────────────────┘
+```
+
+- **ON / OFF** — start or stop the spectral tracker (see above). Greyed out only
+  when the receiver's configuration says 10489.750 MHz is unreachable — usually
+  because no converter/LNB offset has been set up yet
+  (**Settings ▸ Radio ▸ Converter**). If the current capture simply does not
+  reach the beacon, a **Tune to 10489.750 MHz** button appears.
+- **width `−` / `+`** — how far either side of 10489.750 MHz the AO-40 decoder
+  searches, ±5 kHz to ±50 kHz in 5 kHz steps. Wider costs a wider capture and a
+  slower sweep, so open it only as far as needed to find the beacon, then bring
+  it back to ±5 kHz. It does not affect the spectral tracker, which uses the
+  **park** window instead.
+- **park `lo` / `hi`** — the lane, in +kHz above the dial, that the spectral
+  tracker scans for the twin-lobe shape (shaded on the strip). Park the beacon
+  inside it, clear of the DC spike, before switching ON. With AUTO armed the
+  tracker also reaches down toward the centre so it can follow the beacon there
+  after the loop has corrected it.
+- **mini waterfall** — the slice of spectrum around the beacon, with the target
+  line and, once the decoder locks, the measured frequency marked. Purely a
+  picture: if the receiver is on another band the strip is blank but the plugin
+  keeps working. **Double-click** it to hand-mark the beacon for APPLY.
+- **TRACKER / SHAPE** — where the tracker puts the carrier, and how convincing
+  the shape was (`null` depth, lobe `sym`metry, `snr`).
+- **DRIFT** — the LNB's measured drift rate, and its curvature as it warms.
+- **AUTO** — a running total of what the closed loop has corrected, and when it
+  last acted.
+- **RECEIVER / TARGET / MEASURED / DRIFT** — the dial now, the 10489.750 MHz
+  target, where the beacon was actually found (from a decoder lock or your
+  hand-mark), and the difference. DRIFT is green within ±200 Hz, amber to ±3 kHz.
+- **CONVERTER OFFSET** — the converter/LNB offset currently in force, the number
+  APPLY and AUTO write to.
+- **DECODE** — the AO-40 decoder's progress: `carrier → sync → CRC`, plus
+  `sync N/32 err ×M` (fewest sync-word bit errors, and how many candidate frame
+  alignments were seen — `×0` near the error budget means no real frame, just a
+  chance hit).
+- **TELEMETRY** — the beacon's own decoded status text. A valid CRC with garbled
+  text is a warning no number above would catch.
+- The status line under the strip is the honest "attempted vs. succeeded" count,
+  like the ISM decoder's bursts/decoded line.
+
+#### APPLY CORRECTION
 
 **APPLY CORRECTION** writes the corrected converter offset and reopens the
-receiver — the same brief interruption **Settings ▸ Radio ▸ Apply** makes, so a
-bad reading can never disturb a running receiver for more than that. The button
-stays disabled until the decoder has locked **twice** and the latest of those
-frames carried telemetry text: a 32-bit sync word matched within three bit
-errors and then a 16-bit CRC will pass by pure chance roughly once every couple
-of hours of searching, and one lock is not enough to change a setting on. The
-figure written is the one from that most recent lock. After it is applied, the
-window shows what changed and when.
+receiver — the same brief interruption **Settings ▸ Radio ▸ Apply** makes. It
+uses whichever measurement is current: a decoder lock if the telemetry decoded,
+otherwise the beacon mark you double-clicked on the strip. From a decoder lock
+it stays disabled until there have been **two** locks and the latest carried
+telemetry text — a 32-bit sync within three bit errors plus a 16-bit CRC pass
+by pure chance roughly once every couple of hours, and one lock is not enough to
+change a setting on. After it acts, the window shows what changed and when.
 
-Because the coded frames the beacon alternates with are not decoded, a lock
-lands roughly every 20 seconds rather than every 10 — which is normal and not a
-sign the beacon has gone away.
+Once AUTO is armed you rarely touch APPLY again — it is the manual path for the
+first coarse/fine passes, and for stations where the telemetry never decodes and
+the twin-lobe shape is all you have.
 
 #### Remote and browser clients
 
-The decoder runs on the machine the radio is on. Its readout is not sent to
+The plugin runs on the machine the radio is on. Its readout is not sent to
 remote or browser clients yet, so on those the window opens, the strip draws
 from the shared spectrum, and the status line says the readout is local to the
-receiving station rather than sitting on "starting…".
+receiving station.
 
 ---
 

--- a/docs/USER_MANUAL.md
+++ b/docs/USER_MANUAL.md
@@ -2461,13 +2461,14 @@ satellite — a geostationary one, which is why it needs no Doppler correction
 and why its calibration is the only thing it does need.
 
 **In brief.** With an LNB or converter offset set up in the receiver for the
-QO-100 (Es'hail-2) geostationary satellite, the decoder searches a few kHz
-either side of 10489.750 MHz, locks onto the beacon there, and decodes its
-AO-40 telemetry. Having tuned itself onto the signal to get a clean decode, it
-then works out from the frequency it actually found the beacon on how far the
-LNB or receiver offset is in error, and **APPLY CORRECTION** writes the
-corrected figure back. This is the same task the QO-100 beacon plugin performs
-in SDR Console.
+QO-100 (Es'hail-2) geostationary satellite, the decoder searches ±25 kHz either
+side of 10489.750 MHz — without moving the main dial, since it works off the raw
+IQ the hardware is already delivering — locks onto the beacon there, and decodes
+its AO-40 telemetry. From the frequency it actually found the beacon on it works
+out how far the LNB or receiver offset is in error, and **APPLY CORRECTION**
+writes the corrected figure back; the receiver reopens on the new offset and the
+decoder re-centres itself on the now-corrected dial. This is the same task the
+QO-100 beacon plugin performs in SDR Console.
 
 > **Note:** like the skimmers and the ISM decoder, this is a wideband feature.
 > It needs a true IQ source and is unavailable when a CAT radio is feeding
@@ -2477,8 +2478,9 @@ in SDR Console.
 
 - **ON / OFF** starts the decoder. It reads the raw IQ straight from the
   hardware, so it works regardless of where the main dial is pointed, as long as
-  the beacon is inside the span the receiver is delivering — turning it on also
-  tunes VFO A to 10489.750 MHz as a convenience, nothing more. Like SCAN and a
+  the beacon is inside the span the receiver is delivering — **the main dial is
+  left exactly where it is**. If your capture does not reach 10489.750 MHz, the
+  page offers an explicit **Tune to 10489.750 MHz** button. Like SCAN and a
   satellite lock, the **SAT** chip stays lit whenever the decoder is running,
   window open or not, and the QO-100 tab carries a dot — so a hunt in progress
   is visible from the other tab as well as from outside the window.
@@ -2486,16 +2488,17 @@ in SDR Console.
   is unreachable — the usual cause is that no converter/LNB offset has been set
   up yet (**Settings ▸ Radio ▸ Converter**).
 - **width ± / −** sets how far either side of 10489.750 MHz the search looks, in
-  5 kHz steps from ±5 to ±50 kHz. Start at the default ±5 kHz; widen it only if
-  the beacon is not found, which means the LNB is further off than usual. A
-  wider search asks the receiver for a wider capture and takes longer to sweep,
-  so it is not free. The demodulator itself always runs at a fixed rate whatever
-  the capture, which keeps that in hand up to a point: the default ±5 kHz sweeps
-  in a fraction of a second and ±25 kHz in a few seconds, both comfortably
-  inside the window they are searching. ±50 kHz takes longer than the window
-  does to fill, so at the widest setting the decoder runs a core flat out and
-  gets through fewer windows than it receives. Widen it to find the beacon, then
-  bring it back down.
+  5 kHz steps from ±5 to ±50 kHz. It opens at **±25 kHz** — wide enough to catch
+  an uncalibrated LNB, whose LO can be tens of kHz off, on the first pass — and
+  is narrowed right down once a correction has been applied. A wider search asks
+  the receiver for a wider capture and takes longer to sweep, so it is not free.
+  The demodulator itself always runs at a fixed rate whatever the capture, which
+  keeps that in hand up to a point: ±5 kHz sweeps in a fraction of a second and
+  the ±25 kHz it opens at in a few seconds, both comfortably inside the window
+  they are searching. ±50 kHz takes longer than the window does to fill, so at
+  the widest setting the decoder runs a core flat out and gets through fewer
+  windows than it receives. Widen it to ±50 kHz only if the beacon is not found,
+  then bring it back down.
 - The **mini waterfall** draws the slice of spectrum being searched, with the
   measured beacon frequency marked once the decoder locks. It is only a picture:
   if the receiver is parked on another band the strip is blank and the window
@@ -2508,9 +2511,9 @@ in SDR Console.
   is a warning that no number above would catch.
 - The status line under the strip is the honest measure, the same
   "attempted vs. succeeded" idea as the ISM decoder's bursts/decoded line: the
-  first search window fills after about 24 seconds, then repeats, and a search
-  that is running but has not found the beacon reads differently from one that
-  never started.
+  first search window fills after about 24 seconds, then repeats (a wide search
+  sweeps each window more slowly), and a search that is running but has not
+  found the beacon reads differently from one that never started.
 
 #### Applying the correction
 


### PR DESCRIPTION
Reworks the QO-100 tab of the SAT window from a single AO-40 frame decoder into
a two-part tool, because on a real station the frame decoder alone was the weak
link: on my Pluto + non-referenced LNB it would try ~1200 blocks and never lock,
so there was nothing to calibrate against.

## What it does now

- **ON** runs a fast **spectral tracker**. Every ~1 s it scans the operator's
  parking window for the beacon's give-away shape — two symmetric lobes with a
  null between them (Manchester BPSK has a *null* at the carrier, not a peak) —
  and reports where the carrier sits, with `null` / `sym` / `snr` saying how
  convincing the match was. It reads the beacon's *shape*, never its bits, so it
  keeps a measurement where the demodulator cannot lock.
- **AUTO** closes the loop engine-side (`qo100_auto_correction`, pure + tested):
  on a clean, agreeing, deadbanded, rate-limited estimate it nudges
  `RadioConfig::converter_offset_hz` so the beacon lands back on 10489.750 MHz
  and holds it there as the LNB warms up and drifts.
- **TELEMETRY** is now opt-in and separate: it additionally runs the sync-word +
  CRC frame decoder with a `carrier -> sync -> CRC` step-by-step readout and a
  `sync N/32 err xM` diagnostic (`xM` = distinct frame alignments seen, so a
  chance sync hit near the error budget is told apart from a real frame the
  payload demod is failing).
- **Double-click the strip** to hand-mark the beacon when its null is plainly
  visible but the decoder will not lock — drives DRIFT and APPLY exactly as a
  real lock would.
- Drift compensation before frame decode: the tracker fits a least-squares
  Hz/s (and, as the LNB warms, a curvature term) and `acquire_debug` de-rotates
  that chirp before each sweep, since a warming LNB smears the carrier across the
  10.36 s frame.
- On QO-100 ON the main dial is left where it is and the search opens at
  ±25 kHz — wide enough to find an uncalibrated LNB on the first pass.

User manual section 2.21 is rewritten around this flow (ON measures, AUTO
corrects, coarse-then-fine procedure, panel sketch) and renamed "QO-100 beacon
plugin"; the three cross-references and the feature-overview bullet follow.

## On the AO-40 telemetry decode

The framing path (differential + Manchester demod -> 32-bit sync -> CRC-16) is
sound: the synthetic-frame tests decode a full AO-40 uncoded frame end to end,
including drifted and chirped carriers. On a station with a **stable, low
phase-noise LNB** (reference-locked, or a good TCXO unit) the telemetry decodes.

Where it does **not** decode is a station whose LNB LO has significant phase
noise — which is what I have here (a non-referenced Ku LNB). On my captures the
symbol clock locks cleanly to 800 sym/s but neither the uncoded 32-bit sync nor
the FEC 65-bit distributed sync rises above chance, and a faithful reproduction
of gr-satellites' demod chain (FLL + `symbol_sync_cc` + RRC matched filter)
fails the same way. The differential demod shows ~55 deg RMS symbol-to-symbol
carrier phase jitter and ~17 % marginal bits, far more than the ~12 dB AWGN SNR
alone would give — LNB LO phase noise. The twin-lobe *shape* (and so the
tracker and AUTO) survives that; the frame CRC does not.

So the shape-based tracker is what makes this useful for a phase-noisy station.
Follow-ups that would widen the decoder's reach further: a proper matched
filter / timing loop / carrier FLL in `bpsk.rs`, and the AO-40 FEC-frame
format, which is still unimplemented.

## Testing

- `cargo build --release` on the full workspace, `cargo test -p sdroxide-qo100`
  (30 tests), `cargo clippy` — all clean.
- Spectral tracker and AUTO exercised on-air against the real QO-100 beacon
  (Pluto + Ku LNB): twin-lobe shape reads `null ~8-12 dB, sym ~0.9, snr ~12-15`,
  AUTO settles the converter offset and follows the warm-up drift.
- The AO-40 frame decoder is covered by synthetic-signal tests (clean, drifted
  and chirped frames all decode). A real on-air lock was not achieved on my own
  phase-noisy LNB — see the section above.
