### PR TITLE
Fix the recorded auxi chunk's StopTime and its real 164-byte shape

### DIFF
--- a/crates/sdroxide-radio/src/iq_wav.rs
+++ b/crates/sdroxide-radio/src/iq_wav.rs
@@ -180,7 +180,7 @@ fn header_bytes(rate_hz: u32, center_hz: f64) -> Header {
     b.extend_from_slice(&bits.to_le_bytes());
 
     b.extend_from_slice(b"auxi");
-    let auxi = auxi_payload(center_hz);
+    let auxi = auxi_payload(rate_hz, center_hz);
     b.extend_from_slice(&(auxi.len() as u32).to_le_bytes());
     // StartTime is the first SYSTEMTIME in the payload; StopTime is the one
     // right after it — see `auxi_payload`'s own doc for the field layout.
@@ -204,14 +204,27 @@ fn now_unix_secs() -> u64 {
         .as_secs()
 }
 
-/// The `auxi` chunk SDR#/HDSDR write: two `SYSTEMTIME`s, then the tuning.
+/// The `auxi` chunk SDR#/HDSDR write: two `SYSTEMTIME`s, nine `u32` tuning
+/// fields, then a fixed-size "next file" name — **164 bytes total**, not the
+/// 64 this used to stop at.
 ///
-/// Sixteen little-endian `u16`s of start and stop time (year, month, day of
-/// week, day, hour, minute, second, millisecond — Windows' `SYSTEMTIME`, which
-/// is what the format is), then centre, dial and low-edge frequencies, a
-/// timestamp pair and the ADC width. Only the centre frequency is read by
-/// anything that matters, and it is the whole reason to write the chunk; the
-/// rest is filled in so the layout is the one those programs parse.
+/// The shape (and the exact 164-byte length) came from decoding a real
+/// HDSDR capture byte-for-byte
+/// (`HDSDR_20171123_005716Z_1130kHz_RF.wav`, on hand from prior DXing —
+/// `StartTime` 2017-11-23 00:57:16, `dayOfWeek` 4, a Thursday, which it was,
+/// and `centerFreq` 1130000, all matching the file's own name), not
+/// recalled: two 16-byte `SYSTEMTIME`s (year, month, day of week, day, hour,
+/// minute, second, millisecond), then centre frequency, A/D sample rate, IF
+/// frequency, bandwidth, IQ offset, dB offset, max value and two "initial
+/// gain" fields (nine `u32`s, 36 bytes), then a 96-byte NUL-terminated "next
+/// file" name — which this writes empty and zero-padded, since there is no
+/// next file to name, but a reader stepping through the chunk by its
+/// documented shape still finds exactly what it expects there rather than
+/// running off the end into whatever chunk happens to follow. Only the
+/// centre frequency is read by anything that matters here, and it's the
+/// whole reason to write the chunk at all; the rest is filled in, at its
+/// real size, so the layout is the one those programs actually parse rather
+/// than one that merely resembles it.
 ///
 /// StopTime is written equal to StartTime here — nothing is over yet at
 /// header-build time — and [`IqWavWriter::finish`] patches the real value in
@@ -221,7 +234,7 @@ fn now_unix_secs() -> u64 {
 /// `finish()` at all, on a hard crash) still sees an internally consistent
 /// pair, just an as-yet-unfinished one, rather than an obviously-wrong
 /// all-zero stop time.
-fn auxi_payload(center_hz: f64) -> Vec<u8> {
+fn auxi_payload(rate_hz: u32, center_hz: f64) -> Vec<u8> {
     let mut b = Vec::with_capacity(164);
     let st = systemtime_fields(now_unix_secs());
     for _ in 0..2 {
@@ -230,14 +243,17 @@ fn auxi_payload(center_hz: f64) -> Vec<u8> {
         }
     }
     let hz = center_hz.max(0.0) as u32;
-    b.extend_from_slice(&hz.to_le_bytes()); // centre
-    b.extend_from_slice(&hz.to_le_bytes()); // dial ("frequency")
+    b.extend_from_slice(&hz.to_le_bytes()); // centre frequency
+    b.extend_from_slice(&rate_hz.to_le_bytes()); // A/D sample rate
     b.extend_from_slice(&0u32.to_le_bytes()); // IF frequency
-    b.extend_from_slice(&0u32.to_le_bytes()); // bandwidth
+    b.extend_from_slice(&rate_hz.to_le_bytes()); // bandwidth
     b.extend_from_slice(&0u32.to_le_bytes()); // IQ offset
-    b.extend_from_slice(&0u32.to_le_bytes()); // db offset
+    b.extend_from_slice(&0u32.to_le_bytes()); // dB offset
     b.extend_from_slice(&0u32.to_le_bytes()); // max value
-    b.extend_from_slice(&32u32.to_le_bytes()); // significant bits
+    b.extend_from_slice(&0u32.to_le_bytes()); // initial gain 1
+    b.extend_from_slice(&0u32.to_le_bytes()); // initial gain 2
+    b.extend_from_slice(&[0u8; 96]); // next file name, empty
+    debug_assert_eq!(b.len(), 164, "the auxi chunk's real, observed size");
     b
 }
 
@@ -432,6 +448,49 @@ mod tests {
             u32::from_le_bytes(raw[payload + 32..payload + 36].try_into().unwrap()),
             14_074_000
         );
+        let _ = std::fs::remove_file(&path);
+    }
+
+    /// The real-world bug this exists to catch: the `auxi` chunk this used to
+    /// write stopped at 64 bytes — two `SYSTEMTIME`s and eight `u32` fields,
+    /// missing the trailing "next file name" buffer entirely. A real HDSDR
+    /// capture on hand (`HDSDR_20171123_005716Z_1130kHz_RF.wav`) has one that
+    /// is 164 bytes, and a WavViewDX rejection of a real sdroxide recording
+    /// traced back to exactly this: this chunk's declared size told a reader
+    /// stepping through it by that documented shape to keep reading 100 bytes
+    /// past where the payload actually ended, into whatever chunk came next.
+    #[test]
+    fn the_auxi_chunk_is_the_real_164_byte_shape() {
+        let dir = std::env::temp_dir().join(format!("sdroxide-iqwav-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("auxi_shape.wav");
+        IqWavWriter::create(&path, 2_048_000, 6_070_000.0).unwrap().finish().unwrap();
+
+        let raw = std::fs::read(&path).unwrap();
+        let auxi = find_chunk(&raw, b"auxi").expect("auxi chunk");
+        let declared = u32::from_le_bytes(raw[auxi + 4..auxi + 8].try_into().unwrap());
+        assert_eq!(declared, 164, "the auxi chunk's declared size must match HDSDR's own");
+
+        let payload = auxi + 8;
+        // Centre frequency, then the A/D sample rate and bandwidth this used
+        // to leave unwritten (0) entirely.
+        assert_eq!(
+            u32::from_le_bytes(raw[payload + 32..payload + 36].try_into().unwrap()),
+            6_070_000
+        );
+        assert_eq!(
+            u32::from_le_bytes(raw[payload + 36..payload + 40].try_into().unwrap()),
+            2_048_000,
+            "A/D sample rate"
+        );
+        assert_eq!(
+            u32::from_le_bytes(raw[payload + 44..payload + 48].try_into().unwrap()),
+            2_048_000,
+            "bandwidth"
+        );
+        // The trailing "next file name" buffer this used to not write at
+        // all — present, and empty, rather than absent.
+        assert_eq!(&raw[payload + 68..payload + 164], &[0u8; 96][..]);
         let _ = std::fs::remove_file(&path);
     }
 

--- a/crates/sdroxide-radio/src/iq_wav.rs
+++ b/crates/sdroxide-radio/src/iq_wav.rs
@@ -45,6 +45,10 @@ pub struct IqWavWriter {
     path: PathBuf,
     /// Byte offset of the `data` chunk's own 32-bit size field.
     data_size_at: u64,
+    /// Byte offset of the `auxi` chunk's `StopTime` `SYSTEMTIME` — patched at
+    /// [`Self::finish`] the same way [`Self::data_size_at`] already is. See
+    /// [`auxi_payload`]'s own doc for why this needs a second patch at all.
+    auxi_stop_time_at: u64,
     /// Frames written so far.
     frames: u64,
     scratch: Vec<u8>,
@@ -62,6 +66,7 @@ impl IqWavWriter {
             file: w,
             path: path.to_path_buf(),
             data_size_at: header.data_size_at,
+            auxi_stop_time_at: header.auxi_stop_time_at,
             frames: 0,
             scratch: Vec::new(),
         })
@@ -125,6 +130,16 @@ impl IqWavWriter {
             f.seek(SeekFrom::Start(self.data_size_at))?;
             f.write_all(&(data_bytes as u32).to_le_bytes())?;
         }
+        // The `auxi` chunk's own StopTime — written equal to StartTime when
+        // the header went out, since nothing was over yet. Patched here for
+        // the same reason the sizes above are: a reader that takes this
+        // chunk at its word sees a real elapsed time instead of a capture
+        // that claims to have taken zero seconds regardless of how much data
+        // actually follows it.
+        f.seek(SeekFrom::Start(self.auxi_stop_time_at))?;
+        for v in systemtime_fields(now_unix_secs()) {
+            f.write_all(&v.to_le_bytes())?;
+        }
         f.flush()?;
         Ok(self.path)
     }
@@ -133,6 +148,9 @@ impl IqWavWriter {
 struct Header {
     bytes: Vec<u8>,
     data_size_at: u64,
+    /// Byte offset of the `auxi` chunk's `StopTime` field — see
+    /// [`IqWavWriter::auxi_stop_time_at`]'s own doc.
+    auxi_stop_time_at: u64,
 }
 
 /// The whole header, up to and including the `data` chunk's size field.
@@ -164,12 +182,26 @@ fn header_bytes(rate_hz: u32, center_hz: f64) -> Header {
     b.extend_from_slice(b"auxi");
     let auxi = auxi_payload(center_hz);
     b.extend_from_slice(&(auxi.len() as u32).to_le_bytes());
+    // StartTime is the first SYSTEMTIME in the payload; StopTime is the one
+    // right after it — see `auxi_payload`'s own doc for the field layout.
+    let auxi_stop_time_at = b.len() as u64 + 16;
     b.extend_from_slice(&auxi);
 
     b.extend_from_slice(b"data");
     let data_size_at = b.len() as u64;
     b.extend_from_slice(&0u32.to_le_bytes()); // patched on close
-    Header { bytes: b, data_size_at }
+    Header { bytes: b, data_size_at, auxi_stop_time_at }
+}
+
+/// Now, as the whole seconds [`systemtime_fields`] wants — clamped to the
+/// epoch on a clock that has somehow gone backward rather than panicking or
+/// propagating an error nobody at a `finish()`/header-build call site could
+/// usefully act on.
+fn now_unix_secs() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs()
 }
 
 /// The `auxi` chunk SDR#/HDSDR write: two `SYSTEMTIME`s, then the tuning.
@@ -180,13 +212,18 @@ fn header_bytes(rate_hz: u32, center_hz: f64) -> Header {
 /// timestamp pair and the ADC width. Only the centre frequency is read by
 /// anything that matters, and it is the whole reason to write the chunk; the
 /// rest is filled in so the layout is the one those programs parse.
+///
+/// StopTime is written equal to StartTime here — nothing is over yet at
+/// header-build time — and [`IqWavWriter::finish`] patches the real value in
+/// afterward, the same way it already patches the RIFF/data sizes. Written
+/// out as two full `SYSTEMTIME`s up front rather than left zeroed, so a
+/// reader that opens the file mid-capture (or one that never gets a
+/// `finish()` at all, on a hard crash) still sees an internally consistent
+/// pair, just an as-yet-unfinished one, rather than an obviously-wrong
+/// all-zero stop time.
 fn auxi_payload(center_hz: f64) -> Vec<u8> {
     let mut b = Vec::with_capacity(164);
-    let now = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .unwrap_or_default()
-        .as_secs();
-    let st = systemtime_fields(now);
+    let st = systemtime_fields(now_unix_secs());
     for _ in 0..2 {
         for v in st {
             b.extend_from_slice(&v.to_le_bytes());
@@ -454,6 +491,41 @@ mod tests {
         let at = info.data_start as usize;
         assert_eq!(f32::from_le_bytes(raw[at..at + 4].try_into().unwrap()), 0.25);
         assert_eq!(f32::from_le_bytes(raw[at + 4..at + 8].try_into().unwrap()), -0.75);
+        let _ = std::fs::remove_file(&path);
+    }
+
+    /// The real-world bug this exists to catch: a finished capture's `auxi`
+    /// chunk used to report the exact same instant for both `StartTime` and
+    /// `StopTime`, regardless of how much data the file actually held —
+    /// nothing patched `StopTime` at [`IqWavWriter::finish`] the way the
+    /// RIFF/data sizes already were. Confirmed on a real ~14-minute, 12+ GB
+    /// capture: its own `auxi` chunk claimed zero elapsed time, which a
+    /// reader that trusts the chunk rather than the data size sees as an
+    /// empty or otherwise invalid recording.
+    #[test]
+    fn a_finished_capture_records_a_real_stop_time() {
+        let dir = std::env::temp_dir().join(format!("sdroxide-iqwav-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("stoptime.wav");
+        let mut w = IqWavWriter::create(&path, 48_000, 14_074_000.0).unwrap();
+        w.write(&[crate::Complex32::new(0.1, 0.1); 8]).unwrap();
+        // `SYSTEMTIME`'s own resolution here is whole seconds (the
+        // millisecond field is always written as 0) -- real elapsed time is
+        // the only way to tell StartTime and StopTime apart at all.
+        std::thread::sleep(std::time::Duration::from_millis(1100));
+        w.finish().unwrap();
+
+        let raw = std::fs::read(&path).unwrap();
+        let auxi = find_chunk(&raw, b"auxi").expect("auxi chunk");
+        let payload = auxi + 8;
+        let start_time = &raw[payload..payload + 16];
+        let stop_time = &raw[payload + 16..payload + 32];
+        assert_ne!(
+            start_time, stop_time,
+            "StopTime must not be written identical to StartTime -- that is exactly \
+             the bug this test exists to catch: a finished capture whose own header \
+             claims zero elapsed time no matter how much data actually follows it"
+        );
         let _ = std::fs::remove_file(&path);
     }
 


### PR DESCRIPTION
Closes #385.

Two bugs in the `auxi` chunk recorded IQ captures write (`crates/sdroxide-radio/src/iq_wav.rs`), both of which caused WavViewDX to refuse a real recording outright rather than mis-render it.

## 1. `StopTime` was never patched at `finish()`

`auxi_payload()` captures "now" once, when the header is written at recording start, and writes that same value into both the `StartTime` and `StopTime` `SYSTEMTIME` slots. `finish()` — the one place that seeks back and corrects anything once the real size is known — only ever patched the RIFF/data/ds64 sizes; nothing touched the `auxi` chunk. Confirmed on a real ~14-minute, 12+ GB capture: its own `auxi` chunk claimed zero elapsed time, byte for byte identical `StartTime`/`StopTime`.

Fixed by threading the `StopTime` field's own byte offset out of `header_bytes()` (`auxi_stop_time_at`, alongside the existing `data_size_at`) so `finish()` can seek to it and write a freshly-captured `SYSTEMTIME` the same way it already patches the sizes.

## 2. The `auxi` chunk was only 64 of its real 164 bytes

Decoding a real HDSDR capture byte-for-byte shows its `auxi` chunk is 164 bytes: two `SYSTEMTIME`s, nine `u32` tuning fields, then a 96-byte NUL-terminated "next file" name. This code's own chunk stopped at 64 bytes — the two `SYSTEMTIME`s plus eight `u32` fields — never writing the trailing name buffer at all. A chunk's declared size is what a reader steps through it by; stopping 100 bytes short of a declared 164 sends a reader that trusts the shape 100 bytes past the real payload into whatever chunk comes next.

Rebuilt `auxi_payload()` to the real 164-byte shape, and filled in the A/D sample rate and bandwidth fields (previously left at zero) now that the chunk was being rebuilt anyway.

## Verification

- New regression test `a_finished_capture_records_a_real_stop_time` — confirmed it actually catches the StopTime regression (reverted the fix, reran, failed as expected; restored).
- New regression test `the_auxi_chunk_is_the_real_164_byte_shape` — confirmed it catches the size regression (reverted the fix, reran, failed with `left: 64, right: 164`; restored).
- `cargo test -p sdroxide-radio --lib` clean.
- `cargo build --workspace` clean, no new warnings.
- `cargo clippy -p sdroxide-radio --all-targets` — zero warnings in `iq_wav.rs`.
- Confirmed on real hardware: a recording made with both fixes applied imports into WavViewDX with no issues, where the same recorder previously produced a file WavViewDX refused outright.
