### PR TITLE
Refer the SDRplay S-meter to the antenna, and wire up the RSP gain controls the API has

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5335,6 +5335,7 @@ dependencies = [
  "sdroxide-types",
  "thiserror 2.0.20",
  "tracing",
+ "tracing-subscriber",
  "winreg",
 ]
 

--- a/crates/sdroxide-proto/src/lib.rs
+++ b/crates/sdroxide-proto/src/lib.rs
@@ -1169,7 +1169,23 @@ use sdroxide_types::{
 /// reads every field after `hpsdr` out of step; and the enum's new variant is
 /// appended, so no surviving discriminant moved but a v129 peer handed one
 /// fails to decode the message carrying it.
-pub const PROTO_VERSION: u16 = 130;
+///
+/// v131: the SDRplay gain controls say what they are and what they may reach.
+/// [`sdroxide_types::GainElement`] gains a `unit`, because decibels are wrong
+/// for one of them: an RSP's RF gain is a step into a band-dependent table and
+/// a control that appended dB to it reported a number three times too small.
+/// The struct rides `DeviceCaps` inside `ServerMsg::Capabilities`, which an RSP
+/// now re-sends on every retune — the ladder's length belongs to the band — so
+/// a v130 peer would read the tail of each one out of step rather than merely
+/// missing a field.
+///
+/// With it, [`sdroxide_types::SdrPlayConfig`] gains `hdr_bw` (which filter the
+/// RSPdx's HDR path runs, previously left at the API's default because nothing
+/// ever wrote it) and `extended_if_gr` (whether the IF gain reduction may go
+/// below the API's 20 dB floor). Both sit at that block's tail, and
+/// `RadioConfig` rides `ServerMsg::RadioConfig` and `Command::SetRadioConfig`
+/// whole, so a v130 peer handed one reads the tail of each of those out of step.
+pub const PROTO_VERSION: u16 = 131;
 const VERSION_BYTE: u8 = 0x12;
 
 #[derive(Debug, thiserror::Error)]

--- a/crates/sdroxide-radio/src/device.rs
+++ b/crates/sdroxide-radio/src/device.rs
@@ -826,13 +826,11 @@ fn probe_caps(dev: &soapysdr::Device) -> Result<DeviceCaps> {
         }
         for name in dev.list_gains(dir, 0).unwrap_or_default() {
             if let Ok(r) = dev.gain_element_range(dir, 0, name.as_str()) {
-                gains.push(GainElement {
-                    name,
-                    direction: typed,
-                    min_db: r.minimum,
-                    max_db: r.maximum,
-                    step_db: r.step,
-                });
+                // SoapySDR's gain ranges are decibels by contract, whatever
+                // the driver behind them counts in — including the SDRplay
+                // module, which presents its LNA ladder as an "RFGR" range in
+                // dB rather than as the step index the native backend uses.
+                gains.push(GainElement::db(name, typed, r.minimum, r.maximum, r.step));
             }
         }
     }

