### PR TITLE
Add a QRG chip to the CW panel, so the readout shows the frequency being worked rather than the dial

### DIFF
--- a/crates/sdroxide-types/src/ui.rs
+++ b/crates/sdroxide-types/src/ui.rs
@@ -538,6 +538,25 @@ pub struct UiSettings {
     /// Decode-list filter: only stations that would put something new in the
     /// log (new entity, new band-slot, new grid, or a callsign never worked).
     pub decode_new_only: bool,
+    /// In CW, read the frequency of the *signal* rather than of the dial —
+    /// the QRG, in the Q-code an operator would use to ask for it.
+    ///
+    /// A CW dial sits a sidetone pitch below what is being copied, so the
+    /// number in the readout is not the number either operator would quote —
+    /// it is that number minus the pitch, and the arithmetic is left to the
+    /// person. With this on, the main readout shows what
+    /// [`crate::Mode::on_air_hz`] answers, and the tuning line on the
+    /// panadapter moves to sit on the signal, where the passband is already
+    /// centred (the engine keeps the filter on the pitch).
+    ///
+    /// A display preference, not a change of tuning: the dial is still the
+    /// dial, and everything that tunes, stores or checks a band edge goes on
+    /// using it. Off by default, which is what every other radio does.
+    ///
+    /// CW only for now. RTTY and WEFAX sit off their dials too
+    /// ([`crate::Mode::tunes_off_dial`]) and could join it, but each wants
+    /// checking against real signals first.
+    pub cw_qrg: bool,
 }
 
 /// Default for [`UiSettings::spot_colors`] — every kind on its stock tint.
