### PR TITLE
SpyServer: follow the dial with the FFT window instead of the server's start-up frequency

### DIFF
--- a/crates/sdroxide-spyserver/src/net.rs
+++ b/crates/sdroxide-spyserver/src/net.rs
@@ -538,7 +538,7 @@ impl Client {
     /// whatever the operator pinned it to.
     fn digital_gain_wire(&self) -> u32 {
         let db = if self.auto_digital_gain {
-            self.info.digital_gain_db(self.gain_index, self.iq_stage)
+            self.info.digital_gain_db(self.gain_index, self.iq_stage, self.iq_format)
         } else {
             self.digital_gain_db
         };

--- a/crates/sdroxide-spyserver/src/net.rs
+++ b/crates/sdroxide-spyserver/src/net.rs
@@ -487,10 +487,13 @@ impl Client {
 
         self.set(proto::SETTING_IQ_FORMAT, proto::format_wire(self.iq_format))?;
         self.set(proto::SETTING_IQ_DECIMATION, self.iq_stage)?;
-        self.set(proto::SETTING_IQ_FREQUENCY, proto::freq_wire(self.center))?;
+        // The FFT window before the I/Q position, because the receiver follows
+        // the window and `IQ_FREQUENCY` is only a place inside the band the
+        // receiver is on — see [`flush_retune`].
         if self.fft_enabled {
             self.send_fft_config()?;
         }
+        self.set(proto::SETTING_IQ_FREQUENCY, proto::freq_wire(self.center))?;
         self.start_stream()
     }
 
@@ -584,8 +587,22 @@ impl Client {
         want.clamp(lo, hi.max(lo))
     }
 
-    /// The FFT window centred as near `hz` as its own slack allows.
+    /// Where the FFT window should be centred for the dial to be on `hz`.
+    ///
+    /// Where this client controls the receiver that is `hz` itself: with the
+    /// FFT lane running the receiver follows this window, so the window goes
+    /// where the dial goes. Clamping it into the slack around wherever the
+    /// server happened to be sitting is what parked whole sessions on the
+    /// server's own start-up frequency — at decimation stage 0 the window
+    /// covers the entire receiver and has no slack at all, so the clamp
+    /// collapsed to exactly that frequency and never let go.
+    ///
+    /// Where another client owns the receiver the device is theirs and does not
+    /// move, and all this end may do is slide the window inside it.
     fn clamped_fft_center(&self, hz: f64) -> f64 {
+        if self.can_control {
+            return hz;
+        }
         let slack = self.info.fft_slack_hz(self.fft_span);
         hz.clamp(self.device_center - slack, self.device_center + slack)
     }
@@ -598,7 +615,14 @@ impl Client {
         if !self.fft_enabled {
             return None;
         }
-        self.info.fft_recenter(self.center, self.fft_center, self.fft_span, self.device_center)
+        self.info.fft_recenter(
+            self.center,
+            self.fft_center,
+            self.fft_span,
+            self.device_center,
+            self.can_control,
+            self.info.iq_slack_hz(self.iq_rate),
+        )
     }
 
     /// Note an I/Q message's sequence number, reporting messages the server
@@ -734,7 +758,13 @@ fn apply(client: &mut Client, p: &Pending) -> Result<()> {
         // that changes what the server sends is worth.
         client.set(proto::SETTING_STREAMING_ENABLED, 0)?;
         if on {
+            // Where the window is *now*, not where it was left when the lane
+            // was last on: nothing has been maintaining it while it was off, so
+            // sending the stale centre would drag the receiver back to whatever
+            // band the operator was in then.
+            client.fft_center = client.clamped_fft_center(client.center);
             client.send_fft_config()?;
+            client.set(proto::SETTING_IQ_FREQUENCY, proto::freq_wire(client.center))?;
         }
         client.start_stream()?;
     }
@@ -772,20 +802,38 @@ fn flush_retune(client: &mut Client, shared: &Arc<Shared>) -> Result<()> {
     let sent = client.reachable_center(want);
     client.center = sent;
     shared.iq_center_milli_hz.store((sent * 1000.0) as i64, Ordering::Relaxed);
+
+    // The window moves first, and that ordering is load-bearing. On a server
+    // this client controls, the receiver follows the FFT window; `IQ_FREQUENCY`
+    // only places the I/Q window inside the band the receiver is already on, and
+    // a position outside it is clamped — and *stays* clamped, because the server
+    // holds it as an absolute frequency rather than as an offset. Placing the
+    // I/Q window before the receiver has moved therefore leaves it on the band
+    // being left behind.
+    move_fft_window(client)?;
     client.set(proto::SETTING_IQ_FREQUENCY, proto::freq_wire(sent))
 }
 
 /// Move the FFT window if the dial has reached its edge, or if the device
 /// moved out from under it.
 ///
-/// Runs every pass rather than only after a retune: on a server this client
-/// controls, tuning moves the *device* centre too, and the window's slack is
-/// measured against that — so a window that was in the middle of its range can
-/// find itself pinned to an edge without the dial having moved again.
+/// Runs every pass rather than only after a retune: on a shared server the
+/// owner can move the receiver with no dial move here at all, and the window's
+/// slack is measured against where they put it.
 fn maintain_fft(client: &mut Client) -> Result<()> {
     if client.last_fft_retune.elapsed() < RETUNE_MIN_INTERVAL {
         return Ok(());
     }
+    move_fft_window(client)
+}
+
+/// The move itself, without the rate limit.
+///
+/// [`flush_retune`] calls this directly: it has already paid the interval for
+/// the retune it is in the middle of, and on a server this client controls the
+/// window *is* the retune — a window held back by its own limiter would be a
+/// receiver held back with it.
+fn move_fft_window(client: &mut Client) -> Result<()> {
     let Some(target) = client.fft_target_center() else {
         return Ok(());
     };
@@ -1041,5 +1089,196 @@ mod tests {
         let h = header(proto::MSG_PONG, 0, 0);
         f.feed(&h[..5], &mut |_, _| panic!("not a whole header yet")).expect("partial");
         f.feed(&[], &mut |_, _| panic!("still nothing")).expect("empty");
+    }
+
+    // --- against a fake server -----------------------------------------------
+
+    /// The `(setting, value)` pairs a fake server has been sent, in order.
+    type SettingLog = std::sync::Arc<std::sync::Mutex<Vec<(u32, u32)>>>;
+
+    /// A fake SpyServer that records every setting a client sends it.
+    ///
+    /// Shaped like the one this was found on: an Airspy HF+ whose analog
+    /// bandwidth is its whole FFT stage-0 span — so the FFT window has no slack
+    /// of its own — sitting on `device_center_hz`, and which never restates its
+    /// `CLIENT_SYNC`. That last part is why nothing self-corrects: the client
+    /// only ever hears where the receiver is once.
+    fn recording_server(device_center_hz: u32, can_control: u32) -> (String, SettingLog) {
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind");
+        let addr = listener.local_addr().expect("addr").to_string();
+        let log = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+        let seen = std::sync::Arc::clone(&log);
+
+        std::thread::spawn(move || {
+            let Ok((mut sock, _)) = listener.accept() else { return };
+            let msg = |kind: u16, body: &[u8]| {
+                let mut out = Vec::new();
+                out.extend_from_slice(&proto::PROTOCOL_VERSION.to_le_bytes());
+                out.extend_from_slice(&u32::from(kind).to_le_bytes());
+                out.extend_from_slice(&0u32.to_le_bytes());
+                out.extend_from_slice(&0u32.to_le_bytes());
+                out.extend_from_slice(&(body.len() as u32).to_le_bytes());
+                out.extend_from_slice(body);
+                out
+            };
+            let words =
+                |ws: &[u32]| -> Vec<u8> { ws.iter().flat_map(|w| w.to_le_bytes()).collect() };
+
+            // Airspy HF+: 768 ksps, 660 kHz of analog bandwidth, 8 stages, no
+            // decimation floor, tunable across everything the server offers.
+            let info =
+                words(&[2, 0x3933_3038, 768_000, 660_000, 8, 0, 0, 0, 1_700_000_000, 16, 0, 0]);
+            let sync = words(&[
+                can_control,
+                29,
+                device_center_hz,
+                device_center_hz,
+                device_center_hz,
+                0,
+                0,
+                0,
+                0,
+            ]);
+            if sock.write_all(&msg(proto::MSG_DEVICE_INFO, &info)).is_err()
+                || sock.write_all(&msg(proto::MSG_CLIENT_SYNC, &sync)).is_err()
+            {
+                return;
+            }
+
+            // Everything after the hello is commands; record the settings.
+            let mut buf = [0u8; 4096];
+            let mut carry: Vec<u8> = Vec::new();
+            loop {
+                let Ok(n) = sock.read(&mut buf) else { return };
+                if n == 0 {
+                    return;
+                }
+                carry.extend_from_slice(&buf[..n]);
+                while carry.len() >= proto::CMD_HEADER_LEN {
+                    let w = |i: usize| {
+                        u32::from_le_bytes([carry[i], carry[i + 1], carry[i + 2], carry[i + 3]])
+                    };
+                    let (cmd, body_size) = (w(0), w(4) as usize);
+                    if carry.len() < proto::CMD_HEADER_LEN + body_size {
+                        break;
+                    }
+                    if cmd == proto::CMD_SET_SETTING && body_size == 8 {
+                        seen.lock().expect("log").push((w(8), w(12)));
+                    }
+                    carry.drain(..proto::CMD_HEADER_LEN + body_size);
+                }
+            }
+        });
+
+        (addr, log)
+    }
+
+    /// Every `(setting, value)` recorded so far, waiting up to a second for at
+    /// least `at_least` of the given setting to turn up.
+    fn settings_sent(
+        log: &std::sync::Mutex<Vec<(u32, u32)>>,
+        setting: u32,
+        at_least: usize,
+    ) -> Vec<u32> {
+        for _ in 0..200 {
+            let values: Vec<u32> = log
+                .lock()
+                .expect("log")
+                .iter()
+                .filter(|&&(s, _)| s == setting)
+                .map(|&(_, v)| v)
+                .collect();
+            if values.len() >= at_least {
+                return values;
+            }
+            std::thread::sleep(Duration::from_millis(10));
+        }
+        log.lock().expect("log").iter().filter(|&&(s, _)| s == setting).map(|&(_, v)| v).collect()
+    }
+
+    fn cfg(addr: &str) -> SpyServerConfig {
+        SpyServerConfig { address: addr.into(), ..SpyServerConfig::default() }
+    }
+
+    /// The FFT window is where the receiver *is*: with the FFT lane running, a
+    /// SpyServer tunes to `FFT_FREQUENCY` and treats `IQ_FREQUENCY` as a
+    /// position inside the band it is already on. So opening the window on the
+    /// frequency the server happened to be sitting on parks the whole session
+    /// there, whatever the operator asked for — and nothing recovers, because
+    /// this server never says where the receiver went.
+    #[test]
+    fn the_fft_window_opens_on_the_dial_not_on_the_servers_own_frequency() {
+        let (addr, log) = recording_server(100_000_000, 1);
+        let handle = SpyServerHandle::connect_wideband(&cfg(&addr), 7_100_000.0).expect("connect");
+        let sent = settings_sent(&log, proto::SETTING_FFT_FREQUENCY, 1);
+        drop(handle);
+        assert_eq!(
+            sent.first().copied(),
+            Some(7_100_000),
+            "the FFT window opened on the server's own frequency, which is where the \
+             receiver then stayed: {sent:?}"
+        );
+    }
+
+    /// ...and it follows the dial afterwards. At the top of the rate ladder the
+    /// I/Q window has no slack to slide within, so the receiver has to move,
+    /// and moving the receiver means moving this window.
+    #[test]
+    fn the_fft_window_follows_a_retune() {
+        let (addr, log) = recording_server(100_000_000, 1);
+        let handle = SpyServerHandle::connect_wideband(&cfg(&addr), 7_100_000.0).expect("connect");
+        settings_sent(&log, proto::SETTING_FFT_FREQUENCY, 1);
+        handle.set_center_hz(14_100_000.0);
+        let sent = settings_sent(&log, proto::SETTING_FFT_FREQUENCY, 2);
+        drop(handle);
+        assert_eq!(
+            sent.last().copied(),
+            Some(14_100_000),
+            "the receiver follows the FFT window, so a retune that leaves it behind is a \
+             retune that never happens: {sent:?}"
+        );
+    }
+
+    /// The opposite server: another client owns the receiver, so it does not
+    /// move for us and the window may only slide inside what they are already
+    /// receiving. At stage 0 that is nowhere at all — the window covers the
+    /// whole receiver — so it stays on their centre.
+    #[test]
+    fn a_shared_servers_fft_window_stays_inside_the_owners_band() {
+        let (addr, log) = recording_server(100_000_000, 0);
+        let handle = SpyServerHandle::connect_wideband(&cfg(&addr), 7_100_000.0).expect("connect");
+        let sent = settings_sent(&log, proto::SETTING_FFT_FREQUENCY, 1);
+        drop(handle);
+        assert_eq!(
+            sent.first().copied(),
+            Some(100_000_000),
+            "the device belongs to another client; this end cannot tune it away: {sent:?}"
+        );
+    }
+
+    /// The receiver follows the FFT window, and `IQ_FREQUENCY` is only a
+    /// position inside the band it is on — a position the server clamps if it
+    /// is outside, and then keeps. So the window has to move first, or the I/Q
+    /// is placed against a band the receiver is about to leave.
+    #[test]
+    fn a_retune_moves_the_fft_window_before_it_places_the_iq_window() {
+        let (addr, log) = recording_server(100_000_000, 1);
+        let handle = SpyServerHandle::connect_wideband(&cfg(&addr), 7_100_000.0).expect("connect");
+        settings_sent(&log, proto::SETTING_FFT_FREQUENCY, 1);
+        let before = log.lock().expect("log").len();
+        handle.set_center_hz(14_100_000.0);
+        settings_sent(&log, proto::SETTING_FFT_FREQUENCY, 2);
+        let after: Vec<(u32, u32)> = log.lock().expect("log")[before..].to_vec();
+        drop(handle);
+
+        let fft = after
+            .iter()
+            .position(|&(s, v)| s == proto::SETTING_FFT_FREQUENCY && v == 14_100_000)
+            .expect("the FFT window moved");
+        let iq = after
+            .iter()
+            .position(|&(s, v)| s == proto::SETTING_IQ_FREQUENCY && v == 14_100_000)
+            .expect("the I/Q window moved");
+        assert!(fft < iq, "the FFT window must move first: {after:?}");
     }
 }

--- a/crates/sdroxide-spyserver/src/proto.rs
+++ b/crates/sdroxide-spyserver/src/proto.rs
@@ -360,22 +360,43 @@ impl DeviceInfo {
     /// [`FFT_EDGE_FRAC`] of the span, and when it does move it puts the dial
     /// back in the middle — so the next move is most of a span away.
     ///
-    /// At decimation stage 0 the slack is zero and the window is pinned to the
-    /// device centre, so this only ever returns that. Which is correct: a
-    /// window already covering the whole receiver has nowhere else to go.
+    /// `controls_device` is what all of that has to be qualified by, and the
+    /// difference is not cosmetic. With the FFT lane running, a SpyServer tunes
+    /// its *receiver* to the FFT window and treats `IQ_FREQUENCY` as a position
+    /// inside the band the receiver is already on. So where this client controls
+    /// the receiver, holding this window still holds the receiver still, and the
+    /// dial can only stray as far as `iq_slack_hz` — the room the I/Q window has
+    /// to slide on its own. At the top of the rate ladder there is none, and the
+    /// window simply follows the dial.
+    ///
+    /// Where another client owns the receiver none of that applies: the device
+    /// does not move for us at all, the window only slides inside what they are
+    /// receiving, and the hysteresis is free to run its full width.
     pub fn fft_recenter(
         &self,
         iq_center: f64,
         fft_center: f64,
         fft_span: f64,
         device_center: f64,
+        controls_device: bool,
+        iq_slack_hz: f64,
     ) -> Option<f64> {
         let half = fft_span / 2.0;
         if half <= 0.0 {
             return None;
         }
-        if (iq_center - fft_center).abs() <= half * (1.0 - FFT_EDGE_FRAC) {
+        let mut hold = half * (1.0 - FFT_EDGE_FRAC);
+        if controls_device {
+            hold = hold.min(iq_slack_hz);
+        }
+        if (iq_center - fft_center).abs() <= hold {
             return None;
+        }
+        if controls_device {
+            // The receiver goes wherever this window goes, so it goes to the
+            // dial. Nothing to clamp against: the window is not sliding inside
+            // a band somebody else chose, it is choosing the band.
+            return Some(iq_center);
         }
         let slack = self.fft_slack_hz(fft_span);
         Some(iq_center.clamp(device_center - slack, device_center + slack))
@@ -719,11 +740,13 @@ mod tests {
         assert_eq!(freq_wire(1e12), u32::MAX);
     }
 
-    /// The band view holds while the dial roams inside it, and only jumps when
-    /// the dial reaches the outer third — which is what makes it a picture to
-    /// tune *across* rather than one that slides on every nudge.
+    /// On a *shared* server the band view holds while the dial roams inside it,
+    /// and only jumps when the dial reaches the outer third — which is what
+    /// makes it a picture to tune across rather than one that slides on every
+    /// nudge. The receiver belongs to another client and does not move, so
+    /// holding the window costs nothing.
     #[test]
-    fn the_fft_window_holds_until_the_dial_reaches_its_edge() {
+    fn a_shared_servers_fft_window_holds_until_the_dial_reaches_its_edge() {
         let mut info = airspy_r2();
         info.maximum_bandwidth = 10_000_000;
         // A 2.5 MHz window (stage 2) inside a 10 MHz receiver: 3.75 MHz of
@@ -731,37 +754,96 @@ mod tests {
         let span = 2_500_000.0;
         let dc = 100_000_000.0;
         let fft = 100_000_000.0;
+        let held = |iq: f64, from: f64| info.fft_recenter(iq, from, span, dc, false, 0.0);
 
         // Anywhere in the middle 70 % — ±875 kHz — and it does not move.
-        assert_eq!(info.fft_recenter(dc, fft, span, dc), None);
-        assert_eq!(info.fft_recenter(dc + 800_000.0, fft, span, dc), None);
-        assert_eq!(info.fft_recenter(dc - 800_000.0, fft, span, dc), None);
+        assert_eq!(held(dc, fft), None);
+        assert_eq!(held(dc + 800_000.0, fft), None);
+        assert_eq!(held(dc - 800_000.0, fft), None);
 
         // Past it, and the window re-centres on the dial.
-        let moved = info.fft_recenter(dc + 1_000_000.0, fft, span, dc).expect("past the edge");
+        let moved = held(dc + 1_000_000.0, fft).expect("past the edge");
         assert_eq!(moved, dc + 1_000_000.0);
 
         // And having moved, it holds again around the new centre.
-        assert_eq!(info.fft_recenter(dc + 1_100_000.0, moved, span, dc), None);
+        assert_eq!(held(dc + 1_100_000.0, moved), None);
 
         // The slack is a hard limit: the window cannot leave the receiver.
-        let far = info.fft_recenter(dc + 9_000_000.0, fft, span, dc).expect("past the edge");
+        let far = held(dc + 9_000_000.0, fft).expect("past the edge");
         assert_eq!(far, dc + 3_750_000.0, "clamped to the device's own bandwidth");
     }
 
-    /// A window already covering the whole receiver has nowhere to go, so the
-    /// hysteresis never fires — it just stays on the device centre.
+    /// A window already covering the whole of *another client's* receiver has
+    /// nowhere to go, so the hysteresis never fires — it just stays on their
+    /// centre.
     #[test]
-    fn a_full_span_fft_window_is_pinned_to_the_device_centre() {
+    fn a_full_span_fft_window_is_pinned_to_a_shared_device_centre() {
         let info = airspy_r2();
         let span = f64::from(info.maximum_bandwidth);
         let dc = 100_000_000.0;
         assert_eq!(info.fft_slack_hz(span), 0.0);
         // Far off centre, so the hysteresis says "move" — and the clamp puts it
         // straight back where it was, which the caller reads as no change.
-        assert_eq!(info.fft_recenter(dc + 4_000_000.0, dc, span, dc), Some(dc));
+        assert_eq!(info.fft_recenter(dc + 4_000_000.0, dc, span, dc, false, 0.0), Some(dc));
         // A span of zero is the FFT lane switched off.
-        assert_eq!(info.fft_recenter(dc, dc, 0.0, dc), None);
+        assert_eq!(info.fft_recenter(dc, dc, 0.0, dc, false, 0.0), None);
+    }
+
+    /// On a server this client controls, the window *is* the receiver, and the
+    /// dial may only stray as far as the I/Q window can follow it. At the top of
+    /// the rate ladder that is nowhere, so the window tracks the dial exactly —
+    /// and the device centre it is handed is stale by definition, so it must
+    /// have no say in the answer.
+    #[test]
+    fn a_controlled_receivers_fft_window_follows_the_dial() {
+        let info = hf_plus();
+        // Stage 0: the window is the whole receiver, and the I/Q at full rate
+        // has no room to slide inside it.
+        let span = f64::from(info.maximum_bandwidth);
+        let iq_slack = info.iq_slack_hz(f64::from(info.maximum_sample_rate));
+        assert_eq!(iq_slack, 0.0);
+
+        // The server was left on 100 MHz; the operator wants 7.1. The window
+        // goes to the dial, not to where the server happened to be.
+        let stale = 100_000_000.0;
+        assert_eq!(
+            info.fft_recenter(7_100_000.0, stale, span, stale, true, iq_slack),
+            Some(7_100_000.0),
+        );
+        // Once there, it holds — an unchanged dial is not a reason to retune.
+        assert_eq!(info.fft_recenter(7_100_000.0, 7_100_000.0, span, stale, true, iq_slack), None,);
+        // And a dial move of any size takes it along, because the I/Q window
+        // cannot reach a hertz on its own.
+        assert_eq!(
+            info.fft_recenter(7_101_000.0, 7_100_000.0, span, stale, true, iq_slack),
+            Some(7_101_000.0),
+        );
+    }
+
+    /// With room for the I/Q window to slide, the hysteresis comes back: the
+    /// strip holds still while the dial roams whatever the I/Q can still reach.
+    #[test]
+    fn a_controlled_receiver_holds_the_window_while_the_iq_can_still_reach() {
+        let info = hf_plus();
+        let span = f64::from(info.maximum_bandwidth);
+        // I/Q at stage 3 — 96 ksps of 768 — leaves 336 kHz either side.
+        let iq_slack = info.iq_slack_hz(96_000.0);
+        assert_eq!(iq_slack, 336_000.0);
+        let fft = 7_100_000.0;
+        let hold = |iq: f64| info.fft_recenter(iq, fft, span, 100_000_000.0, true, iq_slack);
+
+        // The hysteresis is the narrower of the two here: 70 % of half the
+        // 660 kHz span, so ±231 kHz against the I/Q window's 336 kHz.
+        assert_eq!(hold(fft + 200_000.0), None, "still well inside the strip");
+        assert_eq!(hold(fft + 300_000.0), Some(fft + 300_000.0), "past the strip's edge");
+
+        // And when the I/Q slack is the narrower of the two, it is what bites.
+        let tight = 100_000.0;
+        assert_eq!(
+            info.fft_recenter(fft + 150_000.0, fft, span, 100_000_000.0, true, tight),
+            Some(fft + 150_000.0),
+            "the I/Q window cannot reach 150 kHz with 100 kHz of slack",
+        );
     }
 
     #[test]

--- a/crates/sdroxide-spyserver/src/proto.rs
+++ b/crates/sdroxide-spyserver/src/proto.rs
@@ -309,27 +309,52 @@ impl DeviceInfo {
             .unwrap_or(self.minimum_iq_decimation)
     }
 
-    /// The digital gain to ask for, in dB, given the server's gain index and
-    /// the I/Q decimation stage.
+    /// The digital gain to ask for, in dB, given the server's gain index, the
+    /// I/Q decimation stage, and the format the samples will be sent in.
     ///
     /// Every decimation stage halves the bandwidth and so buys about 3 dB of
     /// processing gain that would otherwise be thrown away when the samples
-    /// are quantised for the wire. The device-specific parts are what the
-    /// reference client does, transcribed:
+    /// are quantised for the wire. That part, and the Airspy R2's, are what
+    /// SDR++'s client computes:
     ///
     /// * An Airspy R2's gain index counts *down* from its maximum, so a low
     ///   index means a quiet signal that needs the headroom back.
-    /// * An Airspy HF+ sending 8-bit needs a further 32 dB. Its analog dynamic
-    ///   range is so large that its I/Q sits far below digital full scale, and
-    ///   eight bits of a signal that only reaches a fraction of full scale is
-    ///   not eight bits of signal.
-    pub fn digital_gain_db(&self, gain_index: u32, decimation_stage: u32) -> f64 {
+    ///
+    /// The HF+ part is not from there — SDR++ gives it decimation gain only —
+    /// it is from measuring what an HF+ actually puts on the wire as **8-bit**.
+    /// Its analog dynamic range is so large that on a quiet band its I/Q sits
+    /// below one eighth-bit LSB: at 0 dB a real one over SpyServer sent
+    /// *three* distinct sample values (mid-scale 97.7 % of the time, ±1 for
+    /// the rest), and the spectrum of that is a flat slicer-noise floor 23 dB
+    /// above the receiver's own with a dip at DC, which reads on screen as a
+    /// band that is quiet only where the dial is.
+    ///
+    /// How much is enough was swept against a 16-bit capture of the same band,
+    /// floor by distance from the centre. At 32 dB the noise is ±2 LSB and the
+    /// quantiser is still a nonlinearity rather than a noise source: the floor
+    /// rose 3.4 dB towards the band edges and filled the receiver's roll-off
+    /// beyond ±330 kHz 14 dB above the truth — a bathtub on the panadapter. At
+    /// 38 dB, 1 dB and 8 dB. At 44 dB the passband matched 16-bit to 0.1 dB
+    /// and the roll-off to 3 dB, with the strongest signal in the band at 20
+    /// of 127 — 16 dB of headroom. 50 dB bought another 2 dB in the roll-off
+    /// for 6 dB of headroom, so 44 it is. The boost is keyed on the *stream*
+    /// being 8-bit and on nothing else: `resolution` is the ADC's width as the
+    /// server reports it — 16 or 18 for an HF+ — and keying on that instead
+    /// is what left the boost never applied. A 16-bit stream has 48 dB more
+    /// room and needs none of this; it is also the answer for a band with a
+    /// station strong enough to clip eight bits at this gain.
+    pub fn digital_gain_db(
+        &self,
+        gain_index: u32,
+        decimation_stage: u32,
+        format: SpyServerFormat,
+    ) -> f64 {
         let stage_gain = f64::from(decimation_stage) * 3.01;
         match self.kind() {
             DeviceKind::AirspyOne => {
                 f64::from(self.maximum_gain_index.saturating_sub(gain_index)) + stage_gain
             }
-            DeviceKind::AirspyHf if self.resolution <= 8 => 32.0 + stage_gain,
+            DeviceKind::AirspyHf if format == SpyServerFormat::Uint8 => 44.0 + stage_gain,
             _ => stage_gain,
         }
     }
@@ -683,26 +708,47 @@ mod tests {
         assert_eq!(r2.stage_for_rate(1.0, false), 8);
     }
 
-    /// Each branch of the reference client's formula, including the HF+
-    /// baseline that only applies to an 8-bit server.
+    /// Each branch of the formula, including the HF+ baseline that applies to
+    /// an 8-bit *stream* — and to nothing else.
     #[test]
     fn the_digital_gain_formula_matches_the_reference() {
+        use SpyServerFormat::{Int16, Uint8};
+
         // Airspy R2: the index counts down from the maximum.
         let r2 = airspy_r2();
-        assert!((r2.digital_gain_db(21, 0) - 0.0).abs() < 1e-9, "full gain needs no help");
-        assert!((r2.digital_gain_db(0, 0) - 21.0).abs() < 1e-9);
-        assert!((r2.digital_gain_db(21, 4) - 12.04).abs() < 1e-9, "four stages of 3.01 dB");
+        assert!((r2.digital_gain_db(21, 0, Uint8) - 0.0).abs() < 1e-9, "full gain needs no help");
+        assert!((r2.digital_gain_db(0, 0, Uint8) - 21.0).abs() < 1e-9);
+        assert!((r2.digital_gain_db(21, 4, Uint8) - 12.04).abs() < 1e-9, "four stages of 3.01 dB");
 
-        // HF+ at its real 18-bit resolution: decimation only.
+        // HF+ sending 16-bit: decimation only, there is room to spare.
         let hf = hf_plus();
-        assert!((hf.digital_gain_db(4, 3) - 9.03).abs() < 1e-9);
+        assert!((hf.digital_gain_db(4, 3, Int16) - 9.03).abs() < 1e-9);
 
-        // The same HF+ behind an 8-bit server: 32 dB of baseline on top.
-        let hf8 = DeviceInfo { resolution: 8, ..hf_plus() };
-        assert!((hf8.digital_gain_db(4, 3) - 41.03).abs() < 1e-9);
+        // The same HF+ sending 8-bit: 44 dB of baseline on top.
+        assert!((hf.digital_gain_db(4, 3, Uint8) - 53.03).abs() < 1e-9);
 
-        // RTL-SDR: decimation only, whatever its resolution.
-        assert!((rtlsdr().digital_gain_db(28, 2) - 6.02).abs() < 1e-9);
+        // RTL-SDR: decimation only, whatever the format.
+        assert!((rtlsdr().digital_gain_db(28, 2, Uint8) - 6.02).abs() < 1e-9);
+        assert!((rtlsdr().digital_gain_db(28, 2, Int16) - 6.02).abs() < 1e-9);
+    }
+
+    /// The boost is keyed on the stream, not on the ADC width the server
+    /// reports. A real HF+ server says 16 (the fixture above says 18; neither
+    /// is ever 8), and keying on that left an 8-bit stream at 0 dB — three
+    /// distinct sample values, and a noise floor 23 dB above the receiver's.
+    #[test]
+    fn an_hf_plus_gets_its_eight_bit_boost_whatever_resolution_the_server_claims() {
+        for resolution in [8, 16, 18] {
+            let hf = DeviceInfo { resolution, ..hf_plus() };
+            assert!(
+                (hf.digital_gain_db(0, 0, SpyServerFormat::Uint8) - 44.0).abs() < 1e-9,
+                "an 8-bit stream from an HF+ reporting {resolution}-bit needs the boost"
+            );
+            assert!(
+                hf.digital_gain_db(0, 0, SpyServerFormat::Int16).abs() < 1e-9,
+                "a 16-bit stream from an HF+ reporting {resolution}-bit does not"
+            );
+        }
     }
 
     /// The slack is what lets the window sit off the device centre, and it is

--- a/crates/sdroxide-spyserver/tests/spyserver.rs
+++ b/crates/sdroxide-spyserver/tests/spyserver.rs
@@ -360,8 +360,14 @@ fn the_handshake_states_the_settings_in_dependency_order() {
     assert_eq!(fake.value_of(SETTING_IQ_DIGITAL_GAIN), Some(6));
 }
 
-/// With the FFT lane on, its whole block lands between the I/Q settings and
+/// With the FFT lane on, its whole block lands between the I/Q lane's shape and
 /// the streaming mode — and the mode becomes the combined one.
+///
+/// The I/Q *frequency* is the exception, and it is deliberately last of the
+/// two windows: with this lane running the receiver follows the FFT window, and
+/// `IQ_FREQUENCY` only places the I/Q window inside the band the receiver is
+/// already on. Sending it first placed it against a band the receiver was about
+/// to leave.
 #[test]
 fn the_fft_block_is_configured_before_the_streaming_mode() {
     let fake = Fake::start(Spec::default());
@@ -373,6 +379,7 @@ fn the_fft_block_is_configured_before_the_streaming_mode() {
     let mode_at = fake.index_of(SETTING_STREAMING_MODE).expect("a streaming mode");
     let gain_at = fake.index_of(SETTING_GAIN).expect("a gain");
     let dgain_at = fake.index_of(SETTING_IQ_DIGITAL_GAIN).expect("a digital gain");
+    let shape_at = fake.index_of(SETTING_IQ_DECIMATION).expect("an I/Q decimation");
     let freq_at = fake.index_of(SETTING_IQ_FREQUENCY).expect("an I/Q frequency");
 
     for s in [
@@ -384,9 +391,14 @@ fn the_fft_block_is_configured_before_the_streaming_mode() {
         SETTING_FFT_DB_RANGE,
     ] {
         let at = fake.index_of(s).unwrap_or_else(|| panic!("setting {s} was never sent"));
-        assert!(at > freq_at, "setting {s} must follow the I/Q block");
+        assert!(at > shape_at, "setting {s} must follow the I/Q lane's shape");
         assert!(at < mode_at, "setting {s} must precede the streaming mode");
     }
+    let fft_freq_at = fake.index_of(SETTING_FFT_FREQUENCY).expect("an FFT frequency");
+    assert!(
+        fft_freq_at < freq_at,
+        "the window the receiver follows has to be placed before the window that sits inside it",
+    );
     assert!(mode_at < gain_at, "the streaming mode must precede the gain");
     assert!(gain_at < dgain_at, "the digital gain is computed from the gain index");
 

--- a/crates/sdroxide-spyserver/tests/spyserver.rs
+++ b/crates/sdroxide-spyserver/tests/spyserver.rs
@@ -610,6 +610,56 @@ fn the_configured_gain_survives_the_servers_opening_sync() {
     assert_eq!(fake.value_of(SETTING_IQ_DIGITAL_GAIN), Some(24));
 }
 
+/// An Airspy HF+ sent as 8-bit needs 44 dB of digital gain or its quiet-band
+/// I/Q arrives as three sample values — and the boost was keyed on the ADC
+/// width the server reports, which for a real HF+ is 16 or 18, never 8, so it
+/// was never sent. It is keyed on the stream format now; the format is the
+/// only thing that decides whether the samples have the room.
+#[test]
+fn an_hf_plus_sent_as_eight_bit_is_asked_for_its_forty_four_db() {
+    // As a real HF+ server describes itself: 768 ksps, 660 kHz of analog
+    // bandwidth, no gain stages, and a 16-bit ADC.
+    let hf_plus = Spec {
+        device_type: 2,
+        max_rate: 768_000,
+        max_bw: 660_000,
+        stages: 8,
+        min_decim: 0,
+        max_gain: 0,
+        min_freq: 0,
+        max_freq: 1_700_000_000,
+        resolution: 16,
+        ..Spec::default()
+    };
+
+    let fake = Fake::start(hf_plus);
+    let cfg = SpyServerConfig {
+        iq_format: SpyServerFormat::Uint8,
+        iq_decimation: 0,
+        fft_enabled: false,
+        ..fake.cfg()
+    };
+    let _h = SpyServerHandle::connect_wideband(&cfg, 1_081_400.0).expect("connect");
+    assert!(eventually(Duration::from_secs(2), || fake
+        .value_of(SETTING_IQ_DIGITAL_GAIN)
+        .is_some()));
+    assert_eq!(fake.value_of(SETTING_IQ_DIGITAL_GAIN), Some(44), "8-bit at stage 0");
+
+    // The same receiver sent as 16-bit has 48 dB more room and gets none of it.
+    let fake = Fake::start(hf_plus);
+    let cfg = SpyServerConfig {
+        iq_format: SpyServerFormat::Int16,
+        iq_decimation: 0,
+        fft_enabled: false,
+        ..fake.cfg()
+    };
+    let _h = SpyServerHandle::connect_wideband(&cfg, 1_081_400.0).expect("connect");
+    assert!(eventually(Duration::from_secs(2), || fake
+        .value_of(SETTING_IQ_DIGITAL_GAIN)
+        .is_some()));
+    assert_eq!(fake.value_of(SETTING_IQ_DIGITAL_GAIN), Some(0), "16-bit at stage 0");
+}
+
 /// The opposite case: where another client owns the receiver, the gain is
 /// theirs and what they set is the only true answer.
 #[test]


### PR DESCRIPTION
Fixes #369.

## The bug

Against a SpyServer publishing an Airspy HF+, tuning did nothing: whatever frequency the dial was set to, the receiver stayed on the frequency the **server** had started on. The log reported the requested centre, so nothing looked wrong from this side.

## Root cause

With the FFT lane running, a SpyServer tunes its **receiver** to `SETTING_FFT_FREQUENCY`. `SETTING_IQ_FREQUENCY` only positions the I/Q window _inside_ the band the receiver is already on — and at I/Q decimation stage 0 there is no room to position it, so it does nothing at all.

`Client::plan` opened the FFT window at `clamped_fft_center(self.center)`, which clamped into `device_center ± fft_slack_hz(span)`:

- `device_center` is whatever the handshake's `CLIENT_SYNC` reported, i.e. where the server sat _before_ we tuned it;
- `fft_slack_hz` at FFT stage 0 is `(maximum_bandwidth - maximum_bandwidth) / 2`, exactly **zero**, because the window already covers the whole receiver.

The clamp therefore collapsed to precisely the server's own frequency, whatever the operator asked for, and `configure()` sent it. The receiver followed the window and parked there.

It never recovered, either: `maintain_fft` re-derived the target through `DeviceInfo::fft_recenter`, which clamped against the same `device_center` — and the server I hit sends exactly one `CLIENT_SYNC`, at the handshake, so `device_center` stayed put for the life of the session and every pass recomputed the same answer.

Stage 0 is the default (`fft_decimation: 0`, `fft_enabled: true`), so this shows on any server whose start-up frequency is not where you want to listen. SDR++ is unaffected because it streams IQ-only and never sends `FFT_FREQUENCY`; in that mode `IQ_FREQUENCY` does move the receiver.

## Measured on the wire

Captured I/Q from a real Airspy HF+ over SpyServer with a minimal protocol client and correlated each spectrum against references taken in IQ-only mode at known frequencies:

| what was set                                                | where the receiver actually was             |
| ----------------------------------------------------------- | ------------------------------------------- |
| I/Q 7.1 MHz, FFT 100 MHz (what sdroxide sent)               | 100 MHz (corr +0.995)                       |
| the same two values, I/Q sent **last**                      | 100 MHz (corr +0.994) — not last-write-wins |
| FFT lane on, then only `IQ_FREQUENCY` retuned to 7.1        | 100 MHz (corr +0.991)                       |
| open both on 7.1, then move **only** the FFT window to 14.1 | 14.1 MHz (corr +0.919)                      |
| open both on 7.1, then move **only** the I/Q window to 14.1 | still 7.1 MHz (corr +0.932)                 |
| both windows moved together to 7.1                          | 7.1 MHz (corr +0.885) — the fixed behaviour |

A further measurement decided the ordering below: with a decimated I/Q window, moving the FFT window carries the receiver but leaves the I/Q window on its old absolute frequency, so a position sent against the outgoing band stays there.

## The fix

- `DeviceInfo::fft_recenter` now takes whether this client controls the receiver, and how much slack the I/Q window has. Where it does control it, the window is the receiver: it recentres on the dial, and it may only hold still while the I/Q window can still reach the dial on its own. At the top of the rate ladder that slack is zero, so the window tracks the dial exactly. Where another client owns the receiver, nothing changes — the device does not move for us, the window slides inside it, and the hysteresis runs its full width.
- `Client::clamped_fft_center` no longer clamps against the device centre when this client controls the receiver. That clamp was the bug.
- The FFT window is now placed **before** `IQ_FREQUENCY`, both at connect and on every retune, because the I/Q position is only meaningful once the receiver is where it belongs. `maintain_fft` keeps its rate limit for the case it exists for — a shared server's owner moving the device — while a retune moves the window directly, having already paid that interval.
- Switching the FFT lane on mid-session recomputes the window centre instead of sending whichever one it was left holding, which would otherwise drag the receiver back to the band the operator was in when the lane was last on.

## Testing

Per the contributing rules, this was tested against real hardware: an Airspy HF+ published over SpyServer, tuning across 40 m, 20 m and the FM broadcast band, confirmed both by ear and by the correlations in the table above.

Automated coverage added:

- four tests in `net.rs` against a fake server shaped like the one this was found on — an HF+ whose analog bandwidth is its whole stage-0 FFT span, sitting on 100 MHz, sending exactly one `CLIENT_SYNC`. Three of them fail on the current `main`;
- two `fft_recenter` unit tests for the controlled-receiver case, covering both the zero-slack and the still-has-slack halves;
- the existing shared-server tests are kept and now guard the other half of the branch.

`cargo test -p sdroxide-spyserver` is green (60 tests), as are the root crate's four `spyserver_source` tests. No new clippy warnings; `cargo fmt` clean.

One existing assertion changed. `the_fft_block_is_configured_before_the_streaming_mode` asserted that the FFT block follows `IQ_FREQUENCY` — which is the ordering being fixed. It now asserts that the block follows the I/Q lane's _shape_ (format and decimation) and that `FFT_FREQUENCY` precedes `IQ_FREQUENCY`, with the reason written down.



## Second fix in the same PR: the HF+'s 8-bit digital gain was never sent, and was too small when it was

Found the moment tuning worked: on a quiet band (1.08 MHz, next to an NDB) the panadapter showed a flat noise floor across the whole 768 kHz with a deep, ripple-edged dip only around the dial — as if everything but the tuned frequency were 20 dB noisier. The server's own FFT strip of the same band was flat and clean, so it was the I/Q lane.

### Measured on the wire

Raw I/Q captured off the socket at 1.0814 MHz, before any client DSP, floor by distance from the centre (dBFS/bin, median per band) against a 16-bit capture of the same band. The last column is the strongest sample seen, out of 127.

| stream | 0–20 kHz | 150–250 | 250–330 | 330–384 (receiver roll-off) | distinct values | max |
| --- | --- | --- | --- | --- | --- | --- |
| 16-bit, 0 dB (reference) | -83.1 | -83.9 | -83.3 | -94.4 | — | — |
| 8-bit, 0 dB (what sdroxide sent) | -78.6 | -60.1 | -59.8 | — | **3** | 1 |
| 8-bit, 32 dB (what it meant to send) | -83.0 | -80.9 | -79.6 | -80.7 | 11 | 5 |
| 8-bit, 38 dB | -83.1 | -83.0 | -82.0 | -86.1 | 15 | 7 |
| **8-bit, 44 dB** | -83.0 | -83.9 | -83.3 | -91.3 | 41 | 20 |
| 8-bit, 50 dB | -83.0 | -83.9 | -83.3 | -95.6 | 78 | 41 |

At 0 dB the HF+'s I/Q sits below one 8-bit LSB, so the server ships a three-level slicer output: a flat floor 23 dB above the receiver's own, with the dip at DC that is the shape of that quantisation error rather than any filter.

At 32 dB the noise is ±2 LSB and the quantiser is still a nonlinearity rather than a noise source: the floor rises 3.4 dB towards the band edges and fills the receiver's roll-off 14 dB above the truth, which shows on the panadapter as a bathtub — quiet in the middle, louder at both ends, where SDR++ (16-bit) shows a flat floor rolling *off*. At 44 dB the passband matches 16-bit to 0.1 dB and the roll-off to 3 dB, with 16 dB of headroom above the strongest signal in the band. 50 dB buys 2 dB more in the roll-off for 6 dB of headroom, so 44 it is.

### Root cause

`DeviceInfo::digital_gain_db` added the HF+'s boost only `if self.resolution <= 8`. But `resolution` is the ADC width the server reports — 16 on this server, 18 in the crate's own fixture, never 8 for an HF+ — so the branch was dead and an 8-bit stream always went out at 0 dB. The doc comment on the function says "an Airspy HF+ *sending 8-bit* needs a further 32 dB"; the code checked the wrong thing, and the number was 12 dB short besides.

It was invisible before the first fix because the receiver was parked on the FM broadcast band, where there is plenty of signal for eight bits.

For the record, the comment attributed the formula to "the reference client". SDR++'s `computeDigitalGain` gives an HF+ decimation gain only (its `serverBits` argument is accepted and unused), so the boost is not from there — an HF+ over 8-bit in SDR++ starves the same way. The doc now says where the number comes from and carries the sweep.

### The fix

`digital_gain_db` takes the stream format and keys the HF+ boost on `SpyServerFormat::Uint8`, at 44 dB. Nothing else in the formula changes; a 16-bit stream from an HF+ has 48 dB more room and gets none of it, as before — and is the answer for a band with a station strong enough to clip eight bits at this gain, as is the manual digital-gain setting.

### Testing

- Same real HF+ over SpyServer: the sweep above.
- `an_hf_plus_gets_its_eight_bit_boost_whatever_resolution_the_server_claims` (unit): resolutions 8, 16 and 18 all get the boost as 8-bit and none as 16-bit.
- `an_hf_plus_sent_as_eight_bit_is_asked_for_its_forty_four_db` (integration, fake server describing itself exactly as the real one does, `resolution = 16`): `IQ_DIGITAL_GAIN` is 44 for an 8-bit stream and 0 for a 16-bit one.
- `cargo test -p sdroxide-spyserver`: 62 tests green.