--- a/crates/sdroxide-radio/src/engine.rs
+++ b/crates/sdroxide-radio/src/engine.rs
@@ -3874,6 +3874,14 @@ fn engine_thread(
     let mut next_drm = Instant::now();
     let mut next_session = Instant::now() + SESSION_SAVE_INTERVAL;
 
+    // The band-dependent gain ranges, once, before anything is published: the
+    // ones the device was opened with are the model's widest, and the band the
+    // session came up on is very likely not that band. Kept out of the loop
+    // below — unlike the antenna refresh beside it, building this allocates,
+    // and the three things that can move it (retune, port, HDR) each ask for
+    // it where they happen.
+    engine.refresh_rx_gains();
+
     // The commands waiting at the top of a tick, kept between iterations so the
     // batch costs no allocation. See [`collapse_superseded`].
     let mut batch: Vec<Command> = Vec::new();
@@ -7383,6 +7391,9 @@ impl Engine {
                     }
                     self.state.gains = self.source.current_gains();
                     self.remember_gain(dir, element, db);
+                    // An RSPdx's HDR switch rides a gain element and changes
+                    // which LNA table is in force.
+                    self.refresh_rx_gains();
                 }
                 Direction::Tx => {
                     if let Err(e) = self.source.set_tx_gain_element(&element, db) {
@@ -7422,6 +7433,9 @@ impl Engine {
                         self.state.antenna_rx = self.source.current_antenna();
                         self.want_antenna.0 = Some(name.clone());
                         self.band_antenna.entry(self.state.band).or_default().0 = Some(name);
+                        // A Hi-Z port has fewer front-end states than the 50 Ω
+                        // one beside it.
+                        self.refresh_rx_gains();
                     }
                     Direction::Tx => {
                         if let Err(e) = self.source.set_tx_antenna(&name) {
@@ -11545,7 +11559,13 @@ impl Engine {
     ///   manufacturer calibrated that against a signal generator, and it is
     ///   already in dBm, so the dBFS→dBm offset must *not* go on top of it.
     /// * An IQ front end — the receive chain measures its own passband, in
-    ///   dBFS, which `cal_offset_db` turns into dBm for this hardware.
+    ///   dBFS, which `cal_offset_db` turns into dBm for this hardware. A front
+    ///   end that reports its own gain ([`IqSource::rx_gain_db`]) has that
+    ///   taken off first: dBFS is a level at the converter, and the level at
+    ///   the antenna is that level minus whatever the front end put in front
+    ///   of it. Without the subtraction the reading follows the gain — every
+    ///   step of an attenuator, and on hardware with its own AGC the loop's
+    ///   whole range, lands on the meter as if the band had done it.
     /// * A rig on a sound card whose family has no meter read: all that is left
     ///   is the level of the audio it sends, after its own AGC and squelch.
     ///   Not the same quantity, but it moves with the signal, and a meter that
@@ -11564,7 +11584,8 @@ impl Engine {
             return Some(self.audio_level_dbfs() + self.cal_offset_db);
         }
         if let Some(p) = self.main.as_ref().and_then(|c| c.power_dbfs()) {
-            return Some(p + self.cal_offset_db);
+            let gain = self.source.rx_gain_db().unwrap_or(0.0);
+            return Some(p - gain + self.cal_offset_db);
         }
         self.audio_mode.then(|| self.audio_level_dbfs() + self.cal_offset_db)
     }
@@ -12415,6 +12436,32 @@ impl Engine {
         self.restore_antennas();
         self.follow_band_antenna(self.state.band);
         let _ = self.event_tx.send(RadioEvent::State(self.state.clone()));
+    }
+
+    /// Re-publish the RX gain ranges when what they depend on has moved.
+    ///
+    /// The same shape as [`Engine::refresh_antennas`], and there for a
+    /// neighbouring reason: an RSP's RF gain is a step into a table whose
+    /// length belongs to the *band*, so a range published once when the device
+    /// opened is wrong for most of the spectrum. Called after a retune, a port
+    /// change and a gain command — the three things that can move it — rather
+    /// than from the loop, because building the answer allocates and the loop
+    /// runs per block.
+    ///
+    /// Also re-reads the values. The driver clamps a state the new band does
+    /// not have and reports the one it kept, and a slider left sitting above
+    /// that would be showing a setting the hardware never took.
+    fn refresh_rx_gains(&mut self) {
+        let Some(gains) = self.source.learned_rx_gains() else { return };
+        if gains != self.caps.gains {
+            self.caps.gains = gains;
+            let _ = self.event_tx.send(RadioEvent::Capabilities(self.caps.clone()));
+        }
+        let now = self.source.current_gains();
+        if now != self.state.gains {
+            self.state.gains = now;
+            let _ = self.event_tx.send(RadioEvent::State(self.state.clone()));
+        }
     }
 
     /// Note down a gain stage the operator has set, so it can be put back on
@@ -15030,6 +15077,9 @@ impl Engine {
             Ok(()) => {
                 self.state.center_hz = center_hz;
                 self.note_center_change(center_hz);
+                // The LNA table an RSP offers belongs to the band, and the band
+                // has just moved.
+                self.refresh_rx_gains();
                 // Re-place the skim window inside the span that has just moved;
                 // one that really moves re-labels its spots and clears its
                 // tracks, so none straddles the old and new axis.

--- a/crates/sdroxide-radio/src/source.rs
+++ b/crates/sdroxide-radio/src/source.rs
@@ -206,6 +206,22 @@ pub trait IqSource: Send {
     fn learned_antennas(&self) -> Option<&'static [&'static str]> {
         None
     }
+    /// The RX gain stages the front end has **right now**, when their ranges
+    /// are not a fact about the hardware alone. `None` — the default — leaves
+    /// `DeviceCaps::gains` exactly as it was built.
+    ///
+    /// One backend needs this. An RSP's RF gain is a step into a table whose
+    /// length is a property of the *band*: an RSPdx has 28 states at 250–420
+    /// MHz and 19 below 12 MHz, so a range published once at open is wrong for
+    /// most of the spectrum, and a slider built from it spends its top third
+    /// moving nothing and snapping back as the driver clamps.
+    ///
+    /// Asked only where the answer can have changed — after a retune, a port
+    /// change or a gain command — rather than on every pass of the engine
+    /// loop, because building it allocates.
+    fn learned_rx_gains(&self) -> Option<Vec<sdroxide_types::GainElement>> {
+        None
+    }
     /// Switch the *radio* off, or back on again, over its control link.
     ///
     /// The radio's own power switch, not sdroxide's: an Icom answers `18 00` /
@@ -368,6 +384,29 @@ pub trait IqSource: Send {
     /// us IQ need none of this — the engine measures the passband itself.
     /// Default: none.
     fn rx_signal_dbm(&mut self) -> Option<f32> {
+        None
+    }
+    /// Absolute gain, in dB, between the antenna socket and the converter that
+    /// produced these samples. `None` when the front end cannot say.
+    ///
+    /// The engine measures the passband in dBFS, which is a level *at the
+    /// converter*; the level at the antenna is that minus whatever the front
+    /// end put in front of it. Where a source knows that number the engine
+    /// takes it off, and what is left is a reading that stays put when the
+    /// gain moves — which is the whole point, because on a front end with an
+    /// AGC the gain moves continuously and an S-meter that follows it is
+    /// measuring the loop rather than the band.
+    ///
+    /// Default: `None`, which leaves the reading on the old footing — dBFS
+    /// plus the operator's fixed calibration offset. That is the right answer
+    /// for a front end whose gain nothing reports, and for one whose gain
+    /// never moves.
+    ///
+    /// Must describe the samples being delivered *now*, not a gain that has
+    /// been commanded and not yet taken effect: a front end that answers with
+    /// the new value while the old samples are still in flight puts a step in
+    /// the meter that the antenna never saw.
+    fn rx_gain_db(&self) -> Option<f32> {
         None
     }
     /// Offset (Hz) of the operator's VFO from the IQ centre, so a rig that keeps
@@ -1250,6 +1289,12 @@ impl IqSource for ConvertedSource {
     fn learned_antennas(&self) -> Option<&'static [&'static str]> {
         self.inner.learned_antennas()
     }
+    /// The front end's own stages. A converter shifts the frequency the *radio*
+    /// shows, but the tuner behind it is still on the converted one, so its
+    /// band-dependent ranges are the inner source's to report.
+    fn learned_rx_gains(&self) -> Option<Vec<sdroxide_types::GainElement>> {
+        self.inner.learned_rx_gains()
+    }
     fn set_rig_power(&mut self, on: bool) -> Result<()> {
         self.inner.set_rig_power(on)
     }
@@ -1344,6 +1389,14 @@ impl IqSource for ConvertedSource {
 
     fn rx_signal_dbm(&mut self) -> Option<f32> {
         self.inner.rx_signal_dbm()
+    }
+
+    /// The front end's own gain, which is what it was: a converter ahead of it
+    /// shifts the frequency and not the level. Its conversion gain or loss is
+    /// the operator's to put in the calibration offset, being a property of
+    /// their box rather than anything the radio can read.
+    fn rx_gain_db(&self) -> Option<f32> {
+        self.inner.rx_gain_db()
     }
 
     /// Relative (VFO minus IQ centre), so untouched.

--- a/crates/sdroxide-radio/tests/gain_memory.rs
+++ b/crates/sdroxide-radio/tests/gain_memory.rs
@@ -103,13 +103,7 @@ impl IqSource for Rig {
 }
 
 fn caps() -> DeviceCaps {
-    let el = |name: &str, dir, max_db| GainElement {
-        name: name.into(),
-        direction: dir,
-        min_db: 0.0,
-        max_db,
-        step_db: 1.0,
-    };
+    let el = |name: &str, dir, max_db| GainElement::db(name, dir, 0.0, max_db, 1.0);
     DeviceCaps {
         driver: "bench".into(),
         label: "bench rig".into(),

--- a/crates/sdroxide-radio/tests/gain_range_follows_band.rs
+++ b/crates/sdroxide-radio/tests/gain_range_follows_band.rs
@@ -1,0 +1,142 @@
+//! A front end whose gain ladder belongs to the band has to re-publish it
+//! when the band moves.
+//!
+//! An RSP's RF gain is a step into a table, and how long that table is depends
+//! on where the dial is: an RSPdx has 28 states at 250–420 MHz and 19 below
+//! 12 MHz. Published once when the device opened, the range is wrong for most
+//! of the spectrum — and wrong in the direction that hurts, because a slider
+//! offering states the service refuses spends its top third moving nothing and
+//! snapping back as the driver clamps.
+
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::{Duration, Instant};
+
+use sdroxide_radio::{Complex32, EngineConfig, IqSource, Result, start_engine};
+use sdroxide_types::{Command, DeviceCaps, Direction, GainElement, GainUnit, RadioEvent};
+
+const RATE: f64 = 2_000_000.0;
+const HF: f64 = 7_100_000.0;
+const VHF: f64 = 300_000_000.0;
+
+/// The stand-in ladder: short on HF, long in the band an RSPdx has all of.
+/// The exact numbers are the RSPdx's own, so a reader can check them against
+/// the API specification's table rather than against a fiction.
+fn states_at(hz: f64) -> u8 {
+    if hz < 12e6 { 18 } else { 27 }
+}
+
+struct Rig {
+    center: Arc<AtomicU64>,
+}
+
+impl Rig {
+    fn hz(&self) -> f64 {
+        f64::from_bits(self.center.load(Ordering::Relaxed))
+    }
+}
+
+impl IqSource for Rig {
+    fn sample_rate(&self) -> f64 {
+        RATE
+    }
+    fn center_hz(&self) -> f64 {
+        self.hz()
+    }
+    fn set_center_hz(&mut self, hz: f64) -> Result<()> {
+        self.center.store(hz.to_bits(), Ordering::Relaxed);
+        Ok(())
+    }
+    fn read(&mut self, buf: &mut [Complex32]) -> Result<usize> {
+        std::thread::sleep(Duration::from_millis(5));
+        let n = buf.len().min(2048);
+        buf[..n].fill(Complex32::new(0.001, 0.0));
+        Ok(n)
+    }
+    fn describe(&self) -> String {
+        "mock banded front end".into()
+    }
+    fn current_gains(&self) -> Vec<(String, f64)> {
+        // Clamped to the band, the way the driver reports what it kept.
+        vec![("LNA".to_string(), -f64::from(states_at(self.hz())))]
+    }
+    fn learned_rx_gains(&self) -> Option<Vec<GainElement>> {
+        Some(vec![GainElement::steps(
+            "LNA",
+            Direction::Rx,
+            -f64::from(states_at(self.hz())),
+            0.0,
+            1.0,
+        )])
+    }
+}
+
+fn caps() -> DeviceCaps {
+    DeviceCaps {
+        driver: "bench".into(),
+        label: "bench front end".into(),
+        rx_channels: 1,
+        sample_rates: vec![RATE],
+        freq_ranges_rx: vec![(0.0, 2_000_000_000.0)],
+        // Deliberately the model-wide ceiling, as a real backend publishes it
+        // before the engine has asked: the point is that it gets corrected.
+        gains: vec![GainElement::steps("LNA", Direction::Rx, -27.0, 0.0, 1.0)],
+        ..DeviceCaps::default()
+    }
+}
+
+/// Run an engine, tune it where `tune_to` says, and return the last gain range
+/// it published for the LNA.
+fn lna_range_after(tune_to: Option<f64>) -> GainElement {
+    let center = Arc::new(AtomicU64::new(HF.to_bits()));
+    let mut h = start_engine(
+        Box::new(Rig { center: Arc::clone(&center) }),
+        caps(),
+        EngineConfig::default(),
+    );
+    let thread = h.thread.take();
+
+    let mut last: Option<GainElement> = None;
+    let mut sent = tune_to.is_none();
+    let deadline = Instant::now() + Duration::from_secs(3);
+    while Instant::now() < deadline {
+        while let Ok(ev) = h.event_rx.try_recv() {
+            if let RadioEvent::Capabilities(c) = ev
+                && let Some(g) = c.gains.iter().find(|g| g.name == "LNA")
+            {
+                last = Some(g.clone());
+            }
+        }
+        if !sent {
+            let _ = h.cmd_tx.send(Command::SetVfo {
+                vfo: sdroxide_types::Vfo::A,
+                hz: tune_to.expect("a frequency to tune to"),
+            });
+            sent = true;
+        }
+        std::thread::sleep(Duration::from_millis(20));
+    }
+
+    drop(h.cmd_tx);
+    if let Some(t) = thread {
+        let _ = t.join();
+    }
+    last.expect("the engine must publish an LNA range")
+}
+
+/// On the band the session came up on, the published range is that band's —
+/// not the wider one the device was opened with.
+#[test]
+fn the_opening_range_is_narrowed_to_the_band_it_came_up_on() {
+    let g = lna_range_after(None);
+    assert_eq!(g.min_db, -18.0, "HF has 19 states, not the model's 28");
+    assert_eq!(g.unit, GainUnit::Step, "a state index is not decibels");
+}
+
+/// And it follows the dial: tuning to a band with a longer ladder re-publishes
+/// the longer one.
+#[test]
+fn the_range_follows_a_retune() {
+    let g = lna_range_after(Some(VHF));
+    assert_eq!(g.min_db, -27.0, "250-420 MHz has all 28 states");
+}

--- a/crates/sdroxide-radio/tests/gain_referred_meter.rs
+++ b/crates/sdroxide-radio/tests/gain_referred_meter.rs
@@ -1,0 +1,173 @@
+//! The S-meter on an I/Q front end that reports its own gain.
+//!
+//! A receive chain measures its passband in dBFS, which is a level at the
+//! converter — so on its own it says as much about the front end's gain as it
+//! does about the antenna. Turning an attenuator in used to move the meter by
+//! the whole step, and on hardware with its own AGC (every SDRplay RSP, by
+//! default) the loop moved it continuously: a signal appearing raised the
+//! reading, the AGC took the gain back down, and the reading sank to where it
+//! started while the signal was still there.
+//!
+//! `IqSource::rx_gain_db` is what fixes that, and what these hold is the
+//! property that makes it worth having — the reading is a fact about the
+//! antenna, so moving the gain must not move it, and a signal that really does
+//! change must still come through.
+//!
+//! Every assertion here is a *difference* between two runs. What the chain's
+//! own gain works out to — filters, decimation, the window on the measurement
+//! — is not what this is about, and pinning an absolute dBm figure would make
+//! the test fail for every honest change to the receive chain.
+
+use std::time::Duration;
+
+use sdroxide_radio::{AudioParams, Complex32, EngineConfig, IqSource, Result, rtrb, start_engine};
+use sdroxide_types::{DeviceCaps, RadioEvent};
+
+const RATE: f64 = 48_000.0;
+const CENTER: f64 = 14_100_000.0;
+/// A deliberately non-zero dBFS→dBm calibration, so a reading that has had it
+/// applied is distinguishable from one that has not.
+const CAL_OFFSET_DB: f32 = 7.0;
+/// The level the stand-in signal would arrive at with the front end at unity,
+/// in dBFS. Low enough that the largest gain below still leaves headroom.
+const ANTENNA_DBFS: f32 = -70.0;
+
+/// An I/Q front end delivering a constant carrier, with a gain it reports.
+///
+/// The gain is applied to the samples as well as reported, because that is
+/// what makes the exercise mean anything: real hardware hands over a bigger
+/// sample for more gain, and the two halves are supposed to cancel. A mock
+/// that reported a gain without applying it would "pass" a meter that had the
+/// subtraction backwards.
+struct Rig {
+    /// Level at the antenna, in dBFS-at-unity-gain.
+    antenna_dbfs: f32,
+    /// What the front end puts in front of the converter, and reports.
+    /// `None` for one that cannot say.
+    gain_db: Option<f32>,
+}
+
+impl Rig {
+    fn amplitude(&self) -> f32 {
+        let at_adc = self.antenna_dbfs + self.gain_db.unwrap_or(0.0);
+        10f32.powf(at_adc / 20.0)
+    }
+}
+
+impl IqSource for Rig {
+    fn sample_rate(&self) -> f64 {
+        RATE
+    }
+    fn center_hz(&self) -> f64 {
+        CENTER
+    }
+    fn set_center_hz(&mut self, _hz: f64) -> Result<()> {
+        Ok(())
+    }
+    fn read(&mut self, buf: &mut [Complex32]) -> Result<usize> {
+        std::thread::sleep(Duration::from_millis(5));
+        let n = buf.len().min(2048);
+        // Constant amplitude: the mean square is exactly this, whatever block
+        // length the engine asks for.
+        buf[..n].fill(Complex32::new(self.amplitude(), 0.0));
+        Ok(n)
+    }
+    fn describe(&self) -> String {
+        "mock I/Q front end".into()
+    }
+    fn rx_gain_db(&self) -> Option<f32> {
+        self.gain_db
+    }
+}
+
+fn caps() -> DeviceCaps {
+    DeviceCaps {
+        driver: "bench".into(),
+        label: "bench front end".into(),
+        rx_channels: 1,
+        sample_rates: vec![RATE],
+        freq_ranges_rx: vec![(0.0, 60_000_000.0)],
+        ..DeviceCaps::default()
+    }
+}
+
+/// The last S-meter reading an engine on this front end published.
+fn s_dbm(antenna_dbfs: f32, gain_db: Option<f32>) -> f32 {
+    // A speaker for the receive chain to end at: no audio sink, no
+    // demodulator, and it is the demodulator that measures the passband.
+    let (producer, mut consumer) = rtrb::RingBuffer::<f32>::new(1 << 16);
+    let mut h = start_engine(
+        Box::new(Rig { antenna_dbfs, gain_db }),
+        caps(),
+        EngineConfig {
+            audio: Some(AudioParams { producer, out_rate: RATE }),
+            cal_offset_db: CAL_OFFSET_DB,
+            ..Default::default()
+        },
+    );
+    let thread = h.thread.take();
+
+    let mut last = None;
+    let deadline = std::time::Instant::now() + Duration::from_secs(2);
+    while std::time::Instant::now() < deadline {
+        while let Ok(ev) = h.event_rx.try_recv() {
+            if let RadioEvent::Meters(m) = ev {
+                last = Some(m.s_dbm);
+            }
+        }
+        // Keep the ring draining, or the chain stalls on a full speaker and
+        // the measurement stops with it.
+        while consumer.pop().is_ok() {}
+        std::thread::sleep(Duration::from_millis(20));
+    }
+
+    drop(h.cmd_tx);
+    if let Some(t) = thread {
+        let _ = t.join();
+    }
+    last.expect("an I/Q front end must publish an S-meter")
+}
+
+/// The one that matters: the same signal, seen through 30 dB more front-end
+/// gain, must read the same. This is the SDRplay AGC case — the loop moves the
+/// gain continuously, and every one of those movements used to land on the
+/// meter as if the band had done it.
+#[test]
+fn the_reading_does_not_follow_the_gain() {
+    let low = s_dbm(ANTENNA_DBFS, Some(20.0));
+    let high = s_dbm(ANTENNA_DBFS, Some(50.0));
+    let drift = (high - low).abs();
+    assert!(
+        drift < 1.0,
+        "30 dB more front-end gain moved the S-meter by {drift:.1} dB \
+         ({low:.1} → {high:.1}); it is metering the gain, not the antenna"
+    );
+}
+
+/// And the meter must still be a meter: a signal that really is 10 dB stronger
+/// reads 10 dB stronger. Subtracting the gain must not have subtracted the
+/// signal with it.
+#[test]
+fn a_stronger_signal_still_reads_stronger() {
+    let weak = s_dbm(ANTENNA_DBFS, Some(30.0));
+    let strong = s_dbm(ANTENNA_DBFS + 10.0, Some(30.0));
+    let rise = strong - weak;
+    assert!(
+        (rise - 10.0).abs() < 1.0,
+        "a 10 dB stronger signal moved the meter by {rise:.1} dB ({weak:.1} → {strong:.1})"
+    );
+}
+
+/// A front end that cannot report a gain is left exactly where it was: raw
+/// dBFS plus the station's calibration offset, which is what a reported gain
+/// of zero also means. Every backend but the SDRplay one is in this case, so a
+/// regression here would be a silent change to every other radio's meter.
+#[test]
+fn a_front_end_that_cannot_say_reads_as_one_at_unity() {
+    let silent = s_dbm(ANTENNA_DBFS, None);
+    let unity = s_dbm(ANTENNA_DBFS, Some(0.0));
+    assert!(
+        (silent - unity).abs() < 1.0,
+        "a front end that reports no gain read {silent:.1}, one reporting 0 dB read {unity:.1}"
+    );
+}

--- a/crates/sdroxide-radio/tests/power_switch.rs
+++ b/crates/sdroxide-radio/tests/power_switch.rs
@@ -89,13 +89,7 @@ fn wide_caps() -> DeviceCaps {
         rx_channels: 1,
         sample_rates: vec![WIDE_RATE],
         freq_ranges_rx: vec![(0.0, 60_000_000.0)],
-        gains: vec![GainElement {
-            name: "LNA".into(),
-            direction: Direction::Rx,
-            min_db: -6.0,
-            max_db: 40.0,
-            step_db: 1.0,
-        }],
+        gains: vec![GainElement::db("LNA", Direction::Rx, -6.0, 40.0, 1.0)],
         ..DeviceCaps::default()
     }
 }

--- a/crates/sdroxide-sdrplay/Cargo.toml
+++ b/crates/sdroxide-sdrplay/Cargo.toml
@@ -20,3 +20,8 @@ libloading.workspace = true
 
 [target."cfg(windows)".dependencies]
 winreg = "0.56.0"
+
+# The gain probe example only; the library itself logs through `tracing` and
+# leaves the subscriber to whoever links it.
+[dev-dependencies]
+tracing-subscriber.workspace = true

--- a/crates/sdroxide-sdrplay/examples/gain_probe.rs
+++ b/crates/sdroxide-sdrplay/examples/gain_probe.rs
@@ -1,0 +1,185 @@
+//! Whether a level referred back to the antenna holds still while the front
+//! end's gain moves, measured against an injected carrier of known level.
+//!
+//! ```sh
+//! # defaults match the bench setup: -73 dBm at 7295 kHz on Antenna A
+//! cargo run --release -p sdroxide-sdrplay --example gain_probe
+//! cargo run --release -p sdroxide-sdrplay --example gain_probe -- 7295000 -73 "Antenna A"
+//! ```
+//!
+//! Measures the **carrier bin**, not the whole span. That distinction is the
+//! whole point: a −73 dBm carrier is far below the receiver's own noise taken
+//! over 2 MHz, so a wideband power measurement reports the noise floor and
+//! says nothing about the signal. The S-meter measures a demodulated passband
+//! a few kHz wide, and this measures narrower still, so what comes out is the
+//! carrier and not the band it sits in.
+//!
+//! For each LNA state it prints the carrier level in dBFS, the system gain the
+//! API reports, the difference (what an antenna-referred S-meter would read in
+//! dBFS-at-the-antenna), and the error against the generator's known level.
+//! The `referred` column is supposed to stay put; the `error` column is what
+//! `cal_offset_db` would have to be to make the reading absolute.
+
+use std::f64::consts::TAU;
+use std::time::{Duration, Instant};
+
+use sdroxide_sdrplay::SdrPlayHandle;
+use sdroxide_types::{SdrPlayAgc, SdrPlayConfig};
+
+/// Samples per coherent block. At 2 Msps this is a 488 Hz bin — narrow enough
+/// to put the carrier well clear of the noise, wide enough that a few ppm of
+/// reference error does not rotate the accumulation apart inside one block.
+const BLOCK: usize = 4096;
+/// How far either side of the expected offset to look for the carrier, in
+/// bins, so a reference error of a few ppm is found rather than missed.
+const SEARCH_BINS: i32 = 6;
+/// Where the carrier is parked relative to the tuned centre. Off DC on
+/// purpose: a zero-IF front end piles LO leakage and flicker noise there.
+const CARRIER_OFFSET_HZ: f64 = 40_000.0;
+
+fn main() {
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::try_from_default_env()
+                .unwrap_or_else(|_| "sdroxide_sdrplay=warn".into()),
+        )
+        .init();
+
+    let mut args = std::env::args().skip(1);
+    let carrier_hz: f64 = args.next().and_then(|a| a.parse().ok()).unwrap_or(7_295_000.0);
+    let known_dbm: f64 = args.next().and_then(|a| a.parse().ok()).unwrap_or(-73.0);
+    let antenna = args.next().unwrap_or_else(|| "Antenna A".into());
+
+    let devices = sdroxide_sdrplay::list();
+    let Some(dev) = devices.first() else {
+        eprintln!("no SDRplay receiver found");
+        return;
+    };
+    println!("using {}", dev.label());
+    println!("reference: {:.3} kHz carrier at {known_dbm} dBm on {antenna}", carrier_hz / 1000.0);
+
+    // Tune below the carrier so it lands at a known offset, clear of DC.
+    let center = carrier_hz - CARRIER_OFFSET_HZ;
+    let cfg = SdrPlayConfig {
+        serial: dev.serial.clone(),
+        sample_rate_hz: 2_000_000.0,
+        agc: SdrPlayAgc::Off,
+        if_gr_db: 40,
+        lna_state: 0,
+        antenna: antenna.clone(),
+        ..SdrPlayConfig::default()
+    };
+
+    let mut h = match sdroxide_sdrplay::spawn(&cfg, center) {
+        Ok(h) => h,
+        Err(e) => {
+            eprintln!("could not open the receiver: {e}");
+            return;
+        }
+    };
+    // The port is a control like any other, and the config above only reaches
+    // the session that opened the device.
+    h.set_antenna(&antenna);
+
+    println!("\n=== AGC off (manual IF gain, 40 dB) ===\n");
+    h.set_agc(SdrPlayAgc::Off.code() as i32);
+    h.set_if_gr_db(40);
+    sweep(&mut h, known_dbm);
+
+    println!("\n=== extended IF range: gRdB below the API's 20 dB floor ===\n");
+    h.set_agc(SdrPlayAgc::Off.code() as i32);
+    h.set_lna_state(9);
+    println!("{:>5}  {:>11}  {:>9}  {:>12}", "IFGR", "carrier dBFS", "currGain", "referred");
+    println!("{}", "-".repeat(42));
+    h.set_extended_if_gr(true);
+    for gr in [0i32, 5, 10, 15, 20, 25] {
+        h.set_if_gr_db(gr);
+        if let Some((dbfs, curr)) = measure(&mut h) {
+            println!("{gr:>5}  {dbfs:>11.2}  {curr:>9.2}  {:>12.2}", dbfs - curr);
+        }
+    }
+    h.set_extended_if_gr(false);
+    h.set_if_gr_db(40);
+}
+
+fn sweep(h: &mut SdrPlayHandle, known_dbm: f64) {
+    println!(
+        "{:>3}  {:>4}  {:>11}  {:>9}  {:>10}  {:>9}  {}",
+        "LNA", "IFGR", "carrier dBFS", "gain dB", "referred", "error", ""
+    );
+    println!("{}", "-".repeat(58));
+    let mut referred = Vec::new();
+    for state in [0u8, 3, 6, 9, 12, 15, 18] {
+        h.set_lna_state(state);
+        let Some((carrier_dbfs, gain)) = measure(h) else {
+            println!("{state:>3}   ---  (no carrier found)");
+            continue;
+        };
+        let r = carrier_dbfs - gain;
+        referred.push(r);
+        println!(
+            "{:>3}  {:>4}  {carrier_dbfs:>11.2}  {gain:>9.2}  {r:>10.2}  {:>+9.2}  {}",
+            h.lna_state(),
+            h.effective_if_gr_db().unwrap_or(0),
+            known_dbm - r,
+            if h.overloaded() { "ADC OVERLOAD" } else { "" },
+        );
+    }
+    if referred.len() < 2 {
+        return;
+    }
+    let (lo, hi) = referred.iter().fold((f64::MAX, f64::MIN), |(l, h), v| (l.min(*v), h.max(*v)));
+    let mean = referred.iter().sum::<f64>() / referred.len() as f64;
+    println!("\nreferred spread across the sweep: {:.2} dB  (0 is perfect)", hi - lo);
+    println!("cal_offset_db that would make this absolute: {:+.2}", known_dbm - mean);
+}
+
+/// Carrier level in dBFS and the system gain that produced it, or `None` if no
+/// carrier stood out of the noise.
+fn measure(h: &mut SdrPlayHandle) -> Option<(f64, f64)> {
+    let rate = h.out_rate_hz();
+    let mut buf = vec![0f32; BLOCK * 2];
+    // Settle first: a window straddling a gain change belongs to neither side
+    // of it, and under AGC the loop needs a moment to find its level again.
+    let settle = Instant::now() + Duration::from_millis(700);
+    while Instant::now() < settle {
+        h.read(&mut buf);
+        std::thread::sleep(Duration::from_millis(5));
+    }
+
+    // Incoherent average of |X(f)|² over several blocks, at each of a few bins
+    // around where the carrier should be. Averaging the power rather than the
+    // complex value is what makes a few ppm of reference error harmless: the
+    // phase differs from block to block, the magnitude does not.
+    let mut acc = vec![0f64; (2 * SEARCH_BINS + 1) as usize];
+    let mut blocks = 0usize;
+    let deadline = Instant::now() + Duration::from_millis(900);
+    while Instant::now() < deadline && blocks < 64 {
+        let got = h.read(&mut buf);
+        if got < BLOCK * 2 {
+            std::thread::sleep(Duration::from_millis(5));
+            continue;
+        }
+        let bin_hz = rate / BLOCK as f64;
+        for (k, slot) in acc.iter_mut().enumerate() {
+            let offset = CARRIER_OFFSET_HZ + (k as i32 - SEARCH_BINS) as f64 * bin_hz;
+            let w = TAU * offset / rate;
+            let (mut re, mut im) = (0f64, 0f64);
+            for n in 0..BLOCK {
+                let (i, q) = (f64::from(buf[2 * n]), f64::from(buf[2 * n + 1]));
+                let (s, c) = (-w * n as f64).sin_cos();
+                // (i + jq) · e^{-jwn}
+                re += i * c - q * s;
+                im += i * s + q * c;
+            }
+            let n = BLOCK as f64;
+            *slot += (re * re + im * im) / (n * n);
+        }
+        blocks += 1;
+    }
+    if blocks == 0 {
+        return None;
+    }
+    let peak = acc.iter().copied().fold(f64::MIN, f64::max) / blocks as f64;
+    Some((10.0 * (peak + 1e-30).log10(), h.system_gain_db().unwrap_or(0.0)))
+}

--- a/crates/sdroxide-sdrplay/examples/hdr_probe.rs
+++ b/crates/sdroxide-sdrplay/examples/hdr_probe.rs
@@ -1,0 +1,245 @@
+//! A driveable RSP for bench work: holds one session open and takes commands
+//! on stdin, so a script can step an external generator between measurements
+//! without paying for a device open each time.
+//!
+//! ```sh
+//! cargo run --release -p sdroxide-sdrplay --example hdr_probe -- <centre_hz>
+//! ```
+//!
+//! Commands, one per line:
+//!
+//! ```text
+//! hdr on|off        the RSPdx's high-dynamic-range path
+//! hdrbw 0|1|2|3     its analog filter: 200 kHz, 500 kHz, 1.2 MHz, 1.7 MHz
+//! lna <n>           LNA state; prints what the band clamp kept
+//! ifgr <n>          IF gain reduction, dB
+//! extgr on|off      allow the reduction below the API's 20 dB floor
+//! maxlna            the clamp in force — 18 below 2 MHz, 21 on the HDR path
+//! measure           one reading: carrier, noise, gain, overload
+//! quit
+//! ```
+//!
+//! `measure` reports the level in the carrier bin **and** in a bin well away
+//! from it, so one pass gives both ends of the dynamic range: the wanted
+//! signal and the floor it is sitting on. Both are narrowband — a bin, not the
+//! span — because a -76 dBm carrier is far below the receiver's own noise
+//! taken over 2 MHz, and a wideband measurement would report only the noise.
+//!
+//! The carrier is expected [`CARRIER_OFFSET_HZ`] above the tuned centre. That
+//! is not a convenience: HDR is built at fixed centres, so the *receiver* has
+//! nowhere else to sit, and a carrier on the centre would land on the zero-IF
+//! DC spike. Offsetting the generator instead keeps both happy.
+
+use std::f64::consts::TAU;
+use std::io::{BufRead, Write};
+use std::time::{Duration, Instant};
+
+use sdroxide_sdrplay::SdrPlayHandle;
+use sdroxide_types::{SdrPlayAgc, SdrPlayConfig, SdrPlayHdrBw};
+
+/// Samples per coherent block: a 488 Hz bin at 2 Msps.
+const BLOCK: usize = 4096;
+/// Bins either side of the expected offset, so a few ppm of reference error is
+/// found rather than missed.
+const SEARCH_BINS: i32 = 6;
+/// Where the generator is parked relative to the tuned centre.
+const CARRIER_OFFSET_HZ: f64 = 40_000.0;
+/// Where the noise floor is read: far enough from the carrier that its skirts
+/// and any spurious product of it do not raise the answer, still inside the
+/// analog filter on every HDR setting (the narrowest is 200 kHz).
+const NOISE_OFFSET_HZ: f64 = -70_000.0;
+
+fn main() {
+    // stdout is the command protocol; anything the driver has to say goes to
+    // stderr or it desynchronises the caller.
+    tracing_subscriber::fmt()
+        .with_writer(std::io::stderr)
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::try_from_default_env()
+                .unwrap_or_else(|_| "sdroxide_sdrplay=warn".into()),
+        )
+        .init();
+
+    let centre: f64 = std::env::args().nth(1).and_then(|a| a.parse().ok()).unwrap_or(875_000.0);
+    // Which port to open on. Part of the experiment rather than a setting: HDR
+    // was at one point suspected of listening on a fixed port whatever the
+    // selector said, which measurement disproved — it is deaf on A and C alike.
+    let antenna = std::env::args().nth(2).unwrap_or_else(|| "Antenna A".into());
+    // Whether HDR is asked for at Init rather than switched on afterwards: the
+    // API takes it either way, and whether the hardware agrees is the question.
+    let hdr_at_init = std::env::args().nth(3).is_some_and(|a| a == "hdr");
+    let rate: f64 = std::env::args().nth(4).and_then(|a| a.parse().ok()).unwrap_or(2_000_000.0);
+    // The *tuner's* analog bandwidth, which is a different control from the
+    // HDR filter and has never been varied in these experiments. 0 = auto.
+    let bw_khz: u32 = std::env::args().nth(5).and_then(|a| a.parse().ok()).unwrap_or(0);
+
+    let devices = sdroxide_sdrplay::list();
+    let Some(dev) = devices.first() else {
+        eprintln!("no SDRplay receiver found");
+        return;
+    };
+
+    let cfg = SdrPlayConfig {
+        serial: dev.serial.clone(),
+        sample_rate_hz: rate,
+        bw_khz,
+        // Manual throughout: an AGC would absorb the compression this exists
+        // to find.
+        agc: SdrPlayAgc::Off,
+        if_gr_db: 40,
+        lna_state: 4,
+        antenna: antenna.clone(),
+        hdr: hdr_at_init,
+        ..SdrPlayConfig::default()
+    };
+
+    let mut h = match sdroxide_sdrplay::spawn(&cfg, centre) {
+        Ok(h) => h,
+        Err(e) => {
+            eprintln!("could not open the receiver: {e}");
+            return;
+        }
+    };
+    h.set_antenna(&antenna);
+    h.set_agc(SdrPlayAgc::Off.code() as i32);
+    h.set_if_gr_db(40);
+
+    println!(
+        "# {} on {:.3} kHz via {antenna}, hdr_at_init={hdr_at_init}, bw={bw_khz} kHz, \
+              carrier expected at +{:.0} kHz",
+        dev.label(),
+        centre / 1e3,
+        CARRIER_OFFSET_HZ / 1e3
+    );
+    println!("ready");
+    let _ = std::io::stdout().flush();
+
+    let stdin = std::io::stdin();
+    for line in stdin.lock().lines().map_while(std::result::Result::ok) {
+        let mut it = line.split_whitespace();
+        let Some(verb) = it.next() else { continue };
+        let arg = it.next().unwrap_or("");
+        match verb {
+            "hdr" => {
+                h.set_hdr(arg == "on");
+                println!("ok hdr {arg}");
+            }
+            "hdrbw" => {
+                let bw = SdrPlayHdrBw::from_code(arg.parse().unwrap_or(3.0));
+                h.set_hdr_bw(bw.code());
+                println!("ok hdrbw {} ({})", bw.code(), bw.label());
+            }
+            "lna" => {
+                h.set_lna_state(arg.parse().unwrap_or(0));
+                settle(&mut h, 400);
+                println!("ok lna {} gain={:.2}", h.lna_state(), h.system_gain_db().unwrap_or(0.0));
+            }
+            "ifgr" => {
+                h.set_if_gr_db(arg.parse().unwrap_or(40));
+                settle(&mut h, 400);
+                println!(
+                    "ok ifgr {} gain={:.2}",
+                    h.effective_if_gr_db().unwrap_or(0),
+                    h.system_gain_db().unwrap_or(0.0)
+                );
+            }
+            "extgr" => {
+                h.set_extended_if_gr(arg == "on");
+                println!("ok extgr {arg}");
+            }
+            "maxlna" => {
+                // Ask for a state past the end of any table and read back what
+                // the driver kept: the clamp *is* the answer, and asking it
+                // this way needs no copy of the table on this side.
+                let was = h.lna_state();
+                h.set_lna_state(u8::MAX);
+                settle(&mut h, 300);
+                let top = h.lna_state();
+                h.set_lna_state(was);
+                settle(&mut h, 300);
+                println!("maxlna {top}");
+            }
+            "measure" => {
+                // Optional offset, so a caller can walk the generator across
+                // the span and find where the path actually passes.
+                let off = arg.parse().unwrap_or(CARRIER_OFFSET_HZ);
+                let (carrier, noise, gain, over) = measure(&mut h, off);
+                // Everything referred to the antenna, which is the only scale
+                // on which the two paths can be compared: their gains differ.
+                println!(
+                    "meas carrier_dbfs={carrier:.2} noise_dbfs={noise:.2} gain_db={gain:.2} \
+                     carrier_ref={:.2} noise_ref={:.2} snr={:.2} overload={}",
+                    carrier - gain,
+                    noise - gain,
+                    carrier - noise,
+                    u8::from(over)
+                );
+            }
+            "quit" => break,
+            _ => println!("? {verb}"),
+        }
+        let _ = std::io::stdout().flush();
+    }
+}
+
+fn settle(h: &mut SdrPlayHandle, ms: u64) {
+    let mut buf = vec![0f32; BLOCK * 2];
+    let until = Instant::now() + Duration::from_millis(ms);
+    while Instant::now() < until {
+        h.read(&mut buf);
+        std::thread::sleep(Duration::from_millis(5));
+    }
+}
+
+/// Carrier level, noise level, the system gain both were taken with, and
+/// whether the converter is overloaded — all in one pass over the same
+/// samples, so the two levels cannot drift apart between readings.
+fn measure(h: &mut SdrPlayHandle, carrier_offset_hz: f64) -> (f64, f64, f64, bool) {
+    let rate = h.out_rate_hz();
+    let mut buf = vec![0f32; BLOCK * 2];
+    settle(h, 500);
+
+    let bin_hz = rate / BLOCK as f64;
+    let mut carrier_acc = vec![0f64; (2 * SEARCH_BINS + 1) as usize];
+    let mut noise_acc = 0f64;
+    let mut blocks = 0usize;
+    let deadline = Instant::now() + Duration::from_millis(900);
+    while Instant::now() < deadline && blocks < 64 {
+        let got = h.read(&mut buf);
+        if got < BLOCK * 2 {
+            std::thread::sleep(Duration::from_millis(5));
+            continue;
+        }
+        for (k, slot) in carrier_acc.iter_mut().enumerate() {
+            let off = carrier_offset_hz + f64::from(k as i32 - SEARCH_BINS) * bin_hz;
+            *slot += bin_power(&buf, off, rate);
+        }
+        noise_acc += bin_power(&buf, NOISE_OFFSET_HZ, rate);
+        blocks += 1;
+    }
+    let n = blocks.max(1) as f64;
+    // The peak of the search, because the carrier is somewhere in it; the
+    // noise bin is a single bin and needs no search.
+    let carrier = carrier_acc.iter().copied().fold(f64::MIN, f64::max) / n;
+    let noise = noise_acc / n;
+    (
+        10.0 * (carrier + 1e-30).log10(),
+        10.0 * (noise + 1e-30).log10(),
+        h.system_gain_db().unwrap_or(0.0),
+        h.overloaded(),
+    )
+}
+
+/// Power in one bin, by mixing it to DC and averaging over the block.
+fn bin_power(buf: &[f32], offset_hz: f64, rate: f64) -> f64 {
+    let w = TAU * offset_hz / rate;
+    let (mut re, mut im) = (0f64, 0f64);
+    for n in 0..BLOCK {
+        let (i, q) = (f64::from(buf[2 * n]), f64::from(buf[2 * n + 1]));
+        let (s, c) = (-w * n as f64).sin_cos();
+        re += i * c - q * s;
+        im += i * s + q * c;
+    }
+    let n = BLOCK as f64;
+    (re * re + im * im) / (n * n)
+}

--- a/crates/sdroxide-sdrplay/src/device.rs
+++ b/crates/sdroxide-sdrplay/src/device.rs
@@ -84,76 +84,15 @@ pub fn bw_khz_for(cfg_bw_khz: u32, effective_hz: f64, dual: bool) -> ffi::BwType
     if dual { khz.min(SdrPlayConfig::DUAL_MAX_BW_KHZ as ffi::BwType) } else { khz }
 }
 
-/// Highest usable LNA state for a model on a band. The counts come from the
-/// API headers where they are defined (`RSPIA_NUM_LNA_STATES` and friends)
-/// and from the API specification's gain tables for the RSP1 and RSPdx band
-/// edges. A state past this is rejected by the service, so the driver clamps
-/// and reports what it kept.
+/// Highest usable LNA state for a model on a band, from the one table in
+/// [`SdrPlayModel::max_lna_state_on`].
 ///
-/// `hiz` says the Hi-Z input is routed (RSP2 / RSPduo tuner 1), which has
-/// fewer front-end states of its own.
+/// A thin forward and deliberately so: the settings UI is wasm-safe and cannot
+/// link this crate, so the table has to live where both can reach it. What is
+/// left here is the clamp's own vocabulary — a state past this is rejected by
+/// the service, so the driver clamps and reports what it kept.
 pub fn max_lna_state(model: SdrPlayModel, freq_hz: f64, hiz: bool, hdr: bool) -> u8 {
-    let f = freq_hz;
-    match model {
-        SdrPlayModel::Rsp1 => {
-            if f >= 1_000e6 {
-                2 // 3 states in L-band
-            } else {
-                3 // 4 states everywhere else
-            }
-        }
-        SdrPlayModel::Rsp1a | SdrPlayModel::Rsp1b => {
-            if f < 60e6 {
-                6 // RSPIA_NUM_LNA_STATES_AM = 7
-            } else if f >= 1_000e6 {
-                8 // RSPIA_NUM_LNA_STATES_LBAND = 9
-            } else {
-                9 // RSPIA_NUM_LNA_STATES = 10
-            }
-        }
-        SdrPlayModel::Rsp2 => {
-            if hiz {
-                4 // RSPII_NUM_LNA_STATES_AMPORT = 5
-            } else if f >= 420e6 {
-                5 // RSPII_NUM_LNA_STATES_420MHZ = 6
-            } else {
-                8 // RSPII_NUM_LNA_STATES = 9
-            }
-        }
-        SdrPlayModel::RspDuo => {
-            if hiz {
-                4 // RSPDUO_NUM_LNA_STATES_AMPORT = 5
-            } else if f < 60e6 {
-                6 // RSPDUO_NUM_LNA_STATES_AM = 7
-            } else if f >= 1_000e6 {
-                8 // RSPDUO_NUM_LNA_STATES_LBAND = 9
-            } else {
-                9 // RSPDUO_NUM_LNA_STATES = 10
-            }
-        }
-        SdrPlayModel::RspDx | SdrPlayModel::RspDxR2 => {
-            if hdr && f < 2e6 {
-                21 // RSPDX_NUM_LNA_STATES_DX = 22
-            } else if f < 12e6 {
-                18 // RSPDX_NUM_LNA_STATES_AMPORT2_0_12 = 19
-            } else if f < 50e6 {
-                19 // RSPDX_NUM_LNA_STATES_AMPORT2_12_50 = 20
-            } else if f < 60e6 {
-                24 // RSPDX_NUM_LNA_STATES_AMPORT2_50_60 = 25
-            } else if f < 250e6 {
-                26 // RSPDX_NUM_LNA_STATES_VHF_BAND3 = 27
-            } else if f < 420e6 {
-                27 // RSPDX_NUM_LNA_STATES = 28
-            } else if f < 1_000e6 {
-                20 // RSPDX_NUM_LNA_STATES_420MHZ = 21
-            } else {
-                18 // RSPDX_NUM_LNA_STATES_LBAND = 19
-            }
-        }
-        // The API guarantees nothing about a model these bindings do not
-        // know; every RSP has at least the RSP1's four states.
-        SdrPlayModel::Unknown => 3,
-    }
+    model.max_lna_state_on(freq_hz, hiz, hdr)
 }
 
 /// RSP2 antenna routing for a name from [`SdrPlayModel::antennas`]:
@@ -187,13 +126,10 @@ pub fn rspduo_tuner1_amport(name: &str) -> Option<i32> {
     }
 }
 
-/// Whether an antenna choice routes a Hi-Z input, for the LNA clamp.
+/// Whether an antenna choice routes a Hi-Z input, for the LNA clamp — from
+/// [`SdrPlayModel::antenna_is_hiz`], for the same reason as above.
 pub fn antenna_is_hiz(model: SdrPlayModel, antenna: &str) -> bool {
-    match model {
-        SdrPlayModel::Rsp2 => antenna == "Hi-Z",
-        SdrPlayModel::RspDuo => antenna == "Hi-Z port",
-        _ => false,
-    }
+    model.antenna_is_hiz(antenna)
 }
 
 #[cfg(test)]

--- a/crates/sdroxide-sdrplay/src/ffi.rs
+++ b/crates/sdroxide-sdrplay/src/ffi.rs
@@ -72,6 +72,9 @@ pub const UPDATE_RSP2_AM_PORT: Reason = 0x0000_0100;
 pub const UPDATE_RSP2_ANTENNA: Reason = 0x0000_0200;
 pub const UPDATE_RSP2_RF_NOTCH: Reason = 0x0000_0400;
 pub const UPDATE_TUNER_GR: Reason = 0x0000_8000;
+/// `sdrplay_api_Update_Tuner_GrLimits` — the *limits* moved, not the value.
+/// What `gain.minGr` is sent with.
+pub const UPDATE_TUNER_GR_LIMITS: Reason = 0x0001_0000;
 pub const UPDATE_TUNER_FRF: Reason = 0x0002_0000;
 pub const UPDATE_TUNER_BW_TYPE: Reason = 0x0004_0000;
 pub const UPDATE_TUNER_IF_TYPE: Reason = 0x0008_0000;
@@ -92,6 +95,7 @@ pub const UPDATE_RSPDX_BIAS_T: ReasonExt1 = 0x0000_0002;
 pub const UPDATE_RSPDX_ANTENNA: ReasonExt1 = 0x0000_0004;
 pub const UPDATE_RSPDX_RF_NOTCH: ReasonExt1 = 0x0000_0008;
 pub const UPDATE_RSPDX_DAB_NOTCH: ReasonExt1 = 0x0000_0010;
+pub const UPDATE_RSPDX_HDR_BW: ReasonExt1 = 0x0000_0020;
 
 /// `sdrplay_api_Bw_MHzT` — the value *is* the bandwidth in kHz.
 pub type BwType = i32;
@@ -101,15 +105,29 @@ pub type IfType = i32;
 pub const IF_ZERO: IfType = 0;
 /// The low IF the API's own downconverter works from. Mandatory with both of
 /// an RSPduo's tuners running, where the ADC is fixed at 6 MHz.
+/// The 450 kHz low IF. What the tuner uses where a zero IF is impractical,
+/// and — per SDRuno's HDR documentation — what the RSPdx's HDR path expects.
+pub const IF_0_450: IfType = 450;
 pub const IF_1_620: IfType = 1620;
 /// The same for an 8 MHz ADC clock.
 pub const IF_2_048: IfType = 2048;
 /// `sdrplay_api_LoModeT`.
 pub type LoMode = i32;
 pub const LO_AUTO: LoMode = 1;
+/// The fixed LO settings. The API picks one under `LO_AUTO`; the HDR path's
+/// short list of usable centres looks like the product of a particular choice,
+/// so they are nameable here.
+pub const LO_120MHZ: LoMode = 2;
+pub const LO_144MHZ: LoMode = 3;
+pub const LO_168MHZ: LoMode = 4;
 /// `sdrplay_api_MinGainReductionT`.
 pub type MinGr = i32;
 pub const NORMAL_MIN_GR: MinGr = 20;
+/// The extended floor, which lets `gRdB` go to 0 instead of stopping at 20 —
+/// the last 20 dB of IF gain the hardware has. The API's own default is
+/// `NORMAL_MIN_GR`; this is opt-in because it also moves the AGC set-point
+/// ceiling (see the set-point clamp in `device`).
+pub const EXTENDED_MIN_GR: MinGr = 0;
 /// `sdrplay_api_AgcControlT`.
 pub type AgcControl = i32;
 pub const AGC_DISABLE: AgcControl = 0;
@@ -369,8 +387,17 @@ pub struct RspDuoTunerParamsT {
 /// `sdrplay_api_RspDxTunerParamsT`.
 #[repr(C)]
 pub struct RspDxTunerParamsT {
-    pub hdr_bw: i32,
+    pub hdr_bw: HdrBw,
 }
+
+/// `sdrplay_api_RspDx_HdrModeBwT` — the analog filter in front of the HDR
+/// path, which is a *different* control from the tuner's own `bwType`.
+pub type HdrBw = i32;
+pub const HDR_BW_0_200: HdrBw = 0;
+pub const HDR_BW_0_500: HdrBw = 1;
+pub const HDR_BW_1_200: HdrBw = 2;
+/// The API's default, and what an RSPdx runs with when nobody sets one.
+pub const HDR_BW_1_700: HdrBw = 3;
 
 /// `sdrplay_api_RxChannelParamsT`.
 #[repr(C)]

--- a/crates/sdroxide-sdrplay/src/handle.rs
+++ b/crates/sdroxide-sdrplay/src/handle.rs
@@ -71,6 +71,12 @@ pub(crate) enum Ctrl {
     Ppm(f64),
     /// The RSPdx's high-dynamic-range path, likewise device-wide.
     Hdr(bool),
+    /// The HDR path's analog filter, as an `sdrplay_api_RspDx_HdrModeBwT`
+    /// code. Device-wide for the same reason as the switch above.
+    HdrBw(i32),
+    /// Whether the IF gain reduction may go below the API's normal 20 dB
+    /// floor. Per tuner, like the reduction it bounds.
+    ExtendedIfGr(TunerIdx, bool),
     Shutdown,
 }
 
@@ -83,6 +89,7 @@ pub(crate) struct TunerPending {
     pub lna: Option<u8>,
     pub agc: Option<i32>,
     pub agc_setpoint: Option<i32>,
+    pub extended_if_gr: Option<bool>,
     pub bias_tee: Option<bool>,
     pub rf_notch: Option<bool>,
     pub dab_notch: Option<bool>,
@@ -104,6 +111,7 @@ pub(crate) struct Pending {
     pub detach: [bool; TUNERS],
     pub ppm: Option<f64>,
     pub hdr: Option<bool>,
+    pub hdr_bw: Option<i32>,
     pub shutdown: bool,
 }
 
@@ -133,6 +141,8 @@ impl Pending {
             Ctrl::Antenna(t, v) if ok(t) => self.t[t].antenna = Some(v),
             Ctrl::Ppm(v) => self.ppm = Some(v),
             Ctrl::Hdr(v) => self.hdr = Some(v),
+            Ctrl::HdrBw(v) => self.hdr_bw = Some(v),
+            Ctrl::ExtendedIfGr(t, v) if ok(t) => self.t[t].extended_if_gr = Some(v),
             Ctrl::Shutdown => self.shutdown = true,
             _ => {}
         }
@@ -144,6 +154,7 @@ impl Pending {
             && !self.detach.iter().any(|d| *d)
             && self.ppm.is_none()
             && self.hdr.is_none()
+            && self.hdr_bw.is_none()
             && !self.shutdown
     }
 }
@@ -162,7 +173,31 @@ pub(crate) struct TunerShared {
     pub ev_gr_db: AtomicI64,
     pub ev_lna_gr_db: AtomicI64,
     /// System gain from the same event, in milli-dB.
+    ///
+    /// The event announces a gain the samples in flight were *not* taken with:
+    /// the service raises it when it programs the tuner, and the USB pipe
+    /// behind it is still full of blocks from before. Subtracting this from a
+    /// measurement straight away puts a step in the S-meter the antenna never
+    /// saw, in the wrong direction, for as long as the pipe takes to drain. So
+    /// this is only the announcement; [`Self::rx_curr_gain_milli_db`] is the
+    /// one to measure against.
     pub ev_curr_gain_milli_db: AtomicI64,
+    /// The system gain the samples now arriving were actually taken with, in
+    /// milli-dB, `i64::MIN` for "not yet". This is the one to measure against.
+    ///
+    /// Promoted from the announcement above by `settle_gain` in the stream
+    /// callback, on the block the service flags with `grChanged` or, where it
+    /// never flags one, once the announcement has stood long enough that the
+    /// pipe cannot still be holding samples from before it. Both paths matter
+    /// and the reasoning for each is on that function.
+    pub rx_curr_gain_milli_db: AtomicI64,
+    /// The announcement `settle_gain` is currently waiting on, and the moment
+    /// it arrived (ms since the session epoch). Separate from the two above
+    /// because the wait is per *announcement*: a loop still hunting replaces
+    /// this every few milliseconds and only the value it settles on ever ages
+    /// into place.
+    pub pending_gain_milli_db: AtomicI64,
+    pub pending_gain_since_ms: AtomicU64,
     /// The LNA state actually programmed, after any per-band clamp.
     pub lna_state: AtomicU8,
     /// Set while the engine reading this tuner is transmitting and therefore
@@ -181,6 +216,9 @@ impl TunerShared {
             ev_gr_db: AtomicI64::new(i64::MIN),
             ev_lna_gr_db: AtomicI64::new(i64::MIN),
             ev_curr_gain_milli_db: AtomicI64::new(i64::MIN),
+            rx_curr_gain_milli_db: AtomicI64::new(i64::MIN),
+            pending_gain_milli_db: AtomicI64::new(i64::MIN),
+            pending_gain_since_ms: AtomicU64::new(0),
             lna_state: AtomicU8::new(0),
             rx_paused: AtomicBool::new(false),
         }
@@ -711,6 +749,28 @@ impl SdrPlayHandle {
         self.shared().lna_state.load(Ordering::Relaxed)
     }
 
+    /// Absolute system gain — LNA plus mixer plus IF, everything between the
+    /// antenna socket and the converter — in dB, as the hardware reports it
+    /// for the samples now arriving. `None` until the first block taken with a
+    /// known gain has been delivered.
+    ///
+    /// This is the number that turns a level in dBFS into a level at the
+    /// antenna, and the only one that does: an RSP's front end has two knobs
+    /// and neither is in dB (the LNA is a step index whose value depends on
+    /// the band, the IF is a *reduction*), so nothing derivable from the
+    /// control settings on this side is the whole gain. The API works it out
+    /// and publishes it as `gainParams.currGain`, which is what this is.
+    ///
+    /// It moves on its own whenever the AGC is running, which is precisely
+    /// when it matters: without it an S-meter reads the loop's activity
+    /// instead of the signal.
+    pub fn system_gain_db(&self) -> Option<f64> {
+        match self.shared().rx_curr_gain_milli_db.load(Ordering::Relaxed) {
+            i64::MIN => None,
+            v => Some(v as f64 / 1000.0),
+        }
+    }
+
     /// Read interleaved complex samples. Returns how many `f32` were taken.
     ///
     /// With both tuners combined the ring holds quadruples rather than pairs,
@@ -854,6 +914,22 @@ impl SdrPlayHandle {
     /// second tuner anyway.
     pub fn set_hdr(&self, on: bool) {
         self.send(Ctrl::Hdr(on));
+    }
+
+    /// The HDR path's analog filter. Only does anything with the path itself
+    /// switched on, and only at the centres that filter is built for — see
+    /// [`sdroxide_types::SdrPlayHdrBw::works_at`], which is what the source
+    /// warns the operator from.
+    pub fn set_hdr_bw(&self, code: i32) {
+        self.send(Ctrl::HdrBw(code));
+    }
+
+    /// Open the last 20 dB of IF gain, below the API's normal floor.
+    pub fn set_extended_if_gr(&self, on: bool) {
+        self.send(Ctrl::ExtendedIfGr(self.tuner, on));
+        if self.dual_tuner() {
+            self.send(Ctrl::ExtendedIfGr(1 - self.tuner, on));
+        }
     }
 
     pub fn set_antenna(&self, name: &str) {
@@ -1030,6 +1106,35 @@ mod tests {
         assert_eq!(h.effective_if_gr_db(), None);
         h.shared().ev_gr_db.store(42, Ordering::Relaxed);
         assert_eq!(h.effective_if_gr_db(), Some(42));
+        h.released = true;
+    }
+
+    /// The announcement alone must not move the meter: an event is the service
+    /// saying it has programmed a gain, not that the samples in the pipe were
+    /// taken with it.
+    #[test]
+    fn system_gain_follows_the_samples_not_the_announcement() {
+        let (_p, cons) = RingBuffer::<f32>::new(16);
+        let mut h = test_handle(cons);
+        assert_eq!(h.system_gain_db(), None);
+        h.shared().ev_curr_gain_milli_db.store(43_500, Ordering::Relaxed);
+        assert_eq!(h.system_gain_db(), None, "an announced gain is not a delivered one");
+        h.shared().rx_curr_gain_milli_db.store(43_500, Ordering::Relaxed);
+        assert_eq!(h.system_gain_db(), Some(43.5));
+        h.released = true;
+    }
+
+    /// A split RSPduo's two radios each read their own front end. The gain is
+    /// per tuner for the same reason the IF reduction is: they are two
+    /// receivers, and one operator's attenuator is not the other's.
+    #[test]
+    fn system_gain_is_per_tuner() {
+        let (_p, cons) = RingBuffer::<f32>::new(16);
+        let mut h = test_handle_with(cons, DuoMode::Split, 1);
+        h.dev.shared.t[0].rx_curr_gain_milli_db.store(20_000, Ordering::Relaxed);
+        assert_eq!(h.system_gain_db(), None, "tuner 1 read tuner 0's gain");
+        h.dev.shared.t[1].rx_curr_gain_milli_db.store(31_000, Ordering::Relaxed);
+        assert_eq!(h.system_gain_db(), Some(31.0));
         h.released = true;
     }
 

--- a/crates/sdroxide-sdrplay/src/stream.rs
+++ b/crates/sdroxide-sdrplay/src/stream.rs
@@ -59,6 +59,14 @@ const SCALE: f32 = 1.0 / 32768.0;
 /// acknowledgements) runs anyway.
 const CTRL_TIMEOUT: Duration = Duration::from_millis(100);
 
+/// How long an announced gain must stand before it is believed without the
+/// service having flagged the block that carries it — see [`settle_gain`].
+///
+/// Comfortably longer than the pipe it is covering for (a few milliseconds of
+/// USB and service buffering at any rate this backend offers) and far shorter
+/// than an operator can see on a meter.
+const GAIN_SETTLE: Duration = Duration::from_millis(25);
+
 /// The tuner's own range: 1 kHz to 2 GHz on every model.
 const MIN_RF_HZ: f64 = 1_000.0;
 const MAX_RF_HZ: f64 = 2_000_000_000.0;
@@ -225,6 +233,9 @@ struct LiveTuner {
     lna_wanted: u8,
     /// What is actually programmed after the per-band clamp.
     lna_programmed: u8,
+    /// The IF gain-reduction floor in force — the API's normal 20 dB, or 0
+    /// where the operator has opened the last of the range.
+    min_gr: ffi::MinGr,
     antenna: String,
 }
 
@@ -350,6 +361,10 @@ fn run(
                 center_hz: center,
                 lna_wanted: if is_main { lna_wanted } else { aux_lna_wanted },
                 lna_programmed: if is_main { lna_programmed } else { aux_lna_programmed },
+                // Both tuners share the operator's choice: they are one board,
+                // and a diversity pair gained differently is a pair the filter
+                // cannot line up.
+                min_gr: if cfg.extended_if_gr { ffi::EXTENDED_MIN_GR } else { ffi::NORMAL_MIN_GR },
                 antenna: if is_main { cfg.antenna.clone() } else { String::new() },
             }
         }),
@@ -373,16 +388,21 @@ fn run(
             ch.tuner_params.lo_mode = ffi::LO_AUTO;
             ch.tuner_params.rf_freq.rf_hz = center;
             ch.tuner_params.gain.g_rdb = if i == main {
-                cfg.if_gr_db.clamp(SdrPlayConfig::IF_GR_MIN, SdrPlayConfig::IF_GR_MAX)
+                cfg.if_gr_db.clamp(cfg.if_gr_min(), SdrPlayConfig::IF_GR_MAX)
             } else {
-                cfg.duo.if_gr_db.clamp(SdrPlayConfig::IF_GR_MIN, SdrPlayConfig::IF_GR_MAX)
+                cfg.duo.if_gr_db.clamp(cfg.if_gr_min(), SdrPlayConfig::IF_GR_MAX)
             };
             ch.tuner_params.gain.lna_state = live.t[i].lna_programmed;
-            ch.tuner_params.gain.min_gr = ffi::NORMAL_MIN_GR;
+            ch.tuner_params.gain.min_gr =
+                if cfg.extended_if_gr { ffi::EXTENDED_MIN_GR } else { ffi::NORMAL_MIN_GR };
             ch.ctrl_params.decimation.enable = (plan.decim > 1) as u8;
             ch.ctrl_params.decimation.decimation_factor = plan.decim;
             ch.ctrl_params.agc.enable = cfg.agc.code() as ffi::AgcControl;
-            ch.ctrl_params.agc.set_point_dbfs = cfg.agc_setpoint_dbfs.clamp(-72, -20);
+            // Clamped to what this *rate* allows, not to the widest range any
+            // rate allows: the API refuses a set point the converter cannot
+            // reach, and this backend offers 10 MSPS where the floor is -48.
+            let sp = cfg.agc_setpoint_range();
+            ch.ctrl_params.agc.set_point_dbfs = cfg.agc_setpoint_dbfs.clamp(*sp.start(), *sp.end());
             if model == SdrPlayModel::RspDuo {
                 ch.rsp_duo_tuner_params.rf_notch_enable = cfg.rf_notch as u8;
                 ch.rsp_duo_tuner_params.rf_dab_notch_enable = cfg.dab_notch as u8;
@@ -659,6 +679,10 @@ fn apply(
         dp.rsp_dx_params.hdr_enable = on as u8;
         ext1 |= ffi::UPDATE_RSPDX_HDR_ENABLE;
     }
+    // The HDR filter rides its own update reason, and belongs to the tuner
+    // block rather than the device one — so it is applied per tuner below,
+    // through `hdr_bw_pending`.
+    let hdr_bw_pending = p.hdr_bw.filter(|_| model.has_hdr());
 
     for t in tuners.live() {
         let ch = unsafe { &mut *tuners.ch[t].expect("live tuner has a block") };
@@ -671,10 +695,21 @@ fn apply(
             ch.tuner_params.rf_freq.rf_hz = lv.center_hz;
             reason |= ffi::UPDATE_TUNER_FRF;
         }
+        // The floor first: a reduction sent in the same pass must be clamped
+        // to the floor this pass installs, not to the one before it.
+        if let Some(on) = pt.extended_if_gr {
+            lv.min_gr = if on { ffi::EXTENDED_MIN_GR } else { ffi::NORMAL_MIN_GR };
+            ch.tuner_params.gain.min_gr = lv.min_gr;
+            // Its own reason: the limits move, not the value.
+            reason |= ffi::UPDATE_TUNER_GR_LIMITS;
+        }
         if let Some(gr) = pt.if_gr {
-            ch.tuner_params.gain.g_rdb =
-                gr.clamp(SdrPlayConfig::IF_GR_MIN, SdrPlayConfig::IF_GR_MAX);
+            ch.tuner_params.gain.g_rdb = gr.clamp(lv.min_gr, SdrPlayConfig::IF_GR_MAX);
             reason |= ffi::UPDATE_TUNER_GR;
+        }
+        if let Some(bw) = hdr_bw_pending {
+            ch.rsp_dx_tuner_params.hdr_bw = bw;
+            ext1 |= ffi::UPDATE_RSPDX_HDR_BW;
         }
         if let Some(lna) = pt.lna {
             lv.lna_wanted = lna.min(model.max_lna_state());
@@ -828,6 +863,66 @@ unsafe extern "C" fn stream_b_cb(
     unsafe { deliver(1, xi, xq, params, num_samples, reset, cb_context) }
 }
 
+/// Promote the gain the GainChange event announced to the gain the arriving
+/// samples were actually taken with.
+///
+/// The event and the samples are two streams that do not run together: the
+/// service announces a gain as it programs the tuner, while the blocks behind
+/// it in the USB pipe are still the old gain's. Adopting the announcement
+/// straight away puts a step in the S-meter the antenna never saw, for as long
+/// as the pipe takes to drain.
+///
+/// `grChanged` on a block is the service saying "from here on", and the AGC
+/// reference note tells anyone measuring the ADC to wait for it. It is right
+/// as far as it goes, and on this hardware it does not go far enough:
+/// **measured on an RSPdx against a −73 dBm carrier, the flag is set for
+/// host-commanded gain updates and never for the hardware AGC's own.** Fifteen
+/// seconds of a settling 50 Hz loop produced six GainChange events — 33.4 dB
+/// climbing to 51.4 — and one flagged block, so a reader that waited for the
+/// flag sat 18 dB stale and stayed there. That is the case this exists for:
+/// the AGC is on by default, and it moves the gain whether or not anybody
+/// touched a control.
+///
+/// So the flag is taken as one of two ways in. The other is age: an
+/// announcement that has stood unchanged for [`GAIN_SETTLE`] is adopted
+/// anyway, on the grounds that the pipe cannot still be holding samples from
+/// before it. What that costs is a wrong reading for the settle window on any
+/// step the service does flag late — and what it buys is a gain that tracks
+/// the loop at all. The two errors are not the same size: a commanded LNA step
+/// is tens of dB and gets the flag, while the AGC's own increments are a few dB
+/// and get the timeout.
+///
+/// # Safety
+///
+/// `params` is the service's, valid for the duration of the callback, and may
+/// be null.
+unsafe fn settle_gain(ctx: &CbCtx, tuner: usize, params: *mut ffi::StreamCbParamsT) {
+    let t = &ctx.shared.t[tuner];
+    let announced = t.ev_curr_gain_milli_db.load(Ordering::Relaxed);
+    if announced == i64::MIN {
+        return;
+    }
+    let live = t.rx_curr_gain_milli_db.load(Ordering::Relaxed);
+    if live == announced {
+        return;
+    }
+    // How long this announcement has stood. Restarted whenever a different one
+    // arrives, so a loop that is still hunting keeps resetting it and only the
+    // value it settles on ages into place.
+    let now_ms = ctx.epoch.elapsed().as_millis() as u64;
+    if t.pending_gain_milli_db.swap(announced, Ordering::Relaxed) != announced {
+        t.pending_gain_since_ms.store(now_ms, Ordering::Relaxed);
+    }
+    let flagged = !params.is_null() && unsafe { (*params).gr_changed } != 0;
+    let stood = now_ms.saturating_sub(t.pending_gain_since_ms.load(Ordering::Relaxed));
+    // The unset arm is the first reading rather than a change: a session that
+    // has not moved its gain yet would otherwise wait out the settle window
+    // before the meter said anything at all.
+    if flagged || live == i64::MIN || stood >= GAIN_SETTLE.as_millis() as u64 {
+        t.rx_curr_gain_milli_db.store(announced, Ordering::Relaxed);
+    }
+}
+
 /// One block of samples, from whichever tuner. Foreign thread — see the module
 /// doc; nothing here may unwind, and nothing here may touch the parameter
 /// block.
@@ -854,6 +949,11 @@ unsafe fn deliver(
         if reset != 0 {
             tracing::debug!("SDRplay stream reset (retune or rate change settled)");
         }
+        // Pair the announced system gain with the samples it was taken with,
+        // before anything below can return early: a tuner nobody is reading
+        // still has a gain, and a block of zero samples still carries the flag
+        // that says the new one has arrived.
+        unsafe { settle_gain(ctx, tuner, params) };
         let n = num_samples as usize;
         if n == 0 || xi.is_null() || xq.is_null() {
             return;

--- a/crates/sdroxide-types/src/caps.rs
+++ b/crates/sdroxide-types/src/caps.rs
@@ -6,7 +6,31 @@ pub enum Direction {
     Tx,
 }
 
+/// What the numbers on a gain element actually are, which is what decides how
+/// a control may label them.
+///
+/// Nearly every front end's stages are in decibels and this is not a question
+/// worth asking. An RSP's front end is the exception the type exists for: its
+/// RF gain is an *index into a table*, and which table depends on the band —
+/// step 7 is 24 dB of reduction at 0–12 MHz and 25 dB at 420–1000 MHz. A
+/// slider that appended "dB" to that index reported a number three times too
+/// small and in the wrong unit.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+pub enum GainUnit {
+    /// Decibels, and safe to label as such.
+    #[default]
+    Db,
+    /// A step index, whose dB value the hardware alone knows. Show the number
+    /// bare: an unlabelled index reads as an index, where one labelled dB is a
+    /// wrong measurement.
+    Step,
+}
+
 /// One adjustable gain stage exposed by the device.
+///
+/// The `*_db` names are historical: they are the range and the increment of
+/// whatever [`Self::unit`] says this element is counted in, decibels or
+/// otherwise. Renaming them would touch every backend for no gain.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct GainElement {
     pub name: String,
@@ -14,6 +38,47 @@ pub struct GainElement {
     pub min_db: f64,
     pub max_db: f64,
     pub step_db: f64,
+    /// Decibels unless the front end says otherwise — see [`GainUnit`].
+    pub unit: GainUnit,
+}
+
+impl GainElement {
+    /// A stage counted in decibels, which is all but one of them.
+    pub fn db(
+        name: impl Into<String>,
+        direction: Direction,
+        min: f64,
+        max: f64,
+        step: f64,
+    ) -> Self {
+        GainElement {
+            name: name.into(),
+            direction,
+            min_db: min,
+            max_db: max,
+            step_db: step,
+            unit: GainUnit::Db,
+        }
+    }
+
+    /// A stage counted in steps of a table the hardware owns.
+    pub fn steps(
+        name: impl Into<String>,
+        direction: Direction,
+        min: f64,
+        max: f64,
+        step: f64,
+    ) -> Self {
+        GainElement { unit: GainUnit::Step, ..GainElement::db(name, direction, min, max, step) }
+    }
+
+    /// The suffix a control should put after the number, if any.
+    pub fn suffix(&self) -> &'static str {
+        match self.unit {
+            GainUnit::Db => " dB",
+            GainUnit::Step => "",
+        }
+    }
 }
 
 /// What a driver setting holds, which is what decides the control drawn for it.
@@ -381,5 +446,28 @@ mod tests {
         assert!(!caps.may_tx_hz(145_000_000.0), "outside the transmit range and inside the RX one");
         // Edges are inclusive, both ends.
         assert!(caps.may_tx_hz(1_800_000.0) && caps.may_tx_hz(54_000_000.0));
+    }
+
+    /// The default matters more than it looks: every backend but one builds
+    /// its stages with [`GainElement::db`], and a stage that arrived without
+    /// an opinion must be labelled decibels rather than left bare.
+    #[test]
+    fn a_stage_is_decibels_unless_it_says_otherwise() {
+        assert_eq!(GainUnit::default(), GainUnit::Db);
+        let g = GainElement::db("LNA", Direction::Rx, 0.0, 40.0, 1.0);
+        assert_eq!(g.unit, GainUnit::Db);
+        assert_eq!(g.suffix(), " dB");
+    }
+
+    /// A step index carries no unit, because the one it would be given is
+    /// wrong: an RSP's state 7 is 24 dB at 0–12 MHz and 25 dB at 420 MHz, so
+    /// "7 dB" is neither the number nor the unit.
+    #[test]
+    fn a_step_index_is_never_labelled_decibels() {
+        let g = GainElement::steps("LNA", Direction::Rx, -18.0, 0.0, 1.0);
+        assert_eq!(g.unit, GainUnit::Step);
+        assert_eq!(g.suffix(), "");
+        // The range still describes the same element, just not in dB.
+        assert_eq!((g.min_db, g.max_db, g.step_db), (-18.0, 0.0, 1.0));
     }
 }

--- a/crates/sdroxide-types/src/lib.rs
+++ b/crates/sdroxide-types/src/lib.rs
@@ -103,7 +103,7 @@ pub use band_segments::{
 pub use bandplan::{BandPlan, BandPlanError, RegionPlan, band_plan, set_band_plan};
 pub use broadcast::{BroadcastStation, BroadcastStations};
 pub use callsign::{CallsignInfo, LoginTarget, LoginTestResult, UploadResult, UploadTarget};
-pub use caps::{DeviceCaps, DeviceSetting, Direction, GainElement, SettingKind};
+pub use caps::{DeviceCaps, DeviceSetting, Direction, GainElement, GainUnit, SettingKind};
 pub use chirp::{chirp_csv_to_memories, memories_to_chirp_csv};
 pub use command::Command;
 pub use contacts::FsqContact;
@@ -189,10 +189,11 @@ pub use radio::{
     PlutoConfig, PlutoDevice, PlutoDuplex, PlutoPtt, PttMethod, QMX_IQ_OFFSET_HZ, QMX_IQ_RATE_HZ,
     RadioConfig, RtlSdrAgc, RtlSdrConfig, RtlSdrDevice, RtlSdrHfMode, RtlTcpConfig, Rx888Config,
     Rx888Device, RxSite, SdrPlayAgc, SdrPlayConfig, SdrPlayDevice, SdrPlayDuo, SdrPlayDuoRole,
-    SdrPlayDuoTuner, SdrPlayModel, SerialConfig, SmartSdrConfig, SmartSdrDevice, SoapyConfig,
-    SoapyDeviceInfo, SoundFormat, SpyServerConfig, SpyServerFormat, StopBits, TciConfig,
-    Transverter, cat_iq_offset_max_hz, converter_preset_name, diversity_cost_note, elad_cat_baud,
-    format_freq_ranges, hackrf_serial_matches, hpsdr_alex_oc, hpsdr_n2adr_oc, parse_freq_ranges,
+    SdrPlayDuoTuner, SdrPlayHdrBw, SdrPlayModel, SerialConfig, SmartSdrConfig, SmartSdrDevice,
+    SoapyConfig, SoapyDeviceInfo, SoundFormat, SpyServerConfig, SpyServerFormat, StopBits,
+    TciConfig, Transverter, cat_iq_offset_max_hz, converter_preset_name, diversity_cost_note,
+    elad_cat_baud, format_freq_ranges, hackrf_serial_matches, hpsdr_alex_oc, hpsdr_n2adr_oc,
+    parse_freq_ranges,
 };
 pub use rds::{
     RdsClock, RdsData, RdsGroupLog, RdsStandard, RdsStats, RtPlus, af_code_hz, pi_callsign,

--- a/crates/sdroxide-types/src/radio.rs
+++ b/crates/sdroxide-types/src/radio.rs
@@ -5215,11 +5215,13 @@ impl SdrPlayModel {
         }
     }
 
-    /// Highest LNA state the model has in *any* band — the settings slider's
-    /// range. State 0 is maximum gain; each step up switches more attenuation
-    /// in front of the tuner. Some bands have fewer states than this; the
-    /// driver clamps per band and reports what it settled on, the same way the
-    /// RTL-SDR backend snaps its tuner gain.
+    /// Highest LNA state the model has in *any* band.
+    ///
+    /// A ceiling, not an offer: on an RSPdx it is 27, and only the 250–420 MHz
+    /// band has all of those — below 12 MHz there are 19. Use it where the
+    /// band is not known (a device that is not open yet); anywhere the dial is
+    /// known, [`Self::max_lna_state_on`] is the honest answer and is what the
+    /// sliders are built from.
     pub fn max_lna_state(self) -> u8 {
         match self {
             SdrPlayModel::Rsp1 => 3,
@@ -5229,6 +5231,102 @@ impl SdrPlayModel {
             SdrPlayModel::RspDx | SdrPlayModel::RspDxR2 => 27,
             // An unknown model still has the API-guaranteed minimum.
             SdrPlayModel::Unknown => 3,
+        }
+    }
+
+    /// Highest LNA state this model has **on this band**, which is the number
+    /// a control should offer.
+    ///
+    /// State 0 is maximum gain; each step up switches more attenuation in
+    /// front of the tuner. How many steps exist is a property of the band, not
+    /// of the box: the counts here are the API headers' `*_NUM_LNA_STATES_*`
+    /// defines, and the band edges are the rows of the gain tables in the API
+    /// specification (v3.15, pp. 38–39). A state past this is refused by the
+    /// service with `OutOfRange`, so the driver clamps to it — and a slider
+    /// built from [`Self::max_lna_state`] instead spends its top third moving
+    /// nothing and snapping back.
+    ///
+    /// `hiz` says the Hi-Z input is routed (RSP2 and RSPduo tuner 1 only),
+    /// which has fewer front-end states of its own. `hdr` is the RSPdx's
+    /// high-dynamic-range path, which has its own table below 2 MHz.
+    ///
+    /// Lives here rather than beside the driver so the settings UI — which is
+    /// wasm-safe and cannot link the backend — builds its slider from the same
+    /// table the clamp uses. Two copies of this drifting apart is exactly the
+    /// bug it prevents.
+    pub fn max_lna_state_on(self, freq_hz: f64, hiz: bool, hdr: bool) -> u8 {
+        let f = freq_hz;
+        match self {
+            SdrPlayModel::Rsp1 => {
+                if f >= 1_000e6 {
+                    2 // 3 states in L-band
+                } else {
+                    3 // 4 states everywhere else
+                }
+            }
+            SdrPlayModel::Rsp1a | SdrPlayModel::Rsp1b => {
+                if f < 60e6 {
+                    6 // RSPIA_NUM_LNA_STATES_AM = 7
+                } else if f >= 1_000e6 {
+                    8 // RSPIA_NUM_LNA_STATES_LBAND = 9
+                } else {
+                    9 // RSPIA_NUM_LNA_STATES = 10
+                }
+            }
+            SdrPlayModel::Rsp2 => {
+                if hiz {
+                    4 // RSPII_NUM_LNA_STATES_AMPORT = 5
+                } else if f >= 420e6 {
+                    5 // RSPII_NUM_LNA_STATES_420MHZ = 6
+                } else {
+                    8 // RSPII_NUM_LNA_STATES = 9
+                }
+            }
+            SdrPlayModel::RspDuo => {
+                if hiz {
+                    4 // RSPDUO_NUM_LNA_STATES_AMPORT = 5
+                } else if f < 60e6 {
+                    6 // RSPDUO_NUM_LNA_STATES_AM = 7
+                } else if f >= 1_000e6 {
+                    8 // RSPDUO_NUM_LNA_STATES_LBAND = 9
+                } else {
+                    9 // RSPDUO_NUM_LNA_STATES = 10
+                }
+            }
+            SdrPlayModel::RspDx | SdrPlayModel::RspDxR2 => {
+                if hdr && f < 2e6 {
+                    21 // RSPDX_NUM_LNA_STATES_DX = 22
+                } else if f < 12e6 {
+                    18 // RSPDX_NUM_LNA_STATES_AMPORT2_0_12 = 19
+                } else if f < 50e6 {
+                    19 // RSPDX_NUM_LNA_STATES_AMPORT2_12_50 = 20
+                } else if f < 60e6 {
+                    24 // RSPDX_NUM_LNA_STATES_AMPORT2_50_60 = 25
+                } else if f < 250e6 {
+                    26 // RSPDX_NUM_LNA_STATES_VHF_BAND3 = 27
+                } else if f < 420e6 {
+                    27 // RSPDX_NUM_LNA_STATES = 28
+                } else if f < 1_000e6 {
+                    20 // RSPDX_NUM_LNA_STATES_420MHZ = 21
+                } else {
+                    18 // RSPDX_NUM_LNA_STATES_LBAND = 19
+                }
+            }
+            // The API guarantees nothing about a model these bindings do not
+            // know; every RSP has at least the RSP1's four states.
+            SdrPlayModel::Unknown => 3,
+        }
+    }
+
+    /// Whether an antenna choice routes a Hi-Z input, for the LNA clamp.
+    ///
+    /// Beside the table above because it is an argument to it, and the UI
+    /// needs both for the same reason.
+    pub fn antenna_is_hiz(self, antenna: &str) -> bool {
+        match self {
+            SdrPlayModel::Rsp2 => antenna == "Hi-Z",
+            SdrPlayModel::RspDuo => antenna == "Hi-Z port",
+            _ => false,
         }
     }
 
@@ -5513,6 +5611,22 @@ pub struct SdrPlayConfig {
     pub duo_tuner: SdrPlayDuoTuner,
     /// RSPdx only: HDR mode below 2 MHz.
     pub hdr: bool,
+    /// RSPdx only: the HDR path's analog filter. Only meaningful with
+    /// [`Self::hdr`], and only at the centre frequencies that filter is
+    /// implemented at — see [`SdrPlayHdrBw::works_at`]. Appended last, like
+    /// every config field before it.
+    #[serde(default)]
+    pub hdr_bw: SdrPlayHdrBw,
+    /// Let the IF gain reduction go below 20 dB, down to 0 — the last 20 dB of
+    /// gain the hardware has.
+    ///
+    /// Off by default, which is the API's own default (`NORMAL_MIN_GR`) and
+    /// the right one for ordinary listening: the bottom of the range is where
+    /// an RSP is easiest to overload. Worth having on for weak-signal work
+    /// with the LNA already at 0, where the AGC note calls IF gain free to
+    /// use. Turning it on also lifts the AGC set-point ceiling to 0 dBFS.
+    #[serde(default)]
+    pub extended_if_gr: bool,
     /// RSPduo only: run the other tuner too — combined with this one, or as a
     /// radio of its own. Read from `radio.json` under either name: the block
     /// was called `diversity` when combining was all it could do.
@@ -5537,8 +5651,102 @@ impl Default for SdrPlayConfig {
             antenna: String::new(),
             duo_tuner: SdrPlayDuoTuner::Tuner1,
             hdr: false,
+            hdr_bw: SdrPlayHdrBw::default(),
+            extended_if_gr: false,
             duo: SdrPlayDuo::default(),
         }
+    }
+}
+
+/// The RSPdx's HDR-path analog filter, and the only frequencies each of its
+/// settings actually works at.
+///
+/// HDR is not a mode that follows the dial. The path has a fixed analog filter
+/// and the hardware only implements it centred on a short list of frequencies:
+/// tuned anywhere else the switch is accepted and does nothing useful, which
+/// reads as HDR being broken rather than as the dial being in the wrong place.
+/// The lists are from the API specification's RSPdx section.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+pub enum SdrPlayHdrBw {
+    Khz200,
+    Khz500,
+    Mhz1_2,
+    /// The API's own default, and what an RSPdx runs with when nobody sets one.
+    #[default]
+    Mhz1_7,
+}
+
+impl SdrPlayHdrBw {
+    pub const ALL: [SdrPlayHdrBw; 4] =
+        [SdrPlayHdrBw::Khz200, SdrPlayHdrBw::Khz500, SdrPlayHdrBw::Mhz1_2, SdrPlayHdrBw::Mhz1_7];
+
+    pub fn label(self) -> &'static str {
+        match self {
+            SdrPlayHdrBw::Khz200 => "200 kHz",
+            SdrPlayHdrBw::Khz500 => "500 kHz",
+            SdrPlayHdrBw::Mhz1_2 => "1.2 MHz",
+            SdrPlayHdrBw::Mhz1_7 => "1.7 MHz",
+        }
+    }
+
+    /// Back from a [`Self::code`] carried on the pseudo-element. Anything
+    /// unrecognised lands on the API's own default rather than on a filter the
+    /// operator did not pick.
+    pub fn from_code(v: f64) -> SdrPlayHdrBw {
+        match v.round() as i32 {
+            0 => SdrPlayHdrBw::Khz200,
+            1 => SdrPlayHdrBw::Khz500,
+            2 => SdrPlayHdrBw::Mhz1_2,
+            _ => SdrPlayHdrBw::Mhz1_7,
+        }
+    }
+
+    /// The API's `sdrplay_api_RspDx_HdrModeBwT` code.
+    pub fn code(self) -> i32 {
+        match self {
+            SdrPlayHdrBw::Khz200 => 0,
+            SdrPlayHdrBw::Khz500 => 1,
+            SdrPlayHdrBw::Mhz1_2 => 2,
+            SdrPlayHdrBw::Mhz1_7 => 3,
+        }
+    }
+
+    /// The centre frequencies, in Hz, this filter is actually implemented at.
+    ///
+    /// Two lists, not four: the narrow filters share the 500 kHz set and the
+    /// wide ones share the 2 MHz set.
+    pub fn centres_hz(self) -> &'static [f64] {
+        match self {
+            SdrPlayHdrBw::Khz200 | SdrPlayHdrBw::Khz500 => {
+                &[135_000.0, 175_000.0, 220_000.0, 250_000.0, 340_000.0, 475_000.0]
+            }
+            SdrPlayHdrBw::Mhz1_2 | SdrPlayHdrBw::Mhz1_7 => {
+                &[516_000.0, 875_000.0, 1_125_000.0, 1_900_000.0]
+            }
+        }
+    }
+
+    /// Whether HDR does anything at this centre. A hertz of slack either way,
+    /// because a dial arrives here through a converter offset and a ppm trim
+    /// and need not land on an exact integer.
+    pub fn works_at(self, centre_hz: f64) -> bool {
+        self.centres_hz().iter().any(|c| (c - centre_hz).abs() < 1.0)
+    }
+
+    /// The list an operator can be pointed at when their dial is not on one.
+    pub fn centres_label(self) -> String {
+        let parts: Vec<String> = self
+            .centres_hz()
+            .iter()
+            .map(|hz| {
+                if *hz < 1e6 {
+                    format!("{:.0} kHz", hz / 1e3)
+                } else {
+                    format!("{:.3} MHz", hz / 1e6)
+                }
+            })
+            .collect();
+        parts.join(", ")
     }
 }
 
@@ -5564,6 +5772,10 @@ impl SdrPlayConfig {
     pub const RF_NOTCH_ELEMENT: &'static str = "RFNOTCH";
     pub const DAB_NOTCH_ELEMENT: &'static str = "DABNOTCH";
     pub const HDR_ELEMENT: &'static str = "HDR";
+    /// The HDR path's analog filter, as a [`SdrPlayHdrBw::code`].
+    pub const HDR_BW_ELEMENT: &'static str = "HDRBW";
+    /// Whether the IF gain reduction may go below the API's 20 dB floor.
+    pub const EXTENDED_IF_GR_ELEMENT: &'static str = "EXTGR";
     /// The RSPduo's second tuner and the diversity filter, through the same
     /// door — the filter's names being the shared ones ([`DIV_MODE_ELEMENT`]
     /// and friends). The two gains are carried negated, like the main
@@ -5580,6 +5792,37 @@ impl SdrPlayConfig {
     /// `MAX_BB_GR`).
     pub const IF_GR_MIN: i32 = 20;
     pub const IF_GR_MAX: i32 = 59;
+    /// The floor with [`Self::extended_if_gr`] on (`EXTENDED_MIN_GR`).
+    pub const IF_GR_MIN_EXTENDED: i32 = 0;
+
+    /// The lowest IF gain reduction this configuration may ask for.
+    pub fn if_gr_min(&self) -> i32 {
+        if self.extended_if_gr { Self::IF_GR_MIN_EXTENDED } else { Self::IF_GR_MIN }
+    }
+
+    /// The AGC set-point range, in dBFS, that the API will accept at a given
+    /// sample rate.
+    ///
+    /// Not one range: the converter's headroom shrinks as it trades resolution
+    /// for speed, and the API refuses a set point below what the rate can
+    /// reach. The thresholds are the specification's — under 8.064 MSPS the
+    /// full −72 dB is available, to 9.216 it is −60, and above that −48. The
+    /// ceiling is −20 unless the extended gain floor is in use, which lifts it
+    /// to 0.
+    ///
+    /// This backend offers 10 MSPS, so the narrow end is reachable in normal
+    /// use rather than being a theoretical edge.
+    pub fn agc_setpoint_range(&self) -> std::ops::RangeInclusive<i32> {
+        let floor = if self.sample_rate_hz < 8_064_000.0 {
+            -72
+        } else if self.sample_rate_hz < 9_216_000.0 {
+            -60
+        } else {
+            -48
+        };
+        let ceiling = if self.extended_if_gr { 0 } else { -20 };
+        floor..=ceiling
+    }
 
     /// Sample rates offered in the UI. Below 2 Msps the ADC still runs at
     /// 2 Msps and the API decimates; above 6.048 Msps the ADC trades
@@ -7628,6 +7871,108 @@ mod tests {
         assert!(SdrPlayModel::Rsp1b.has_dab_notch());
         assert!(!SdrPlayModel::Rsp1b.has_hdr());
         assert!(SdrPlayModel::RspDx.has_hdr());
+    }
+
+    /// The RSPdx's ladder, band by band, against the gain tables in the API
+    /// specification (v3.15 p. 39). The model-wide ceiling is 27 and only
+    /// 250–420 MHz has all of it — everywhere else a slider built from the
+    /// ceiling offers states the service refuses.
+    #[test]
+    fn the_rspdx_ladder_follows_the_band() {
+        let dx = SdrPlayModel::RspDx;
+        let at = |hz: f64| dx.max_lna_state_on(hz, false, false);
+        assert_eq!(at(7.295e6), 18, "0-12 MHz has 19 states");
+        assert_eq!(at(14.1e6), 19, "12-50 MHz has 20");
+        assert_eq!(at(52e6), 24, "50-60 MHz has 25");
+        assert_eq!(at(145e6), 26, "60-250 MHz has 27");
+        assert_eq!(at(300e6), 27, "250-420 MHz is the only band with all 28");
+        assert_eq!(at(435e6), 20, "420-1000 MHz has 21");
+        assert_eq!(at(1296e6), 18, "L-band has 19");
+        // The HDR path has a table of its own, and only below 2 MHz.
+        assert_eq!(dx.max_lna_state_on(1e6, false, true), 21);
+        assert_eq!(dx.max_lna_state_on(3e6, false, true), 18, "HDR is a sub-2 MHz path");
+        // The ceiling is a ceiling: no band exceeds it, and one reaches it.
+        for mhz in [0.5, 7.0, 14.0, 52.0, 145.0, 300.0, 435.0, 1296.0] {
+            assert!(at(mhz * 1e6) <= dx.max_lna_state());
+        }
+    }
+
+    /// HDR is not a mode that follows the dial: each filter is built at a
+    /// fixed set of centres and does nothing elsewhere. The lists are from the
+    /// API specification's RSPdx section, and the two narrow filters share one
+    /// while the two wide ones share the other.
+    #[test]
+    fn the_hdr_path_only_works_at_its_own_centres() {
+        use SdrPlayHdrBw::*;
+        // 500 kHz set.
+        assert!(Khz500.works_at(135_000.0));
+        assert!(Khz500.works_at(475_000.0));
+        assert!(Khz200.works_at(220_000.0), "the narrow filters share a set");
+        // 2 MHz set.
+        assert!(Mhz1_7.works_at(516_000.0));
+        assert!(Mhz1_7.works_at(1_900_000.0));
+        assert!(Mhz1_2.works_at(875_000.0), "the wide filters share a set");
+        // The sets are not interchangeable.
+        assert!(!Khz500.works_at(516_000.0));
+        assert!(!Mhz1_7.works_at(135_000.0));
+        // And nothing else works at all — including the LF/MF frequencies an
+        // operator would most reasonably expect to.
+        for hz in [0.0, 153_000.0, 198_000.0, 600_000.0, 1_000_000.0, 1_395_000.0] {
+            assert!(!Mhz1_7.works_at(hz), "{hz} Hz is not an HDR centre");
+        }
+        // A hertz of slack, because a dial arrives through a ppm trim.
+        assert!(Mhz1_7.works_at(1_900_000.4));
+        assert!(!Mhz1_7.works_at(1_900_002.0));
+    }
+
+    /// The AGC set point's floor is a property of the sample rate: the
+    /// converter trades headroom for speed, and this backend offers rates on
+    /// both sides of each threshold.
+    #[test]
+    fn the_agc_set_point_range_follows_the_rate() {
+        let at = |hz: f64| {
+            let c = SdrPlayConfig { sample_rate_hz: hz, ..SdrPlayConfig::default() };
+            let r = c.agc_setpoint_range();
+            (*r.start(), *r.end())
+        };
+        assert_eq!(at(2_000_000.0), (-72, -20));
+        assert_eq!(at(8_000_000.0), (-72, -20), "8 Msps is still under the 8.064 threshold");
+        assert_eq!(at(8_064_000.0), (-60, -20));
+        assert_eq!(at(9_216_000.0), (-48, -20), "above 9.216 the floor is -48");
+        assert_eq!(at(10_000_000.0), (-48, -20), "a rate this backend actually offers");
+        // The extended gain floor lifts the ceiling to 0.
+        let ext = SdrPlayConfig {
+            sample_rate_hz: 2_000_000.0,
+            extended_if_gr: true,
+            ..SdrPlayConfig::default()
+        };
+        assert_eq!(*ext.agc_setpoint_range().end(), 0);
+    }
+
+    /// The IF gain floor is the API's 20 dB unless the operator opens the last
+    /// of the range.
+    #[test]
+    fn the_extended_range_opens_the_last_twenty_db() {
+        let normal = SdrPlayConfig::default();
+        assert_eq!(normal.if_gr_min(), SdrPlayConfig::IF_GR_MIN);
+        assert_eq!(normal.if_gr_min(), 20);
+        let ext = SdrPlayConfig { extended_if_gr: true, ..SdrPlayConfig::default() };
+        assert_eq!(ext.if_gr_min(), 0);
+    }
+
+    /// A Hi-Z input has fewer front-end states than the 50 Ω socket beside it,
+    /// and only two models have one at all.
+    #[test]
+    fn a_hi_z_port_has_its_own_ladder() {
+        let duo = SdrPlayModel::RspDuo;
+        assert!(duo.antenna_is_hiz("Hi-Z port"));
+        assert!(!duo.antenna_is_hiz("50 Ohm port"));
+        assert_eq!(duo.max_lna_state_on(7e6, true, false), 4);
+        assert_eq!(duo.max_lna_state_on(7e6, false, false), 6);
+        assert!(SdrPlayModel::Rsp2.antenna_is_hiz("Hi-Z"));
+        // Every other model routes no Hi-Z, whatever the port is called.
+        assert!(!SdrPlayModel::RspDx.antenna_is_hiz("Antenna C"));
+        assert!(!SdrPlayModel::Rsp1b.antenna_is_hiz("Hi-Z"));
         // Antenna lists: single-port models hide the selector entirely.
         assert!(SdrPlayModel::Rsp1b.antennas(SdrPlayDuoTuner::Tuner1).is_empty());
         assert_eq!(SdrPlayModel::Rsp2.antennas(SdrPlayDuoTuner::Tuner1).len(), 3);

--- a/crates/sdroxide-ui/src/app/settings/radio.rs
+++ b/crates/sdroxide-ui/src/app/settings/radio.rs
@@ -6131,7 +6131,7 @@ pub(in crate::app) fn settings_sdrplay_tab(
     can_probe: bool,
     cmds: &mut Vec<Command>,
 ) {
-    use sdroxide_types::{SdrPlayAgc, SdrPlayConfig, SdrPlayDuoTuner, SdrPlayModel};
+    use sdroxide_types::{SdrPlayAgc, SdrPlayConfig, SdrPlayDuoTuner, SdrPlayHdrBw, SdrPlayModel};
     let Some(cfg) = radio_edit.as_mut() else {
         ui.label("Waiting for the configuration of the machine the radio is attached to.");
         return;
@@ -6211,8 +6211,14 @@ pub(in crate::app) fn settings_sdrplay_tab(
     }
 
     // Same story as the ports: an RSPdx guessed to be an RSP1B would lose two
-    // thirds of its LNA range. The open device publishes the real one. Hoisted
-    // out of the grid because the second tuner's ladder is the same ladder.
+    // thirds of its LNA range. The open device publishes the real one — and
+    // publishes it *per band*, re-sent on every retune, so this follows the
+    // dial rather than offering a ladder the current band does not have.
+    // Hoisted out of the grid because the second tuner's ladder is the same
+    // ladder.
+    //
+    // The fallback is the model's widest, which is all that can be said about
+    // a receiver that is not open: there is no band yet to narrow it to.
     let max_lna = open
         .and_then(|c| c.gains.iter().find(|g| g.name == SdrPlayConfig::LNA_ELEMENT))
         .map(|g| (-g.min_db).round().clamp(0.0, 255.0) as u8)
@@ -6348,11 +6354,20 @@ pub(in crate::app) fn settings_sdrplay_tab(
         if cfg.sdrplay.agc != SdrPlayAgc::Off {
             ui.label("AGC set point").on_hover_text(
                 "Signal level the loop holds the ADC at. Lower leaves more \
-                 headroom for signals off-channel.",
+                 headroom for signals off-channel. How low it may go depends on \
+                 the sample rate — above 8.064 Msps the converter has less \
+                 headroom to give, and above 9.216 Msps less still.",
             );
+            // The range the *rate* allows, not the widest any rate allows: the
+            // converter trades headroom for speed, and the API refuses a set
+            // point below what the rate can reach. At 10 Msps the floor is
+            // -48, and this backend offers 10 Msps.
+            let sp = cfg.sdrplay.agc_setpoint_range();
+            let (sp_lo, sp_hi) = (*sp.start(), *sp.end());
+            cfg.sdrplay.agc_setpoint_dbfs = cfg.sdrplay.agc_setpoint_dbfs.clamp(sp_lo, sp_hi);
             if crate::chrome::slider(
                 ui,
-                Slider::new(&mut cfg.sdrplay.agc_setpoint_dbfs, -72..=-20).suffix(" dBFS"),
+                Slider::new(&mut cfg.sdrplay.agc_setpoint_dbfs, sp_lo..=sp_hi).suffix(" dBFS"),
             )
             .changed()
             {
@@ -6366,18 +6381,19 @@ pub(in crate::app) fn settings_sdrplay_tab(
         }
 
         ui.label("IF gain reduction").on_hover_text(
-            "The RSP's native gain unit: 20 dB is maximum gain, 59 dB minimum. \
+            "The RSP's native gain unit: 20 dB is maximum gain (0 with the extended \
+             range below), 59 dB minimum. \
              Applies immediately. Ignored while the AGC is running — the loop \
              owns this value then, and the S-meter shows what it settled on.",
         );
+        // Read before the borrow below: the floor is a property of the whole
+        // config, and the slider takes one field of it mutably.
+        let if_gr_min = cfg.sdrplay.if_gr_min();
         ui.add_enabled_ui(cfg.sdrplay.agc == SdrPlayAgc::Off, |ui| {
             if crate::chrome::slider(
                 ui,
-                Slider::new(
-                    &mut cfg.sdrplay.if_gr_db,
-                    SdrPlayConfig::IF_GR_MIN..=SdrPlayConfig::IF_GR_MAX,
-                )
-                .suffix(" dB"),
+                Slider::new(&mut cfg.sdrplay.if_gr_db, if_gr_min..=SdrPlayConfig::IF_GR_MAX)
+                    .suffix(" dB"),
             )
             .changed()
             {
@@ -6388,6 +6404,31 @@ pub(in crate::app) fn settings_sdrplay_tab(
                 });
             }
         });
+        ui.end_row();
+
+        ui.label("Extended IF range").on_hover_text(
+            "Lets the IF gain reduction go below 20 dB, down to 0 — the last 20 dB \
+             of gain the receiver has. Off is the API's own default and the right \
+             one for ordinary listening, because the bottom of the range is where \
+             an RSP is easiest to overload. Worth having on for weak signals with \
+             the LNA already at 0. It also lets the AGC set point go up to 0 dBFS. \
+             Applies immediately.",
+        );
+        {
+            let mut on = cfg.sdrplay.extended_if_gr;
+            if ui.checkbox(&mut on, "Allow IF gain reduction below 20 dB").changed() {
+                cfg.sdrplay.extended_if_gr = on;
+                // The floor moves under the value, so put it back in range
+                // before the slider above redraws with the new bound.
+                let min = cfg.sdrplay.if_gr_min();
+                cfg.sdrplay.if_gr_db = cfg.sdrplay.if_gr_db.max(min);
+                cmds.push(Command::SetGain {
+                    dir: Direction::Rx,
+                    element: SdrPlayConfig::EXTENDED_IF_GR_ELEMENT.to_string(),
+                    db: if on { 1.0 } else { 0.0 },
+                });
+            }
+        }
         ui.end_row();
 
         ui.label("LNA state").on_hover_text(
@@ -6532,8 +6573,10 @@ pub(in crate::app) fn settings_sdrplay_tab(
             if ui
                 .checkbox(&mut on, "Enable below 2 MHz")
                 .on_hover_text(
-                    "The RSPdx's high-dynamic-range path for LF/MF. Not yet \
-                     verified against hardware. Applies immediately.",
+                    "The RSPdx's high-dynamic-range path for LF/MF. It is not a mode \
+                     that follows the dial: the path has a fixed analog filter, built \
+                     only at the centres listed under the filter below. Tuned anywhere \
+                     else it does nothing. Applies immediately.",
                 )
                 .changed()
             {
@@ -6545,6 +6588,30 @@ pub(in crate::app) fn settings_sdrplay_tab(
                 });
             }
             ui.end_row();
+
+            // Only with the path switched on: the filter is a property of a
+            // mode that is otherwise off, and an control that does nothing is
+            // worse than one that is not there.
+            if cfg.sdrplay.hdr {
+                ui.label("HDR filter").on_hover_text(format!(
+                    "The analog filter in front of the HDR path — a different control \
+                     from the receiver's own bandwidth. Each setting is built at a \
+                     fixed set of centres and does nothing elsewhere; this one works \
+                     at {}. Applies immediately.",
+                    cfg.sdrplay.hdr_bw.centres_label(),
+                ));
+                let mut bw = cfg.sdrplay.hdr_bw;
+                enum_combo(ui, "sdrplay_hdr_bw", &mut bw, &SdrPlayHdrBw::ALL, SdrPlayHdrBw::label);
+                if bw != cfg.sdrplay.hdr_bw {
+                    cfg.sdrplay.hdr_bw = bw;
+                    cmds.push(Command::SetGain {
+                        dir: Direction::Rx,
+                        element: SdrPlayConfig::HDR_BW_ELEMENT.to_string(),
+                        db: f64::from(bw.code()),
+                    });
+                }
+                ui.end_row();
+            }
         }
 
         if model.has_bias_tee() {

--- a/crates/sdroxide-ui/src/app/top_bar.rs
+++ b/crates/sdroxide-ui/src/app/top_bar.rs
@@ -25,8 +25,8 @@ use eframe::egui::{self, Color32, ComboBox, DragValue, RichText, Slider};
 use sdroxide_types::{
     AgcMode, BURST_MS_RANGE, Band, Command, CwSkimmerDecoder, DCS_CODES, DIV_FREEZE_ELEMENT,
     DIV_MODE_ELEMENT, DIV_RATE_ELEMENT, DIV_RESET_ELEMENT, DeviceCaps, Direction, DiversityMode,
-    GainElement, MAX_OFFSET_HZ, Mode, NrEngine, NrLevel, NrStrength, RadioState, RxId, Shift,
-    SkimmerKind, SpectrumDetail, Speed, SubTone, ToneMode, Vfo,
+    GainElement, GainUnit, MAX_OFFSET_HZ, Mode, NrEngine, NrLevel, NrStrength, RadioState, RxId,
+    Shift, SkimmerKind, SpectrumDetail, Speed, SubTone, ToneMode, Vfo,
 };
 
 use crate::widgets::{freq_display, smeter};
@@ -2420,6 +2420,18 @@ impl SdroxideApp {
                              smears spurious signals across the band; too little and it goes deaf.",
                     g.name
                 );
+                // A stage counted in steps rather than decibels — an RSP's RF
+                // gain, where the number is an index into a table the hardware
+                // owns and its dB value depends on the band. Say so, because
+                // the bare number on the rail otherwise reads as decibels for
+                // want of anything saying it is not.
+                if g.unit == GainUnit::Step {
+                    hint.push_str(
+                        "\n\nCounted in steps, not decibels: 0 is maximum gain and each \
+                         step switches more attenuation in. How many dB a step is depends \
+                         on the band — Settings → Device has the exact figure.",
+                    );
+                }
                 if rx_gains.len() > 1 {
                     hint.push_str(&format!(
                         "\n\nThis rig has {} RX gain stages — the rest are in \
@@ -2447,7 +2459,12 @@ impl SdroxideApp {
                         }
                         crate::chrome::slider(
                             ui,
-                            Slider::new(&mut db, g.min_db..=g.max_db).step_by(step).suffix(" dB"),
+                            Slider::new(&mut db, g.min_db..=g.max_db)
+                                .step_by(step)
+                                // Whatever this element is actually counted in.
+                                // Labelling a step index "dB" reported a number
+                                // three times too small, in a unit it was not.
+                                .suffix(g.suffix()),
                         )
                     })
                     .inner

--- a/src/main.rs
+++ b/src/main.rs
@@ -1640,13 +1640,13 @@ fn hpsdr_caps(board: &str, sample_rate: f64, protocol: u8, has_lna: bool, ddc: u
     let hermes_lite = sdroxide_hpsdr::board_has_lna_gain(board);
     let nyquist = if hermes_lite { 38_400_000.0 } else { 61_440_000.0 };
     let gains = if has_lna {
-        vec![sdroxide_types::GainElement {
-            name: sdroxide_hpsdr::LNA_GAIN_ELEMENT.into(),
-            direction: sdroxide_types::Direction::Rx,
-            min_db: sdroxide_hpsdr::LNA_GAIN_MIN_DB,
-            max_db: sdroxide_hpsdr::LNA_GAIN_MAX_DB,
-            step_db: 1.0,
-        }]
+        vec![sdroxide_types::GainElement::db(
+            sdroxide_hpsdr::LNA_GAIN_ELEMENT,
+            sdroxide_types::Direction::Rx,
+            sdroxide_hpsdr::LNA_GAIN_MIN_DB,
+            sdroxide_hpsdr::LNA_GAIN_MAX_DB,
+            1.0,
+        )]
     } else {
         Vec::new()
     };
@@ -1722,35 +1722,25 @@ fn rx888_caps(src: &rx888_source::Rx888Source) -> DeviceCaps {
     use sdroxide_types::{Direction, GainElement, Rx888Config};
     let rate = src.sample_rate_hz();
     let mut gains = vec![
-        GainElement {
-            name: Rx888Config::VGA_ELEMENT.into(),
-            direction: Direction::Rx,
-            min_db: -6.0,
-            max_db: 34.0,
-            // The AD8370's vernier is linear in voltage, so the dB step
-            // varies; a request is snapped to the nearest code and reported
-            // back, which makes a fine slider honest enough.
-            step_db: 0.5,
-        },
-        GainElement {
-            name: Rx888Config::ATT_ELEMENT.into(),
-            direction: Direction::Rx,
-            min_db: -31.5,
-            max_db: 0.0,
-            step_db: 0.5,
-        },
+        // The AD8370's vernier is linear in voltage, so the dB step
+        // varies; a request is snapped to the nearest code and reported
+        // back, which makes a fine slider honest enough.
+        GainElement::db(Rx888Config::VGA_ELEMENT, Direction::Rx, -6.0, 34.0, 0.5),
+        GainElement::db(Rx888Config::ATT_ELEMENT, Direction::Rx, -31.5, 0.0, 0.5),
     ];
     // Only offer the tuner's gain on a receiver that has one, so the control
     // does not appear on a board where it would do nothing.
     if src.vhf_capable() {
-        gains.push(GainElement {
-            name: Rx888Config::TUNER_GAIN_ELEMENT.into(),
-            direction: Direction::Rx,
-            min_db: 0.0,
-            max_db: Rx888Config::TUNER_GAIN_MAX_DB,
+        gains.push(
             // 29 discrete steps, snapped and reported back like the two above.
-            step_db: 0.1,
-        });
+            GainElement::db(
+                Rx888Config::TUNER_GAIN_ELEMENT,
+                Direction::Rx,
+                0.0,
+                Rx888Config::TUNER_GAIN_MAX_DB,
+                0.1,
+            ),
+        );
     }
     DeviceCaps {
         driver: "rx888".into(),
@@ -1803,13 +1793,13 @@ fn airspyhf_caps(src: &airspyhf_source::AirspyHfSource) -> DeviceCaps {
         audio_mode: false,
         freq_ranges_rx: src.model().freq_ranges().to_vec(),
         sample_rates: src.available_rates().to_vec(),
-        gains: vec![GainElement {
-            name: AirspyHfConfig::ATT_ELEMENT.into(),
-            direction: Direction::Rx,
-            min_db: -att_max_db,
-            max_db: 0.0,
-            step_db: att_step_db,
-        }],
+        gains: vec![GainElement::db(
+            AirspyHfConfig::ATT_ELEMENT,
+            Direction::Rx,
+            -att_max_db,
+            0.0,
+            att_step_db,
+        )],
         ..DeviceCaps::default()
     }
 }
@@ -1874,13 +1864,13 @@ fn elad_caps(src: &elad_source::EladSource) -> DeviceCaps {
         // One real gain: the input pad, in or out. The pre-selection filter
         // switch is a pseudo-element and deliberately absent, so only this
         // backend's own settings tab draws it.
-        gains: vec![GainElement {
-            name: EladConfig::ATT_ELEMENT.into(),
-            direction: Direction::Rx,
-            min_db: -sdroxide_types::ELAD_ATTENUATOR_DB,
-            max_db: 0.0,
-            step_db: sdroxide_types::ELAD_ATTENUATOR_DB,
-        }],
+        gains: vec![GainElement::db(
+            EladConfig::ATT_ELEMENT,
+            Direction::Rx,
+            -sdroxide_types::ELAD_ATTENUATOR_DB,
+            0.0,
+            sdroxide_types::ELAD_ATTENUATOR_DB,
+        )],
         // The transceiver's two antenna sockets, on either control path — the
         // rig's `AN` command. Receive only, because that is all `AN` moves: it
         // chooses whether the receiver listens on the shared RTX socket or on
@@ -1934,13 +1924,13 @@ fn airspy_caps(src: &airspy_source::AirspySource) -> DeviceCaps {
         audio_mode: false,
         freq_ranges_rx: vec![AirspyConfig::FREQ_RANGE],
         sample_rates: src.available_rates().to_vec(),
-        gains: vec![GainElement {
-            name: AirspyConfig::GAIN_ELEMENT.into(),
-            direction: Direction::Rx,
-            min_db: 0.0,
-            max_db: (AirspyConfig::GAIN_STEPS - 1) as f64,
-            step_db: 1.0,
-        }],
+        gains: vec![GainElement::db(
+            AirspyConfig::GAIN_ELEMENT,
+            Direction::Rx,
+            0.0,
+            (AirspyConfig::GAIN_STEPS - 1) as f64,
+            1.0,
+        )],
         ..DeviceCaps::default()
     }
 }
@@ -1984,13 +1974,13 @@ fn hydrasdr_caps(src: &hydrasdr_source::HydraSdrSource) -> DeviceCaps {
         audio_mode: false,
         freq_ranges_rx: vec![HydraSdrConfig::FREQ_RANGE],
         sample_rates: src.available_rates().to_vec(),
-        gains: vec![GainElement {
-            name: HydraSdrConfig::GAIN_ELEMENT.into(),
-            direction: Direction::Rx,
-            min_db: 0.0,
-            max_db: (HydraSdrConfig::GAIN_STEPS - 1) as f64,
-            step_db: 1.0,
-        }],
+        gains: vec![GainElement::db(
+            HydraSdrConfig::GAIN_ELEMENT,
+            Direction::Rx,
+            0.0,
+            (HydraSdrConfig::GAIN_STEPS - 1) as f64,
+            1.0,
+        )],
         ..DeviceCaps::default()
     }
 }
@@ -2069,20 +2059,20 @@ fn fobos_caps(src: &fobos_source::FobosSource, port: FobosPort) -> DeviceCaps {
         sample_rates: rates,
         gains: if port == FobosPort::Rf {
             vec![
-                GainElement {
-                    name: FobosConfig::LNA_GAIN_ELEMENT.into(),
-                    direction: Direction::Rx,
-                    min_db: 0.0,
-                    max_db: f64::from(FobosConfig::LNA_GAIN_MAX),
-                    step_db: 1.0,
-                },
-                GainElement {
-                    name: FobosConfig::VGA_GAIN_ELEMENT.into(),
-                    direction: Direction::Rx,
-                    min_db: 0.0,
-                    max_db: f64::from(FobosConfig::VGA_GAIN_MAX),
-                    step_db: 1.0,
-                },
+                GainElement::db(
+                    FobosConfig::LNA_GAIN_ELEMENT,
+                    Direction::Rx,
+                    0.0,
+                    f64::from(FobosConfig::LNA_GAIN_MAX),
+                    1.0,
+                ),
+                GainElement::db(
+                    FobosConfig::VGA_GAIN_ELEMENT,
+                    Direction::Rx,
+                    0.0,
+                    f64::from(FobosConfig::VGA_GAIN_MAX),
+                    1.0,
+                ),
             ]
         } else {
             Vec::new()
@@ -2135,29 +2125,11 @@ fn hackrf_caps(src: &hackrf_source::HackRfSource) -> DeviceCaps {
     let range = src.freq_range();
     let tx = src.tx_enabled();
     let mut gains = vec![
-        GainElement {
-            name: HackRfConfig::LNA_ELEMENT.into(),
-            direction: Direction::Rx,
-            min_db: 0.0,
-            max_db: 40.0,
-            step_db: 8.0,
-        },
-        GainElement {
-            name: HackRfConfig::VGA_ELEMENT.into(),
-            direction: Direction::Rx,
-            min_db: 0.0,
-            max_db: 62.0,
-            step_db: 2.0,
-        },
+        GainElement::db(HackRfConfig::LNA_ELEMENT, Direction::Rx, 0.0, 40.0, 8.0),
+        GainElement::db(HackRfConfig::VGA_ELEMENT, Direction::Rx, 0.0, 62.0, 2.0),
     ];
     if tx {
-        gains.push(GainElement {
-            name: HackRfConfig::TXVGA_ELEMENT.into(),
-            direction: Direction::Tx,
-            min_db: 0.0,
-            max_db: 47.0,
-            step_db: 1.0,
-        });
+        gains.push(GainElement::db(HackRfConfig::TXVGA_ELEMENT, Direction::Tx, 0.0, 47.0, 1.0));
     }
     DeviceCaps {
         driver: "hackrf".into(),
@@ -2223,23 +2195,25 @@ fn open_lime_source(
 fn lime_caps(src: &lime_source::LimeSource) -> DeviceCaps {
     use sdroxide_types::{Direction, GainElement, LimeConfig};
     let tx = src.tx_enabled();
-    let mut gains = vec![GainElement {
-        name: LimeConfig::RX_GAIN_ELEMENT.into(),
-        direction: Direction::Rx,
-        min_db: LimeConfig::GAIN_MIN_DB,
-        max_db: LimeConfig::GAIN_MAX_DB,
+    let mut gains = vec![
         // LimeSuite takes an unsigned number of decibels; anything finer is
         // truncated by the library, so offering finer would be a fiction.
-        step_db: 1.0,
-    }];
+        GainElement::db(
+            LimeConfig::RX_GAIN_ELEMENT,
+            Direction::Rx,
+            LimeConfig::GAIN_MIN_DB,
+            LimeConfig::GAIN_MAX_DB,
+            1.0,
+        ),
+    ];
     if tx {
-        gains.push(GainElement {
-            name: LimeConfig::TX_GAIN_ELEMENT.into(),
-            direction: Direction::Tx,
-            min_db: LimeConfig::GAIN_MIN_DB,
-            max_db: LimeConfig::GAIN_MAX_DB,
-            step_db: 1.0,
-        });
+        gains.push(GainElement::db(
+            LimeConfig::TX_GAIN_ELEMENT,
+            Direction::Tx,
+            LimeConfig::GAIN_MIN_DB,
+            LimeConfig::GAIN_MAX_DB,
+            1.0,
+        ));
     }
     DeviceCaps {
         driver: "lime".into(),
@@ -2274,22 +2248,14 @@ fn open_sdrplay_source(
 /// Capabilities for an SDRplay RSP: wideband IQ, receive only, 1 kHz–2 GHz on
 /// every model.
 ///
-/// The two real gain elements are both *negated reductions* — `IF` is −(IF
-/// gain reduction), `LNA` is −(LNA state) — so the sliders read the usual way
-/// round: right is louder. The LNA range is the model's best band; bands with
-/// fewer states get clamped by the driver, which reports the state it kept.
-/// The switches (AGC, notches, bias tee, HDR) ride pseudo-elements that are
-/// deliberately not listed here, so only the SDRplay settings panel renders
-/// them.
-///
-/// The LNA is listed first — the first element is the main window's Gain
-/// slider, and the LNA is the only gain the operator always owns: with the
-/// hardware AGC on (the default) the service holds the IF gain, and a slider
-/// the AGC snaps back is worse than none. It is also the control that
-/// actually clears an overloaded front end, which the IF gain never can.
+/// The two real gain elements come from [`SdrPlaySource::rx_gain_elements`],
+/// which is also what the engine re-asks after a retune — the LNA ladder's
+/// length belongs to the band, so this is a snapshot rather than a fact, and
+/// one place has to own it. The switches (AGC, notches, bias tee, HDR) ride
+/// pseudo-elements that are deliberately not listed here, so only the SDRplay
+/// settings panel renders them.
 fn sdrplay_caps(src: &sdrplay_source::SdrPlaySource) -> DeviceCaps {
-    use sdroxide_types::{Direction, GainElement, SdrPlayConfig};
-    let model = src.model();
+    use sdroxide_types::SdrPlayConfig;
     DeviceCaps {
         driver: "sdrplay".into(),
         label: src.describe(),
@@ -2307,22 +2273,7 @@ fn sdrplay_caps(src: &sdrplay_source::SdrPlaySource) -> DeviceCaps {
         } else {
             SdrPlayConfig::SAMPLE_RATES.to_vec()
         },
-        gains: vec![
-            GainElement {
-                name: SdrPlayConfig::LNA_ELEMENT.into(),
-                direction: Direction::Rx,
-                min_db: -(model.max_lna_state() as f64),
-                max_db: 0.0,
-                step_db: 1.0,
-            },
-            GainElement {
-                name: SdrPlayConfig::IF_GAIN_ELEMENT.into(),
-                direction: Direction::Rx,
-                min_db: -(SdrPlayConfig::IF_GR_MAX as f64),
-                max_db: -(SdrPlayConfig::IF_GR_MIN as f64),
-                step_db: 1.0,
-            },
-        ],
+        gains: src.rx_gain_elements(),
         antennas_rx: src.antennas().to_vec(),
         // Two aerials arriving as one span: what puts the filter's controls on
         // the main strip rather than only in the settings dialog (issue #165).
@@ -2386,23 +2337,23 @@ fn pluto_caps(src: &pluto_source::PlutoSource, rx: u8) -> DeviceCaps {
     // The transmitter belongs to the chain-0 radio — the device has one DUC
     // path wired here.
     let tx_capable = rx == 0;
-    let mut gains = vec![GainElement {
-        name: PlutoConfig::RF_GAIN_ELEMENT.into(),
-        direction: Direction::Rx,
-        min_db: limits.rx_gain_db.0,
-        max_db: limits.rx_gain_db.1,
-        step_db: limits.rx_gain_db.2,
-    }];
+    let mut gains = vec![GainElement::db(
+        PlutoConfig::RF_GAIN_ELEMENT,
+        Direction::Rx,
+        limits.rx_gain_db.0,
+        limits.rx_gain_db.1,
+        limits.rx_gain_db.2,
+    )];
     if tx_capable {
         // Transmit "gain" is the AD9361's attenuator, so this range is
         // negative: 0 dB is full output.
-        gains.push(GainElement {
-            name: PlutoConfig::TX_GAIN_ELEMENT.into(),
-            direction: Direction::Tx,
-            min_db: limits.tx_gain_db.0,
-            max_db: limits.tx_gain_db.1,
-            step_db: limits.tx_gain_db.2,
-        });
+        gains.push(GainElement::db(
+            PlutoConfig::TX_GAIN_ELEMENT,
+            Direction::Tx,
+            limits.tx_gain_db.0,
+            limits.tx_gain_db.1,
+            limits.tx_gain_db.2,
+        ));
     }
     DeviceCaps {
         driver: "pluto".into(),
@@ -2473,15 +2424,17 @@ fn rtlsdr_caps(src: &rtlsdr_source::RtlSdrSource, driver: &str) -> DeviceCaps {
         audio_mode: false,
         freq_ranges_rx,
         sample_rates: sdroxide_types::RtlSdrConfig::SAMPLE_RATES.to_vec(),
-        gains: vec![sdroxide_types::GainElement {
-            name: sdroxide_types::RtlSdrConfig::TUNER_GAIN_ELEMENT.into(),
-            direction: sdroxide_types::Direction::Rx,
-            min_db: 0.0,
-            max_db: sdroxide_types::RtlSdrConfig::GAIN_MAX_DB,
+        gains: vec![
             // The hardware only has 29 discrete steps; a request is snapped to
             // the nearest and reported back, so a fine slider is honest enough.
-            step_db: 0.1,
-        }],
+            sdroxide_types::GainElement::db(
+                sdroxide_types::RtlSdrConfig::TUNER_GAIN_ELEMENT,
+                sdroxide_types::Direction::Rx,
+                0.0,
+                sdroxide_types::RtlSdrConfig::GAIN_MAX_DB,
+                0.1,
+            ),
+        ],
         ..DeviceCaps::default()
     }
 }
@@ -2537,18 +2490,20 @@ fn spyserver_caps(src: &spyserver_source::SpyServerSource, driver: &str) -> Devi
     let gains = if info.maximum_gain_index == 0 || !src.can_control() {
         Vec::new()
     } else {
-        vec![sdroxide_types::GainElement {
-            name: sdroxide_types::SpyServerConfig::GAIN_ELEMENT.into(),
-            direction: sdroxide_types::Direction::Rx,
+        vec![
             // An index into the far end's gain table, carried in a field named
             // for decibels because `GainElement` has no other — the same thing
             // the SDRplay backend's LNA state already does. What an index means
             // depends on the receiver and on the band, so no dB mapping is
             // invented; the settings tab says so instead.
-            min_db: 0.0,
-            max_db: f64::from(info.maximum_gain_index),
-            step_db: 1.0,
-        }]
+            sdroxide_types::GainElement::db(
+                sdroxide_types::SpyServerConfig::GAIN_ELEMENT,
+                sdroxide_types::Direction::Rx,
+                0.0,
+                f64::from(info.maximum_gain_index),
+                1.0,
+            ),
+        ]
     };
     DeviceCaps {
         driver: driver.into(),
@@ -2609,23 +2564,23 @@ fn kiwisdr_caps(src: &kiwisdr_source::KiwiSdrSource) -> DeviceCaps {
         freq_ranges_rx: vec![(lo, hi)],
         sample_rates: vec![src.sample_rate()],
         gains: vec![
-            sdroxide_types::GainElement {
-                name: sdroxide_types::KiwiConfig::AGC_ELEMENT.into(),
-                direction: sdroxide_types::Direction::Rx,
-                min_db: 0.0,
-                max_db: 1.0,
-                step_db: 1.0,
-            },
-            sdroxide_types::GainElement {
-                name: sdroxide_types::KiwiConfig::MAN_GAIN_ELEMENT.into(),
-                direction: sdroxide_types::Direction::Rx,
-                // The receiver's own scale, carried in a field named for
-                // decibels because `GainElement` has no other - the same thing
-                // the SpyServer's gain index and the SDRplay's LNA state do.
-                min_db: 0.0,
-                max_db: 90.0,
-                step_db: 1.0,
-            },
+            sdroxide_types::GainElement::db(
+                sdroxide_types::KiwiConfig::AGC_ELEMENT,
+                sdroxide_types::Direction::Rx,
+                0.0,
+                1.0,
+                1.0,
+            ),
+            // The receiver's own scale, carried in a field named for
+            // decibels because `GainElement` has no other - the same thing
+            // the SpyServer's gain index and the SDRplay's LNA state do.
+            sdroxide_types::GainElement::db(
+                sdroxide_types::KiwiConfig::MAN_GAIN_ELEMENT,
+                sdroxide_types::Direction::Rx,
+                0.0,
+                90.0,
+                1.0,
+            ),
         ],
         ..DeviceCaps::default()
     }

--- a/src/sdrplay_source.rs
+++ b/src/sdrplay_source.rs
@@ -21,7 +21,8 @@ use sdroxide_dsp::Diversity;
 use sdroxide_radio::{Complex32, IqSource, Result, lo_offset_for};
 use sdroxide_sdrplay::{DuoMode, SdrPlayDevice, SdrPlayHandle};
 use sdroxide_types::{
-    DiversityMode, SdrPlayAgc, SdrPlayConfig, SdrPlayDuo, SdrPlayDuoTuner, SdrPlayModel,
+    Direction, DiversityMode, GainElement, SdrPlayAgc, SdrPlayConfig, SdrPlayDuo, SdrPlayDuoTuner,
+    SdrPlayHdrBw, SdrPlayModel,
 };
 
 use crate::device_registry::{DeviceKey, SharedDevice, registry};
@@ -51,6 +52,14 @@ pub struct SdrPlaySource {
     if_gr_db: i32,
     agc: SdrPlayAgc,
     bias_tee: bool,
+    /// The RSPdx's high-dynamic-range path, tracked because it selects a
+    /// different LNA table below 2 MHz — see [`Self::rx_gain_elements`].
+    hdr: bool,
+    /// The HDR path's analog filter, tracked so the open-status note can say
+    /// which centres it is actually implemented at.
+    hdr_bw: SdrPlayHdrBw,
+    /// Whether the IF gain reduction may go below the API's 20 dB floor.
+    extended_if_gr: bool,
     antenna: String,
     /// The ports this model (and, on the RSPduo, this tuner) offers — what
     /// the capabilities advertise. Empty hides the selector.
@@ -106,9 +115,14 @@ impl SdrPlaySource {
         let diversity = dual.then(|| {
             Diversity::new(div_mode(cfg.duo.mode), usize::from(cfg.duo.taps), cfg.duo.rate)
         });
+        // The *effective* offset, not the computed one: HDR withdraws it (see
+        // `lo_offset_hz`), and a log line reporting the offset that would have
+        // applied is a log line that disagrees with the hardware.
+        let effective_offset = if cfg.hdr && handle.model().has_hdr() { 0.0 } else { lo_offset };
         tracing::info!(
             "SDRplay source ready: {label}, center {center_hz:.0} Hz, \
-             LO offset {lo_offset:.0} Hz (0 = LO on the VFO)"
+             LO offset {effective_offset:.0} Hz (0 = LO on the VFO){}",
+            if effective_offset == 0.0 && lo_offset != 0.0 { " — withdrawn for HDR" } else { "" }
         );
         if diversity.is_some() {
             tracing::info!(
@@ -134,6 +148,9 @@ impl SdrPlaySource {
             if_gr_db: cfg.if_gr_db,
             agc: cfg.agc,
             bias_tee: cfg.bias_tee,
+            hdr: cfg.hdr,
+            hdr_bw: cfg.hdr_bw,
+            extended_if_gr: cfg.extended_if_gr,
             antenna,
             antennas,
             div_cfg: cfg.duo.clone(),
@@ -166,6 +183,46 @@ impl SdrPlaySource {
     /// source being one of them.
     pub fn split_tuner(&self) -> bool {
         self.handle.split_tuner()
+    }
+
+    /// The two real gain stages, as they stand on the band this source is
+    /// tuned to.
+    ///
+    /// Both are carried *negated* — `IF` is −(gain reduction dB), `LNA` is
+    /// −(state) — so that on a slider more is louder, like every other
+    /// backend. The LNA is listed first because the first element is the main
+    /// window's Gain slider, and the LNA is the only gain the operator always
+    /// owns: with the hardware AGC on (the default) the service holds the IF
+    /// gain, and a slider the AGC snaps back is worse than none. It is also
+    /// the control that actually clears an overloaded front end, which the IF
+    /// gain never can.
+    ///
+    /// The LNA's range follows the *band*, not the model: an RSPdx has 28
+    /// states at 250–420 MHz and 19 below 12 MHz, and offering the longer
+    /// ladder on HF gives the operator a third of a slider that moves nothing
+    /// and snaps back as the driver clamps. It is also a `Step` element rather
+    /// than a dB one, because a state index is not a measurement: state 7 is
+    /// 24 dB of reduction here and 25 dB at 420 MHz, and a control that
+    /// appended "dB" to the 7 would be wrong by both the number and the unit.
+    pub fn rx_gain_elements(&self) -> Vec<GainElement> {
+        let hiz = self.model().antenna_is_hiz(&self.antenna);
+        let max_lna = self.model().max_lna_state_on(self.center, hiz, self.hdr);
+        vec![
+            GainElement::steps(
+                SdrPlayConfig::LNA_ELEMENT,
+                Direction::Rx,
+                -(f64::from(max_lna)),
+                0.0,
+                1.0,
+            ),
+            GainElement::db(
+                SdrPlayConfig::IF_GAIN_ELEMENT,
+                Direction::Rx,
+                -f64::from(SdrPlayConfig::IF_GR_MAX),
+                -f64::from(SdrPlayConfig::IF_GR_MIN),
+                1.0,
+            ),
+        ]
     }
 
     /// Push this radio's own settings at its tuner.
@@ -251,8 +308,20 @@ impl IqSource for SdrPlaySource {
         Ok(())
     }
 
+    /// Zero, on the HDR path.
+    ///
+    /// The offset exists to park the LO clear of the zero-IF DC spike, and the
+    /// engine tunes the hardware to `VFO + this`. HDR cannot pay that: its
+    /// analog filter is built at a fixed handful of centres, so an offset puts
+    /// the hardware beside every one of them — and for the highest, 1.9 MHz,
+    /// beside *and above* the 2 MHz ceiling the path has at all. Left in, HDR
+    /// is a switch that can never do anything.
+    ///
+    /// The same withdrawal the low-IF path gets a few lines up, for the
+    /// neighbouring reason: where the tuned frequency is not ours to choose,
+    /// the offset is not ours to add.
     fn lo_offset_hz(&self) -> f64 {
-        self.lo_offset
+        if self.hdr && self.model().has_hdr() { 0.0 } else { self.lo_offset }
     }
 
     /// One block from the receiver — and, with both tuners running, the second
@@ -315,7 +384,12 @@ impl IqSource for SdrPlaySource {
         match name {
             SdrPlayConfig::IF_GAIN_ELEMENT => {
                 let gr = (-db).round() as i32;
-                self.if_gr_db = gr.clamp(SdrPlayConfig::IF_GR_MIN, SdrPlayConfig::IF_GR_MAX);
+                let min = if self.extended_if_gr {
+                    SdrPlayConfig::IF_GR_MIN_EXTENDED
+                } else {
+                    SdrPlayConfig::IF_GR_MIN
+                };
+                self.if_gr_db = gr.clamp(min, SdrPlayConfig::IF_GR_MAX);
                 self.handle.set_if_gr_db(self.if_gr_db);
             }
             SdrPlayConfig::LNA_ELEMENT => {
@@ -343,7 +417,31 @@ impl IqSource for SdrPlaySource {
                 self.handle.set_dab_notch(db >= 0.5);
             }
             SdrPlayConfig::HDR_ELEMENT => {
-                self.handle.set_hdr(db >= 0.5);
+                self.hdr = db >= 0.5;
+                self.handle.set_hdr(self.hdr);
+                // Switching HDR moves the LO offset by half a megahertz (see
+                // `lo_offset_hz`). Nothing has to be done about that here: the
+                // engine compares its centre against `vfo + lo_offset_hz()` on
+                // every pass and retunes when they part company, so the dial
+                // stays where the operator left it and the hardware follows.
+            }
+            SdrPlayConfig::HDR_BW_ELEMENT => {
+                self.hdr_bw = SdrPlayHdrBw::from_code(db);
+                self.handle.set_hdr_bw(self.hdr_bw.code());
+            }
+            SdrPlayConfig::EXTENDED_IF_GR_ELEMENT => {
+                self.extended_if_gr = db >= 0.5;
+                self.handle.set_extended_if_gr(self.extended_if_gr);
+                // The floor just moved under a reduction that may be below it.
+                let min = if self.extended_if_gr {
+                    SdrPlayConfig::IF_GR_MIN_EXTENDED
+                } else {
+                    SdrPlayConfig::IF_GR_MIN
+                };
+                if self.if_gr_db < min {
+                    self.if_gr_db = min;
+                    self.handle.set_if_gr_db(min);
+                }
             }
             // The second tuner and its filter. Everything here is live: a null
             // is found by adjusting and listening, so a control that needed a
@@ -421,6 +519,36 @@ impl IqSource for SdrPlaySource {
         ]
     }
 
+    /// What the API says is between the antenna socket and the converter, so
+    /// the engine's dBFS measurement can be referred back to the aerial.
+    ///
+    /// Worth having on this backend more than on most: the RSP's own AGC is on
+    /// by default and owns the IF gain, so the gain here moves whether the
+    /// operator touches anything or not. Without this the S-meter would report
+    /// the loop working — a signal appearing would raise the reading, the AGC
+    /// would take the gain back down, and the reading would sink to where it
+    /// started while the signal was still there.
+    ///
+    /// `None` until the first block arrives carrying a settled gain, which is
+    /// the first block of the session: the engine then falls back to raw dBFS
+    /// for the fraction of a second before the receiver has delivered
+    /// anything, which is the same thing it shows for every other front end.
+    ///
+    /// The pair's second aerial is deliberately not in this: the two branches
+    /// are combined by an adaptive filter with a gain of its own, so no single
+    /// front-end figure describes what comes out. The main tuner's is the
+    /// honest half, and it is the one the operator's own controls move.
+    fn rx_gain_db(&self) -> Option<f32> {
+        self.handle.system_gain_db().map(|db| db as f32)
+    }
+
+    /// The LNA ladder as this band has it — see [`Self::rx_gain_elements`].
+    /// The engine asks after a retune, a port change and the HDR switch, which
+    /// are the three things that can change the answer.
+    fn learned_rx_gains(&self) -> Option<Vec<GainElement>> {
+        Some(self.rx_gain_elements())
+    }
+
     fn set_antenna(&mut self, name: &str) -> Result<()> {
         self.antenna = name.to_string();
         self.handle.set_antenna(name);
@@ -465,6 +593,19 @@ impl IqSource for SdrPlaySource {
                  enable AGC"
                     .to_string(),
             );
+        }
+        // HDR is not a mode that follows the dial: the path has a fixed analog
+        // filter, built only at a short list of centres. Tuned anywhere else
+        // the switch is accepted and does nothing, which reads as HDR being
+        // broken rather than as the dial being in the wrong place — so say
+        // where it does work rather than only that it does not.
+        if self.hdr && self.model().has_hdr() && !self.hdr_bw.works_at(self.center) {
+            notes.push(format!(
+                "HDR is on but does nothing at {:.3} MHz: the {} path is only built at {}.",
+                self.center / 1e6,
+                self.hdr_bw.label(),
+                self.hdr_bw.centres_label(),
+            ));
         }
         // A setting that quietly did nothing is worse than one that is
         // refused: only an RSPduo has a second tuner, and only the API's


### PR DESCRIPTION
Thanks for sdroxide — the SDRplay backend was already in good shape to build
on, and the comment style made it unusually easy to work out what was intended
where.

This is offered for review rather than as a finished proposal: it is one commit
because the pieces share a `PROTO_VERSION` bump, but I am happy to split it,
drop any part, or rework it however suits you.

## What this is

The SDRplay backend's gain handling, referred to the antenna — and, along the way, several things the vendor API offers that were never wired up.

All of it is measured against real hardware: an **RSPdx (serial 210307BB44)** with a **tinySA Ultra** injecting a known carrier, not against the specification alone.

## The headline: the S-meter was reading the AGC, not the band

An RSP's front end has two knobs and neither is in decibels, so nothing derived from the control settings is the whole gain. The API works it out and publishes it as `gainParams.currGain` — which this backend was already capturing and then never reading. The S-meter showed passband dBFS plus a fixed offset, so it followed the gain instead of the signal. With the hardware AGC on (the default) a signal appearing raised the reading, the loop pulled the gain down, and the reading sank back to where it started while the signal was still there.

`IqSource::rx_gain_db` is the new seam: a front end that knows what it put in front of the converter says so, and the engine subtracts it. Every other backend returns `None` and is bit-for-bit unaffected.

Pairing that gain with the samples it was taken with needed more than the AGC note's advice. **`grChanged` is set for host-commanded gain updates and never for the hardware AGC's own** — 15 s of a settling 50 Hz loop produced six GainChange events (33.4 dB climbing to 51.4) and one flagged block, so a reader that waited for the flag sat 18 dB stale indefinitely. The flag is now one of two ways in; an announcement that has stood 25 ms is adopted regardless.

**Measured against an injected carrier:** the meter holds within **0.35 dB across 27.8 dB of front-end gain change**, and reads the same with the AGC on as off. Those two disagreed by **20 dB** before. Reproduced at three drive levels spanning 26 dB (−76, −60 and −50 dBm at the antenna port), on the current `main`.

**How far this can be trusted.** The figures above are for LNA states 9 and up, and it is worth being precise about where they stop holding. Below about state 9 the API's own `currGain` and the actual signal path disagree — by up to 7.5 dB on a single step at 7.3 MHz, in both directions, with the worst of it either side of the LNA switch-out between states 6 and 7. That is reproducible at all three drive levels, so it is not compression: nothing was within 25 dB of clipping at the lowest one. Separately, moving the IF gain reduction across its range shifts the reading by about 4 dB (reported gain changes 20.00 dB where the carrier changes 15.91 dB between GR 40 and GR 20).

So: solid to well under a dB over the gain settings a real antenna actually uses at HF, and a few dB out at the extreme high-gain end. Both are inaccuracies in the gain figure the API reports rather than anything this code can correct — and the behaviour being replaced was wrong by the *entire* gain range everywhere, so it is still a large net improvement. Flagging it so nobody calibrates at LNA 0 and concludes the meter is broken.

`Settings::cal_offset_db` still does what it always did — it turns the referred reading into absolute dBm — and it is worth setting now that there is something stable to refer. It remains editable only in `config.toml`; a control for it would be a sensible follow-up, not part of this.

## Two gain controls that displayed the wrong quantity

- **The main window's Gain slider labelled the LNA "dB".** It is a step index into a band-dependent table — state 7 is 24 dB of reduction below 12 MHz and 25 dB at 420 MHz — so the number was wrong by roughly 3× and in the wrong unit. `GainElement` now carries a `GainUnit` and the slider asks it for the suffix.
- **Both LNA sliders offered the model's widest ladder on every band.** An RSPdx has 28 states at 250–420 MHz and 19 below 12 MHz, so a third of the travel moved nothing and snapped back as the driver clamped. Verified on the hardware: with the clamp lifted, states 19–27 at 875 kHz are refused with `sdrplay_api_OutOfRange` on Antenna A and C alike. The table moves to `SdrPlayModel::max_lna_state_on` so the wasm-safe settings UI and the native clamp share one copy, and ranges are re-published on retune, port change or the HDR switch.

## Three API controls that were not being set

- **`rspDxTunerParams.hdrBw`** was declared and never written, so HDR always ran the API's default filter. And the zero-IF LO offset parked the hardware half a megahertz off every fixed centre HDR is built at — above the 2 MHz ceiling entirely, for the highest — so the switch could never land anywhere useful. The offset is now withdrawn on the HDR path, and a dial that is not on a centre says so.
- **The AGC set point was clamped to −72…−20 whatever the rate.** The converter trades headroom for speed and the API refuses a set point it cannot reach: the floor is −60 above 8.064 Msps and −48 above 9.216, and this backend offers 10 Msps.
- **`gain.minGr` was pinned to `NORMAL_MIN_GR`**, so the last 20 dB of IF gain was unreachable. Now behind a switch, since the bottom of that range is where an RSP is easiest to overload. Measured: `currGain` reaches 57.34 dB at `gRdB` 5 against a previous floor of 42.34 at `gRdB` 20.

## An important caveat: HDR is not fixed here (still work in progress)

The two HDR bugs above are real and fixed, but **enabling HDR still silences the receiver**, so please do not merge this expecting HDR to start working. Against a −50 dBm carrier that reads 59 dB SNR with HDR off, with it on there is nothing — on Antenna A and C, with the selector deliberately mismatched, at all four filter settings, LNA states 0–8, levels −80 to −40 dBm, offsets of 5 and 40 kHz, enabled before `Init` and at runtime, at 2.0/1.0/0.5 Msps, zero-IF and 450 kHz IF, LO auto and all three fixed settings, and tuner bandwidths of 200/600/1536 kHz. With decimation running it delivers no samples at all rather than noise.

It is not a binding fault: the struct layouts match `sdrplay_api_rspDx.h`, and SoapySDRPlay3 sets `hdrEnable` and issues `Update_RspDx_HdrEnable` exactly as this does. Whatever the mode needs is not on the documented API surface. **SDRconnect offers HDR only as part of an LW or MW band preset and drops it when the sample rate changes** — that seems the thread worth pulling next and it is where I am looking now.

I have not given up on this — it is work in progress at my end rather than a
dead end I am handing over, and I will follow up if I get it working. If you or
anyone reading already knows what the mode actually needs, I would be glad of
the pointer and it would save me a good deal of bench time.

## Compatibility

This needs a wire-protocol bump: **`PROTO_VERSION` 122 → 124.** `GainElement` gained a unit and `SdrPlayConfig` gained `hdr_bw` and `extended_if_gr`. Old clients are rejected at `Hello`, so remote clients and servers must be updated together.

## Testing

- `cargo test --workspace` — 12 new tests (HDR centre pairing, the rate thresholds either side of each boundary, the extended floor, the band-aware ladder, and the antenna-referred meter).
- Bench-verified on an RSPdx against a tinySA Ultra, as above. Two harnesses are included under `crates/sdroxide-sdrplay/examples/`: `gain_probe.rs` (carrier-bin measurement, which is what makes a signal far below the receiver's wideband noise visible at all) and `hdr_probe.rs` (holds one session open and takes commands on stdin, so a script can step an external generator between readings).
- One pre-existing failure is untouched and unrelated: `auto_follows_the_band_plan_and_stays_simplex_outside_it` in `crates/sdroxide-radio/tests/repeater.rs`, which also fails on a clean `main`.

## LLM usage

Written with LLM assistance, in line with the project's guidelines. I have read
and reviewed the whole diff, it is tested against real hardware as described
above, and I can answer questions about any part of it.

## Happy to help elsewhere

I also have an **ELAD FDM-DUO** on the bench. If the ELAD backend ever needs
something measured, confirmed, or a change tried against real hardware, I am
glad to help — likewise for anything else on the RSPdx.

## Side note

`ffi.rs` also gains `sdrplay_api_IF_0_450` and the three fixed LO settings. Nothing uses them yet — the driver still pins a zero IF and an automatic LO — but they were absent from the bindings altogether, and the 450 kHz IF looks like a real gap for LF/MF.