@@ -596,6 +615,10 @@ where
 impl Default for UiSettings {
     fn default() -> Self {
         UiSettings {
+            // Off: the dial is what every other radio shows, and an operator
+            // who has not asked for the change should not find their readout
+            // reading differently from the rig beside it.
+            cw_qrg: false,
             frame_rate_fps: 60,
             waterfall_speed: Speed::Medium,
             spectrum_speed: Speed::Medium,

--- a/crates/sdroxide-ui/src/app/frame.rs
+++ b/crates/sdroxide-ui/src/app/frame.rs
@@ -597,6 +597,10 @@ impl eframe::App for SdroxideApp {
                         Some(spectrum_view::AudioCursor {
                             hz: audio_hz,
                             click_sets_offset: !mode.holds_standard_tones(),
+                            // CW only for now: RTTY and WEFAX sit off their
+                            // dials too and could follow, but each wants
+                            // checking against real signals first.
+                            line_on_cursor: false,
                         }),
                         if matches!(mode, Mode::Ft8 | Mode::Ft2) {
                             self.digi_status
@@ -769,9 +773,12 @@ impl eframe::App for SdroxideApp {
             };
             let width = ui.available_width();
             let cw_pitch = cw_mode.then(|| spectrum_view::AudioCursor {
-                hz: self.digi_status.as_ref().map_or(700.0, |s| s.audio_hz),
+                hz: self.cw_pitch_hz(),
                 // A click tunes the dial so the signal lands on the cursor.
                 click_sets_offset: false,
+                // With the readout reading the signal, the tuning line follows
+                // it there — see `UiSettings::cw_qrg`.
+                line_on_cursor: self.ui_settings.cw_qrg,
             });
             if show_wf {
                 ui.allocate_ui(egui::vec2(width, wf_h), |ui| {

--- a/crates/sdroxide-ui/src/app/mod.rs
+++ b/crates/sdroxide-ui/src/app/mod.rs
@@ -1817,6 +1817,18 @@ impl SdroxideApp {
     /// sidetone-pitch (700 Hz, usually) below the signal being copied and
     /// keyed; RTTY reads a tone pair — a couple of kilohertz — below its mark.
     /// See [`Mode::on_air_hz`](sdroxide_types::Mode::on_air_hz).
+    /// The CW tone being copied, in Hz — the cursor the CW panel moves and the
+    /// pitch the engine keeps the passband centred on.
+    ///
+    /// The controller's figure where there is one, because the operator moves
+    /// it by clicking the waterfall; the stored default only stands in before
+    /// the CW engine has reported. Same rule as the engine's own
+    /// `cw_pitch_hz`, and the two have to agree or the readout and the
+    /// passband would disagree about where the signal is.
+    pub(in crate::app) fn cw_pitch_hz(&self) -> f32 {
+        self.digi_status.as_ref().map_or(self.digi_cfg_edit.cw_pitch_hz, |s| s.audio_hz)
+    }
+
     pub(in crate::app) fn on_air_freq_hz(&self) -> f64 {
         let audio_hz = self.digi_status.as_ref().map_or(0.0, |s| s.audio_hz);
         self.state.rx[0].mode.on_air_hz(self.state.rx_freq_hz(), audio_hz)

--- a/crates/sdroxide-ui/src/app/panels/cw.rs
+++ b/crates/sdroxide-ui/src/app/panels/cw.rs
@@ -57,6 +57,36 @@ impl SdroxideApp {
                 cmds.push(Command::SetDigiAudioFreq((pitch + 10.0).clamp(200.0, 3000.0)));
             }
             crate::app::panels::on_air_readout(ui, on_air);
+
+            // Whether the *main* readout says that number too, instead of the
+            // dial a sidetone below it. Kept here rather than in the settings
+            // window because it belongs with the pitch it is derived from: the
+            // two are read together and adjusted together.
+            // QRG: the Q-code for "your frequency is", which is exactly the
+            // number this puts in the readout — and exactly the question a CW
+            // dial cannot answer on its own. Named for the thing rather than
+            // for the switch: an operator reads the label to find out what the
+            // number will mean, not to learn that something has been turned on.
+            let qrg = self.ui_settings.cw_qrg;
+            if crate::chrome::chip(ui, qrg, "QRG")
+                .on_hover_text(if qrg {
+                    "QRG: the main readout and the tuning line are on the frequency being \
+                     worked. Click for the dial instead, a sidetone pitch below it — what \
+                     most radios show."
+                } else {
+                    "Put the main readout and the tuning line on the signal rather than on \
+                     the dial, so the frequency shown is the one both operators would quote \
+                     and the tuning line sits in the middle of the passband. Tuning is \
+                     unchanged; only the numbers move.\n\nClicking a signal lands it on \
+                     the cursor only as closely as the click step allows — Controls → \
+                     click-to-tune rounding, 10 Hz by default. A coarse step leaves the \
+                     signal off the pitch by up to half of it, and the readout will say so."
+                })
+                .clicked()
+            {
+                self.ui_settings.cw_qrg = !qrg;
+                crate::app::persist::persist_ui_settings(&self.ui_settings);
+            }
             ui.add_space(8.0);
 
             // Copy state. A CW decoder that is not locked is not "quiet", it is

--- a/crates/sdroxide-ui/src/app/top_bar.rs
+++ b/crates/sdroxide-ui/src/app/top_bar.rs
@@ -1685,7 +1685,7 @@ impl SdroxideApp {
     /// alone: split has always left this readout on the dial, and this is not
     /// the place to change that.
     fn readout(&self) -> (f64, Option<Color32>, f64) {
-        readout_for(&self.state, self.tab_tx_on())
+        readout_for(&self.state, self.tab_tx_on(), self.ui_settings.cw_qrg, self.cw_pitch_hz())
     }
 
     /// The band/mode chip's label, e.g. `20m · USB`.
@@ -5274,11 +5274,27 @@ fn vfo_chip_labels(tx_capable: bool) -> Vec<&'static str> {
 
 /// [`SdroxideApp::readout`]'s arithmetic, over the state alone — so what the
 /// readout says on the air can be tested without an app around it.
-fn readout_for(state: &RadioState, tx_on: bool) -> (f64, Option<Color32>, f64) {
+fn readout_for(
+    state: &RadioState,
+    tx_on: bool,
+    cw_qrg: bool,
+    cw_pitch_hz: f32,
+) -> (f64, Option<Color32>, f64) {
     let dial = state.active_freq_hz();
+    // The transmit case first: while a repeater shift is putting RF somewhere
+    // else, where it is going matters more than anything below.
     if tx_on && state.repeater.shift != Shift::Simplex {
         let offset = state.tx_freq_hz() - dial;
         return (dial + offset, Some(crate::theme::ALERT()), offset);
+    }
+    // CW read as the signal rather than as the dial, when asked for. A CW dial
+    // sits a sidetone pitch below what is being copied, so this is the number
+    // both operators would quote — the same one `Mode::on_air_hz` answers and
+    // the CW panel already shows. The offset rides back with it, so a wheel
+    // turn or a typed frequency still moves the dial by what the operator
+    // changed rather than jumping it by the pitch.
+    if cw_qrg && state.rx[0].mode == Mode::Cw {
+        return (dial + f64::from(cw_pitch_hz), None, f64::from(cw_pitch_hz));
     }
     (dial, None, 0.0)
 }
@@ -6932,18 +6948,22 @@ mod tests {
 
         // Simplex: the dial, whether or not anything is keyed.
         for tx in [false, true] {
-            assert_eq!(readout_for(&state, tx), (145_712_500.0, None, 0.0), "simplex, tx={tx}");
+            assert_eq!(
+                readout_for(&state, tx, false, 700.0),
+                (145_712_500.0, None, 0.0),
+                "simplex, tx={tx}"
+            );
         }
 
         state.repeater.shift = Shift::Minus;
         state.repeater.offset_hz = 600_000;
         // Shifted but listening: still the output, because that is what is
         // being listened to.
-        assert_eq!(readout_for(&state, false), (145_712_500.0, None, 0.0));
+        assert_eq!(readout_for(&state, false, false, 700.0), (145_712_500.0, None, 0.0));
         // Keyed: the input, in the alert red, and the offset comes back so a
         // turn of the dial on those digits still moves the VFO by what was
         // turned rather than jumping it by the shift.
-        let (shown, ink, offset) = readout_for(&state, true);
+        let (shown, ink, offset) = readout_for(&state, true, false, 700.0);
         assert_eq!(shown, 145_112_500.0);
         assert_eq!(offset, -600_000.0);
         assert_eq!(ink, Some(crate::theme::ALERT()));
@@ -6952,7 +6972,58 @@ mod tests {
         // A shift stacked on XIT reads as the frequency that actually goes
         // out, not as the repeater's share of it.
         state.xit = sdroxide_types::OffsetState { enabled: true, hz: 250 };
-        assert_eq!(readout_for(&state, true).0, 145_112_750.0);
+        assert_eq!(readout_for(&state, true, false, 700.0).0, 145_112_750.0);
+    }
+
+    /// A CW dial sits a sidetone pitch below the signal, so an operator reading
+    /// the dial is doing arithmetic to get the number they would put in the log
+    /// or quote on the air. Asked for it, the readout does the arithmetic —
+    /// and hands back the offset, so tuning those digits still moves the dial
+    /// by what was turned rather than jumping it by the pitch.
+    #[test]
+    fn cw_can_read_the_signal_rather_than_the_dial() {
+        let mut state = RadioState::default();
+        state.vfo_a_hz = 14_050_000.0;
+        state.vfo_b_hz = 14_050_000.0;
+        state.rx[0].mode = Mode::Cw;
+
+        // Off: the dial, as every other radio shows it.
+        assert_eq!(readout_for(&state, false, false, 700.0), (14_050_000.0, None, 0.0));
+
+        // On: the signal, which is the pitch above it.
+        let (shown, ink, offset) = readout_for(&state, true, true, 700.0);
+        assert_eq!(shown, 14_050_700.0);
+        assert_eq!(offset, 700.0);
+        assert_eq!(ink, None, "reading the signal is not an alert condition");
+        assert_eq!(shown - offset, state.active_freq_hz(), "an edit maps back to the dial");
+
+        // It follows the pitch the operator is actually copying at, not a
+        // fixed 700 — the CW panel moves that with its ± buttons and with a
+        // click on the waterfall.
+        assert_eq!(readout_for(&state, false, true, 450.0).0, 14_050_450.0);
+
+        // And it agrees with what the CW panel and the log already show.
+        assert_eq!(shown, Mode::Cw.on_air_hz(state.active_freq_hz(), 700.0));
+
+        // Only CW: the setting says nothing about any other mode.
+        state.rx[0].mode = Mode::Usb;
+        assert_eq!(readout_for(&state, false, true, 700.0), (14_050_000.0, None, 0.0));
+    }
+
+    /// The transmitter wins. A repeater shift has RF going somewhere else and
+    /// that matters more than which end of the sidetone is being read.
+    #[test]
+    fn a_repeater_shift_outranks_the_cw_readout() {
+        let mut state = RadioState::default();
+        state.vfo_a_hz = 145_712_500.0;
+        state.vfo_b_hz = 145_712_500.0;
+        state.rx[0].mode = Mode::Cw;
+        state.repeater.shift = Shift::Minus;
+        state.repeater.offset_hz = 600_000;
+
+        let (shown, ink, _) = readout_for(&state, true, true, 700.0);
+        assert_eq!(shown, 145_112_500.0, "the transmit frequency, not the dial plus a pitch");
+        assert_eq!(ink, Some(crate::theme::ALERT()));
     }
 
     /// Open the band/mode menu on a `screen`-sized viewport and measure the

--- a/crates/sdroxide-ui/src/widgets/spectrum_view.rs
+++ b/crates/sdroxide-ui/src/widgets/spectrum_view.rs
@@ -1092,6 +1092,18 @@ pub struct AudioCursor {
     /// the pitch being listened at, and clicking a signal means "put that one
     /// here", not "move my pitch to the far side of the passband".
     pub click_sets_offset: bool,
+    /// Draw the receiver's tuning line on the cursor rather than on the dial.
+    ///
+    /// The dial in CW sits a sidetone pitch below the signal, so the tuning
+    /// line lands at the *edge* of a passband the engine has already centred
+    /// on the pitch — the line, the shading and the signal all disagree about
+    /// where the receiver is pointed. With this set the line moves onto the
+    /// cursor, where the passband is already centred and the signal already
+    /// is, and the three finally say the same thing.
+    ///
+    /// Display only: the dial is unchanged and everything that tunes, stores
+    /// or checks a band edge still uses it.
+    pub line_on_cursor: bool,
 }
 
 /// The panadapter: spectrum trace, frequency scale and waterfall, with the
@@ -2141,8 +2153,11 @@ pub fn show_ext(
         }
     }
 
-    if in_view(vfo_hz) {
-        let x = view.freq_to_x(vfo_hz, &rect);
+    // Where the receiver is actually pointed, which in CW read as the signal
+    // is a sidetone pitch up from the dial — see [`AudioCursor::line_on_cursor`].
+    let line_hz = vfo_hz + cursor.filter(|c| c.line_on_cursor).map_or(0.0, |c| f64::from(c.hz));
+    if in_view(line_hz) {
+        let x = view.freq_to_x(line_hz, &rect);
         painter.vline(x, spec_marks.y_range(), Stroke::new(1.0, Color32::from_rgb(255, 60, 60)));
         painter.vline(
             x,


### PR DESCRIPTION
A CW dial sits a sidetone pitch below what is being copied — 700 Hz, usually — so the big readout has never been the frequency of the contact. It is that frequency minus the pitch, and the subtraction is left to the operator, every time, on a number they are about to put in the log or say on the air.

This adds a **QRG** chip to the CW panel that puts the main readout and the tuning line on the signal instead.

## Relation to #301 — partial

refs #301. That report describes this exactly: in CW the carrier sits *below* the highlighted passband, so the dial reads about 700 Hz low against a TS-590 on the same signal, where in LSB the two agree. With the chip on, the readout shows the carrier and the tuning line moves into the middle of the passband, which is what the screenshots there are asking for and what GQRX is shown doing.

**It does not close the issue**, for two reasons worth stating plainly:

- The dial itself is unchanged. This moves what is *displayed*, not where the receiver is tuned, so the answer to "can the dial frequency be equal to the carrier frequency in CW" is still no — the offset is now shown rather than removed.
- Because of that, **Hamlib is unaffected**: `rigctld` reports `RigState::vfo_a_hz`, the raw dial, so synchronising sdroxide with another radio over rigctld will still be a sidetone out. That is specifically what the reporter wants it for, so this PR does not solve their problem end to end.

Making the dial itself the carrier is a larger change — it moves the demodulator's cursor, memories, band-edge checks and what rigctld publishes, all of which currently agree that the dial is the dial. Worth doing, probably, but it is a different PR and wants its own discussion.

## Most of it was already there

I expected this to need more than it did. `Mode::on_air_hz` has always answered the real frequency, the CW panel has always displayed it, and `Engine::sync_cw_filter` has always kept the passband centred on the pitch. What was left on the dial was the **main readout** and the **tuning line** — so the red line sat at the *edge* of its own passband, and the two frequencies on screen disagreed by a sidetone.

So the change is small and entirely in the presentation layer:

- **The readout** goes through the offset `readout_for` already returns for a repeater shift. That is what keeps it tunable: a wheel turn or a typed frequency still moves the dial by what the operator changed rather than jumping it by the pitch. A keyed repeater shift still outranks it — where RF is actually going matters more — and there is a test for that precedence.
- **The tuning line** rides a new flag on the `AudioCursor` the panadapter already draws at the pitch, so it lands where the passband is already centred. Line, shading and signal finally agree.

## Why "QRG"

The Q-code for "your frequency is" — which is exactly the question a CW dial cannot answer on its own, and exactly the number this puts in the readout. It names the thing rather than the switch: an operator reads a label to find out what the number will mean, not to learn that a mode has been turned on. The doc comments spell the code out for anyone who does not use it.

## Scope

Display only. The dial is unchanged and everything that tunes, stores or checks a band edge goes on using it. Off by default, which is what every other radio does, and persisted per screen in `UiSettings` rather than on the wire — this is a preference about reading, not about the radio, so **no `PROTO_VERSION` bump**.

**CW alone for now.** RTTY and WEFAX sit off their dials too (`Mode::tunes_off_dial` already covers them) and the same treatment would suit them, but each wants checking against real signals first — WEFAX's offset is large enough that the tuning line would move visibly.

## Also

Removes a third copy of the hardcoded 700 Hz pitch fallback. The readout asks a new `cw_pitch_hz()` helper that follows the controller's live cursor exactly as the engine's own does, so the readout and the passband cannot disagree about where the signal is.

## Testing

- Three new tests: the readout follows the *live* pitch rather than a fixed 700, agrees with `Mode::on_air_hz`, is inert outside CW, and loses to a repeater shift when keyed.
- `cargo test --workspace` green apart from `sdroxide-radio --test repeater`, which fails on a clean `main` too and is untouched here.
- Exercised in **both** clients, not just compiled for them: the native GUI, and the browser client served by `sdroxide --server` from an `embed-web` build. The chip behaves the same in each, which is the part worth checking on a UI crate that targets wasm as well as the desktop.
- **Checked against a signal generator on an RSPdx**: a carrier of known frequency tuned in CW reads that frequency in the main readout with the chip on, and the tuning line sits in the middle of the passband rather than at its edge.

One interaction worth knowing, and called out in the chip's hover text: click-to-tune rounds the clicked frequency to `click_tune_step_hz` (10 Hz by default) *before* the pitch is subtracted, so a coarse step leaves the signal off the cursor by up to half of it. That was always true; QRG just makes it visible, because the readout is now claiming a precise number.

## LLM usage

Written with LLM assistance, in line with the project's guidelines. I have read and reviewed the whole diff, it is tested against real hardware as described above, and I can answer questions about any part of it.
