### PR TITLE
SpyServer: revert the flat 44 dB for 8-bit HF+ streams and close the loop on the digital gain instead

### DIFF
--- a/crates/sdroxide-spyserver/examples/spyserver_level.rs
+++ b/crates/sdroxide-spyserver/examples/spyserver_level.rs
@@ -1,0 +1,93 @@
+//! Pull I/Q from a SpyServer through the real client — framer, decoder, ring —
+//! and report the level it arrives at, so one format or gain setting can be
+//! held against another with nothing of the engine in the way.
+//!
+//! `cargo run --release --example spyserver_level -- host:port FORMAT GAIN [SECS] [HZ] [nofft]`
+//!
+//! `FORMAT` is `8`, `16` or `32`; `GAIN` is `auto` or a digital gain in dB.
+//! `HZ` is where to tune, and it matters: how much headroom an 8-bit stream has
+//! is a property of the band, not of the receiver, so a figure measured on one
+//! band says nothing about another. The FFT lane is on unless `nofft` is given,
+//! to match an ordinary session.
+
+use std::time::{Duration, Instant};
+
+use sdroxide_spyserver::SpyServerHandle;
+use sdroxide_types::{SpyServerConfig, SpyServerFormat};
+
+fn main() {
+    // `RUST_LOG` if set, `info` otherwise. `sdroxide_spyserver::net=debug` is
+    // the one that shows the digital-gain loop's steps.
+    let filter = tracing_subscriber::EnvFilter::try_from_default_env()
+        .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("info"));
+    tracing_subscriber::fmt().with_env_filter(filter).with_writer(std::io::stderr).init();
+
+    let a: Vec<String> = std::env::args().collect();
+    let address = a.get(1).cloned().unwrap_or_else(|| "127.0.0.1:5555".into());
+    let format = match a.get(2).map(String::as_str) {
+        Some("16") => SpyServerFormat::Int16,
+        Some("32") => SpyServerFormat::Float32,
+        _ => SpyServerFormat::Uint8,
+    };
+    let gain = a.get(3).cloned().unwrap_or_else(|| "auto".into());
+    let seconds: f64 = a.get(4).and_then(|s| s.parse().ok()).unwrap_or(5.0);
+    let center: f64 = a.get(5).and_then(|s| s.parse().ok()).unwrap_or(1_081_400.0);
+    let fft = !a.iter().any(|s| s == "nofft");
+    let (auto_digital_gain, digital_gain_db) =
+        if gain == "auto" { (true, 0.0) } else { (false, gain.parse().expect("gain in dB")) };
+
+    let cfg = SpyServerConfig {
+        address,
+        iq_format: format,
+        iq_decimation: 0,
+        auto_digital_gain,
+        digital_gain_db,
+        fft_enabled: fft,
+        ..SpyServerConfig::default()
+    };
+    let mut h = SpyServerHandle::connect_wideband(&cfg, center).expect("connect");
+    eprintln!("{}", h.label);
+
+    // |v| buckets: <1e-4, <1e-3, <1e-2, <0.1, <0.5, <1, <10, >=10.
+    let mut hist = [0usize; 8];
+    let mut buf = vec![0f32; 1 << 16];
+    let (mut total, mut max, mut sumsq, mut nonfinite) = (0usize, 0f32, 0f64, 0usize);
+    let start = Instant::now();
+    while start.elapsed() < Duration::from_secs_f64(seconds) {
+        let n = h.rx_read(&mut buf);
+        if n == 0 {
+            std::thread::sleep(Duration::from_millis(2));
+            continue;
+        }
+        for &v in &buf[..n] {
+            if !v.is_finite() {
+                nonfinite += 1;
+                continue;
+            }
+            let m = v.abs();
+            max = max.max(m);
+            sumsq += f64::from(v) * f64::from(v);
+            let b =
+                [1e-4, 1e-3, 1e-2, 0.1, 0.5, 1.0, 10.0].iter().position(|&t| m < t).unwrap_or(7);
+            hist[b] += 1;
+        }
+        total += n;
+    }
+    let secs = start.elapsed().as_secs_f64();
+    println!(
+        "format={format:?} gain={gain} fft={fft} alive={} silent_for={:.2?}",
+        h.is_alive(),
+        h.silent_for()
+    );
+    println!(
+        "pairs={} ({:.1} ksps over {secs:.2} s)  max|v|={max:.5}  rms={:.5}  non-finite={nonfinite}",
+        total / 2,
+        (total / 2) as f64 / secs / 1e3,
+        (sumsq / total.max(1) as f64).sqrt(),
+    );
+    println!(
+        "|v|: <1e-4 {}  <1e-3 {}  <1e-2 {}  <0.1 {}  <0.5 {}  <1 {}  <10 {}  >=10 {}",
+        hist[0], hist[1], hist[2], hist[3], hist[4], hist[5], hist[6], hist[7]
+    );
+    h.release();
+}

--- a/crates/sdroxide-spyserver/src/decode.rs
+++ b/crates/sdroxide-spyserver/src/decode.rs
@@ -43,14 +43,19 @@ pub fn iq_to_f32(format: SpyServerFormat, body: &[u8], gain: f32, out: &mut Vec<
             }
         }
         SpyServerFormat::Float32 => {
-            // Deliberately a multiply, matching the reference client. Float
-            // samples arrive already normalised and *pre-attenuated* by the
-            // server's digital gain rather than scaled up by it, so undoing it
-            // goes the other way from the integer formats above. Turning this
-            // into a divide "for consistency" is the mistake to avoid: it is
-            // silent, and it lands the level out by twice the gain.
+            // A divide, like the integer formats — and *not* what SDR++ does.
+            // Its client multiplies floats by the header gain on the belief
+            // that the server pre-attenuates them, and this branch used to copy
+            // that. Measured against a real server it is the other way round:
+            // a float stream asked for 20 dB arrives with header flags of 20
+            // and its samples ten times larger — the same raw values as the
+            // int16 stream at 20 dB, noise floor 20 dB up. So the multiply
+            // applied the gain twice. Nobody notices at 0 dB, which is what an
+            // undecimated stream opens at; with the gain set by hand, or by
+            // the client's own loop, it is hard clipping.
+            let scale = 1.0 / gain;
             for w in body[..whole].chunks_exact(4) {
-                out.push(f32::from_le_bytes([w[0], w[1], w[2], w[3]]) * gain);
+                out.push(f32::from_le_bytes([w[0], w[1], w[2], w[3]]) * scale);
             }
         }
     }
@@ -110,9 +115,12 @@ mod tests {
         assert_eq!(out[2], 0.5);
     }
 
-    /// The header's gain is undone, and the float path goes the *other way*
-    /// from the integer ones. Asserted against literals precisely so that a
-    /// divide slipping into the float branch is caught.
+    /// The header's gain is undone the same way in every format. The float
+    /// path used to multiply instead — copied from SDR++, on the belief that
+    /// the server pre-attenuates floats — and a real server amplifies them
+    /// exactly as it does the integers, so that applied the gain twice.
+    /// Asserted against literals precisely so that a multiply slipping back
+    /// into the float branch is caught.
     #[test]
     fn the_digital_gain_in_the_flags_is_undone_per_format() {
         // 20 dB is a linear factor of ten.
@@ -126,9 +134,11 @@ mod tests {
         iq_to_f32(SpyServerFormat::Int16, &body, gain, &mut out);
         assert!((out[0] - 0.05).abs() < 1e-6, "16-bit divides by the gain");
 
-        let body: Vec<u8> = [0.05f32, 0.0].iter().flat_map(|v| v.to_le_bytes()).collect();
+        // The same 0.5 full scale, as the server sends it after 20 dB of gain:
+        // a float of 0.5, which has to come out as the 0.05 the int16 did.
+        let body: Vec<u8> = [0.5f32, 0.0].iter().flat_map(|v| v.to_le_bytes()).collect();
         iq_to_f32(SpyServerFormat::Float32, &body, gain, &mut out);
-        assert!((out[0] - 0.5).abs() < 1e-6, "float MULTIPLIES by the gain");
+        assert!((out[0] - 0.05).abs() < 1e-6, "float divides by the gain too");
 
         // A gain of unity is the identity in every format.
         iq_to_f32(SpyServerFormat::Uint8, &[255, 128], 1.0, &mut out);

--- a/crates/sdroxide-spyserver/src/net.rs
+++ b/crates/sdroxide-spyserver/src/net.rs
@@ -71,6 +71,35 @@ const RETUNE_MIN_INTERVAL: Duration = Duration::from_millis(125);
 /// what actually catches a dead link is `SpyServerHandle::silent_for`.
 const PING_INTERVAL: Duration = Duration::from_secs(3);
 
+/// Where the digital-gain loop parks the peak of an 8-bit stream: half of
+/// full scale, so 6 dB of headroom for whatever turns on next. See
+/// [`maintain_digital_gain`].
+const GAIN_TARGET_PEAK: f32 = 0.5;
+
+/// A peak at or above this is a rail, and a rail means the quantiser is being
+/// driven past full scale rather than merely close to it.
+const GAIN_CLIP_PEAK: f32 = 0.98;
+
+/// Corrections smaller than this are not worth a setting on the wire: the
+/// gain goes out as whole dB, so a tighter deadband is a client that hunts.
+const GAIN_DEADBAND_DB: f64 = 3.0;
+
+/// The most one step may add. Coming down is not limited — a clipped stream
+/// is already carrying nothing, and dawdling about it costs seconds of audio.
+const GAIN_STEP_UP_DB: f64 = 3.0;
+
+/// The floor between gain changes. The server takes about eight settings a
+/// second in total and the retune lane is already spending some of them; it
+/// is also how long the last figure gets to reach the samples before they are
+/// judged against it.
+const GAIN_MIN_INTERVAL: Duration = Duration::from_millis(250);
+
+/// How long the peak must stay below target before the gain is raised.
+const GAIN_QUIET_BEFORE_RAISE: Duration = Duration::from_secs(2);
+
+/// The ceiling on `IQ_DIGITAL_GAIN`, in dB.
+const GAIN_MAX_DB: f64 = 60.0;
+
 /// Bins to ask the server for.
 ///
 /// Matched to the engine's `DISPLAY_BINS`, which is what the full-band strip
@@ -155,6 +184,10 @@ pub(crate) fn probe(cfg: &SpyServerConfig, timeout: Duration) -> Result<(DeviceI
         gain_index: 0,
         auto_digital_gain: true,
         digital_gain_db: 0.0,
+        servo_db: 0.0,
+        peak_fraction: None,
+        last_gain_move: Instant::now(),
+        quiet_since: None,
         fft_enabled: false,
         fft_stage: 0,
         fft_span: 0.0,
@@ -265,7 +298,24 @@ struct Client {
     gain_index: u32,
 
     auto_digital_gain: bool,
+    /// The operator's own figure, in dB, for when automatic is off.
     digital_gain_db: f64,
+    /// The digital gain the loop has settled on, in dB. Only an 8-bit stream
+    /// in automatic runs the loop — see [`Client::loop_runs`] — and this is
+    /// where it starts from: the reference formula's figure.
+    servo_db: f64,
+    /// The largest sample since the loop last looked, as a fraction of full
+    /// scale: one is a rail. `None` is nothing having arrived, which is not
+    /// the same thing as `Some(0.0)` — that is a stream of mid-scale having
+    /// arrived, and it is the strongest possible case for more gain.
+    peak_fraction: Option<f32>,
+    /// When a digital gain last went out, whoever sent it. The loop waits on
+    /// this before judging the samples, so that they are the ones that figure
+    /// made rather than the ones already in flight when it was sent.
+    last_gain_move: Instant,
+    /// Since when the peak has been continuously below target. Raising the
+    /// gain waits on this so a pause in the traffic does not pump it up.
+    quiet_since: Option<Instant>,
 
     fft_enabled: bool,
     fft_stage: u32,
@@ -318,6 +368,11 @@ impl Client {
             gain_index: cfg.gain_index,
             auto_digital_gain: cfg.auto_digital_gain,
             digital_gain_db: cfg.digital_gain_db,
+            // Overwritten in `plan`, once the stage is known.
+            servo_db: 0.0,
+            peak_fraction: None,
+            last_gain_move: Instant::now(),
+            quiet_since: None,
             fft_enabled: cfg.fft_enabled,
             fft_stage: cfg.fft_decimation,
             fft_span: 0.0,
@@ -466,6 +521,7 @@ impl Client {
         // The FFT starts where the dial is, clamped into whatever room the
         // window has beside the device centre.
         self.fft_center = self.clamped_fft_center(self.center);
+        self.reset_servo();
     }
 
     /// Send the whole configuration, in the order the protocol wants it.
@@ -530,19 +586,47 @@ impl Client {
             if self.fft_enabled { proto::STREAM_MODE_FFT_IQ } else { proto::STREAM_MODE_IQ_ONLY };
         self.set(proto::SETTING_STREAMING_MODE, mode)?;
         self.set(proto::SETTING_GAIN, self.gain_index)?;
-        self.set(proto::SETTING_IQ_DIGITAL_GAIN, self.digital_gain_wire())?;
+        self.send_digital_gain()?;
         self.set(proto::SETTING_STREAMING_ENABLED, 1)
     }
 
-    /// The digital gain to ask for: computed from the device and the stage, or
-    /// whatever the operator pinned it to.
+    /// The digital gain to ask for: what the loop has settled on for an 8-bit
+    /// stream, the reference formula for anything wider, or whatever the
+    /// operator pinned it to.
     fn digital_gain_wire(&self) -> u32 {
-        let db = if self.auto_digital_gain {
-            self.info.digital_gain_db(self.gain_index, self.iq_stage, self.iq_format)
-        } else {
+        let db = if !self.auto_digital_gain {
             self.digital_gain_db
+        } else if self.loop_runs() {
+            self.servo_db
+        } else {
+            self.info.digital_gain_db(self.gain_index, self.iq_stage)
         };
-        db.round().clamp(0.0, 60.0) as u32
+        db.round().clamp(0.0, GAIN_MAX_DB) as u32
+    }
+
+    /// Whether the closed loop is the authority on the digital gain: only an
+    /// 8-bit stream in automatic. Everything wider has 48 dB of room it will
+    /// never need, and moving its gain would spend the server's settings
+    /// budget for nothing in the samples. The operator's manual figure is
+    /// never touched — automatic off means a number was typed.
+    fn loop_runs(&self) -> bool {
+        self.auto_digital_gain && self.iq_format == SpyServerFormat::Uint8
+    }
+
+    /// Send the digital gain, and note when, so the loop does not judge
+    /// samples the new figure has not reached yet.
+    fn send_digital_gain(&mut self) -> Result<()> {
+        self.last_gain_move = Instant::now();
+        self.set(proto::SETTING_IQ_DIGITAL_GAIN, self.digital_gain_wire())
+    }
+
+    /// Put the loop back at its starting point and forget its evidence. For
+    /// wherever its basis moves: a fresh connection, the gain index on an R2,
+    /// automatic being switched on.
+    fn reset_servo(&mut self) {
+        self.servo_db = self.info.digital_gain_db(self.gain_index, self.iq_stage);
+        self.peak_fraction = None;
+        self.quiet_since = None;
     }
 
     fn set(&mut self, setting: u32, value: u32) -> Result<()> {
@@ -779,11 +863,14 @@ fn apply(client: &mut Client, p: &Pending) -> Result<()> {
         if let Some(v) = p.digital_gain {
             client.digital_gain_db = v;
         }
+        // The loop's starting point moves with the gain index on an R2, and a
+        // loop that has just been switched on has no evidence yet.
+        client.reset_servo();
         // Always resent alongside the gain index, never on its own. On an
         // Airspy R2 the computed digital gain is a function of the gain index,
         // so sending one without the other leaves the level wrong by as much
         // as the whole gain range.
-        client.set(proto::SETTING_IQ_DIGITAL_GAIN, client.digital_gain_wire())?;
+        client.send_digital_gain()?;
     }
     Ok(())
 }
@@ -845,6 +932,77 @@ fn move_fft_window(client: &mut Client) -> Result<()> {
     client.set(proto::SETTING_FFT_FREQUENCY, proto::freq_wire(target))
 }
 
+/// Walk the digital gain towards a peak that fits, on the evidence of what has
+/// arrived since the last look.
+///
+/// Only an 8-bit stream in automatic — see [`Client::loop_runs`]. Nothing the
+/// loop does is visible in the level: the decoder divides by the gain the
+/// *header* states, so a stream whose gain changed mid-flight comes out at the
+/// same amplitude either side of the change. What moves is how many of the
+/// eight bits the signal is using, and that is the whole point. How much gain
+/// a band needs is a property of the band — a dead 20 m and 80 m at night are
+/// thirty decibels apart — so no fixed figure serves both, and the one that was
+/// tried clipped every band that had a signal on it.
+///
+/// Asymmetric on purpose. Down is immediate and as far as the peak says: a
+/// clipped stream is carrying nothing, and every message spent on it is lost
+/// audio. A rail hides how far past full scale it is, so a clipped stream comes
+/// down a step at a time — 6 dB, what would put a rail on target — and the next
+/// step sees an honest peak the moment the rail lets go. Up is slow and small:
+/// only after the peak has sat below target for [`GAIN_QUIET_BEFORE_RAISE`],
+/// and by no more than [`GAIN_STEP_UP_DB`], so a pause in the traffic is not
+/// mistaken for room and the next syllable does not land on a rail.
+fn maintain_digital_gain(client: &mut Client) -> Result<()> {
+    if !client.loop_runs() {
+        return Ok(());
+    }
+    // Nothing arrived is not an argument for anything. A stream of mid-scale
+    // is: that is `Some(0.0)`, and the strongest case there is for more gain.
+    let Some(peak) = client.peak_fraction.take() else {
+        return Ok(());
+    };
+
+    // The move that would put this peak on target. Positive is room to spare;
+    // infinite when nothing in the stream cleared mid-scale, which the step
+    // limit below makes finite.
+    let want = 20.0 * f64::from(GAIN_TARGET_PEAK / peak).log10();
+    if want > 0.0 {
+        // Room to spare. Wait for it to be a settled fact rather than a gap in
+        // the traffic, and then take it a step at a time.
+        let quiet = *client.quiet_since.get_or_insert_with(Instant::now);
+        if quiet.elapsed() < GAIN_QUIET_BEFORE_RAISE || want < GAIN_DEADBAND_DB {
+            return Ok(());
+        }
+    } else {
+        client.quiet_since = None;
+        if peak < GAIN_CLIP_PEAK && -want < GAIN_DEADBAND_DB {
+            return Ok(());
+        }
+    }
+    if client.last_gain_move.elapsed() < GAIN_MIN_INTERVAL {
+        // The last figure may not have reached these samples yet. Judging
+        // them against it would take the same step twice.
+        return Ok(());
+    }
+
+    let step = want.min(GAIN_STEP_UP_DB);
+    let next = (client.servo_db + step).round().clamp(0.0, GAIN_MAX_DB);
+    if next == client.servo_db.round() {
+        // Already against a stop. Saying so again costs a setting.
+        return Ok(());
+    }
+    tracing::debug!(
+        "SpyServer {}: 8-bit peak at {:.0} % of full scale, digital gain {:.0} -> {:.0} dB",
+        client.endpoint,
+        peak * 100.0,
+        client.servo_db,
+        next,
+    );
+    client.servo_db = next;
+    client.quiet_since = None;
+    client.send_digital_gain()
+}
+
 /// Everything one completed message does.
 #[allow(clippy::too_many_arguments)]
 fn on_message(
@@ -862,6 +1020,18 @@ fn on_message(
         proto::MSG_UINT8_IQ | proto::MSG_INT16_IQ | proto::MSG_FLOAT_IQ => {
             let pairs = iq_to_f32(client.iq_format, body, h.digital_gain(), iq_scratch);
             if pairs > 0 {
+                if client.loop_runs() {
+                    // The peak as a fraction of full scale, which is what the
+                    // loop needs and what the decoder has just divided out:
+                    // the samples are `raw / (gain * full scale)`, so putting
+                    // the gain back gives the raw fraction, in any format.
+                    // The *header's* gain — what the server did — so a message
+                    // from before the last change still reports where its own
+                    // bytes sat.
+                    let peak = iq_scratch.iter().fold(0f32, |m, v| m.max(v.abs()));
+                    let peak = peak * h.digital_gain();
+                    client.peak_fraction = Some(client.peak_fraction.map_or(peak, |p| p.max(peak)));
+                }
                 client.note_sequence(h.sequence, stats);
                 stats.on_iq(pairs);
                 push_iq(rx, iq_scratch, stats, shared.rx_paused.load(Ordering::Relaxed));
@@ -963,6 +1133,7 @@ fn pump(
         }
         flush_retune(client, shared)?;
         maintain_fft(client)?;
+        maintain_digital_gain(client)?;
         if client.last_ping.elapsed() >= PING_INTERVAL {
             client.last_ping = Instant::now();
             client.ping()?;

--- a/crates/sdroxide-spyserver/src/proto.rs
+++ b/crates/sdroxide-spyserver/src/proto.rs
@@ -221,8 +221,10 @@ pub struct DeviceInfo {
     pub maximum_gain_index: u32,
     pub minimum_frequency: u32,
     pub maximum_frequency: u32,
-    /// ADC bits, as the server counts them. Feeds the digital-gain formula and
-    /// nothing else.
+    /// ADC bits, as the server counts them — 16 or 18 for an Airspy HF+, 8 for
+    /// an RTL-SDR. Shown in [`Self::describe`] and used for nothing else: it
+    /// is the width of the ADC, not of the wire, and keying a wire decision on
+    /// it is a mistake that has been made here once already.
     pub resolution: u32,
     pub minimum_iq_decimation: u32,
     /// A format the server insists on, or 0 for "take your pick".
@@ -309,52 +311,38 @@ impl DeviceInfo {
             .unwrap_or(self.minimum_iq_decimation)
     }
 
-    /// The digital gain to ask for, in dB, given the server's gain index, the
-    /// I/Q decimation stage, and the format the samples will be sent in.
+    /// The digital gain to open with, in dB, given the server's gain index and
+    /// the I/Q decimation stage.
     ///
-    /// Every decimation stage halves the bandwidth and so buys about 3 dB of
-    /// processing gain that would otherwise be thrown away when the samples
-    /// are quantised for the wire. That part, and the Airspy R2's, are what
-    /// SDR++'s client computes:
+    /// This is the reference client's formula and deliberately nothing more:
     ///
+    /// * Every decimation stage halves the bandwidth and so buys about 3 dB of
+    ///   processing gain that would otherwise be thrown away when the samples
+    ///   are quantised for the wire.
     /// * An Airspy R2's gain index counts *down* from its maximum, so a low
     ///   index means a quiet signal that needs the headroom back.
     ///
-    /// The HF+ part is not from there — SDR++ gives it decimation gain only —
-    /// it is from measuring what an HF+ actually puts on the wire as **8-bit**.
-    /// Its analog dynamic range is so large that on a quiet band its I/Q sits
-    /// below one eighth-bit LSB: at 0 dB a real one over SpyServer sent
-    /// *three* distinct sample values (mid-scale 97.7 % of the time, ±1 for
-    /// the rest), and the spectrum of that is a flat slicer-noise floor 23 dB
-    /// above the receiver's own with a dip at DC, which reads on screen as a
-    /// band that is quiet only where the dial is.
+    /// The wire format is not an input, and the signature refuses it on
+    /// purpose. An 8-bit stream from an Airspy HF+ used to get a flat 44 dB on
+    /// top of this, because on a quiet band the HF+'s I/Q sits below one
+    /// eighth-bit LSB and arrives as three distinct sample values. The boost is
+    /// gone: how much gain a band needs is a property of the *band*, and 44 dB
+    /// measured on a dead one drove the quantiser twenty-odd dB past full
+    /// scale on every band with a signal on it. Every sample came back a rail
+    /// and the stream carried nothing — the same figures on 80 m, 40 m and
+    /// 20 m alike, which reads on screen as a receiver gone deaf.
     ///
-    /// How much is enough was swept against a 16-bit capture of the same band,
-    /// floor by distance from the centre. At 32 dB the noise is ±2 LSB and the
-    /// quantiser is still a nonlinearity rather than a noise source: the floor
-    /// rose 3.4 dB towards the band edges and filled the receiver's roll-off
-    /// beyond ±330 kHz 14 dB above the truth — a bathtub on the panadapter. At
-    /// 38 dB, 1 dB and 8 dB. At 44 dB the passband matched 16-bit to 0.1 dB
-    /// and the roll-off to 3 dB, with the strongest signal in the band at 20
-    /// of 127 — 16 dB of headroom. 50 dB bought another 2 dB in the roll-off
-    /// for 6 dB of headroom, so 44 it is. The boost is keyed on the *stream*
-    /// being 8-bit and on nothing else: `resolution` is the ADC's width as the
-    /// server reports it — 16 or 18 for an HF+ — and keying on that instead
-    /// is what left the boost never applied. A 16-bit stream has 48 dB more
-    /// room and needs none of this; it is also the answer for a band with a
-    /// station strong enough to clip eight bits at this gain.
-    pub fn digital_gain_db(
-        &self,
-        gain_index: u32,
-        decimation_stage: u32,
-        format: SpyServerFormat,
-    ) -> f64 {
+    /// The quiet-band problem is real and is not solved here. It cannot be: a
+    /// constant cannot be right for both a dead 20 m and a crowded 80 m at
+    /// night, which are 30 dB apart. It belongs to the closed loop in the
+    /// client that watches what actually arrives — `maintain_digital_gain` in
+    /// `net.rs` — and this figure is only where that loop starts from.
+    pub fn digital_gain_db(&self, gain_index: u32, decimation_stage: u32) -> f64 {
         let stage_gain = f64::from(decimation_stage) * 3.01;
         match self.kind() {
             DeviceKind::AirspyOne => {
                 f64::from(self.maximum_gain_index.saturating_sub(gain_index)) + stage_gain
             }
-            DeviceKind::AirspyHf if format == SpyServerFormat::Uint8 => 44.0 + stage_gain,
             _ => stage_gain,
         }
     }
@@ -364,8 +352,8 @@ impl DeviceInfo {
     /// `MaximumBandwidth` wherever a server states one, because that is the
     /// analog passband and everything between it and the sample rate is
     /// roll-off. On an Airspy HF+ the two are 660 kHz and 768 kHz, and the
-    /// 54 kHz either side of the difference is the same roll-off
-    /// [`Self::digital_gain_db`] swept the noise floor climbing into.
+    /// 54 kHz either side of the difference is where the noise floor climbs
+    /// and nothing is received.
     ///
     /// Guarded rather than trusted. A server that leaves the field at zero
     /// would otherwise read as a receiver that hears nothing, which would pin
@@ -751,45 +739,41 @@ mod tests {
         assert_eq!(r2.stage_for_rate(1.0, false), 8);
     }
 
-    /// Each branch of the formula, including the HF+ baseline that applies to
-    /// an 8-bit *stream* — and to nothing else.
+    /// Each branch of the formula, which is the reference client's and no more.
     #[test]
     fn the_digital_gain_formula_matches_the_reference() {
-        use SpyServerFormat::{Int16, Uint8};
-
         // Airspy R2: the index counts down from the maximum.
         let r2 = airspy_r2();
-        assert!((r2.digital_gain_db(21, 0, Uint8) - 0.0).abs() < 1e-9, "full gain needs no help");
-        assert!((r2.digital_gain_db(0, 0, Uint8) - 21.0).abs() < 1e-9);
-        assert!((r2.digital_gain_db(21, 4, Uint8) - 12.04).abs() < 1e-9, "four stages of 3.01 dB");
+        assert!((r2.digital_gain_db(21, 0) - 0.0).abs() < 1e-9, "full gain needs no help");
+        assert!((r2.digital_gain_db(0, 0) - 21.0).abs() < 1e-9);
+        assert!((r2.digital_gain_db(21, 4) - 12.04).abs() < 1e-9, "four stages of 3.01 dB");
 
-        // HF+ sending 16-bit: decimation only, there is room to spare.
-        let hf = hf_plus();
-        assert!((hf.digital_gain_db(4, 3, Int16) - 9.03).abs() < 1e-9);
+        // HF+: decimation only. The reference client gives it nothing else,
+        // and neither does this.
+        assert!((hf_plus().digital_gain_db(4, 3) - 9.03).abs() < 1e-9);
 
-        // The same HF+ sending 8-bit: 44 dB of baseline on top.
-        assert!((hf.digital_gain_db(4, 3, Uint8) - 53.03).abs() < 1e-9);
-
-        // RTL-SDR: decimation only, whatever the format.
-        assert!((rtlsdr().digital_gain_db(28, 2, Uint8) - 6.02).abs() < 1e-9);
-        assert!((rtlsdr().digital_gain_db(28, 2, Int16) - 6.02).abs() < 1e-9);
+        // RTL-SDR: the same.
+        assert!((rtlsdr().digital_gain_db(28, 2) - 6.02).abs() < 1e-9);
     }
 
-    /// The boost is keyed on the stream, not on the ADC width the server
-    /// reports. A real HF+ server says 16 (the fixture above says 18; neither
-    /// is ever 8), and keying on that left an 8-bit stream at 0 dB — three
-    /// distinct sample values, and a noise floor 23 dB above the receiver's.
+    /// Nothing about the receiver's own description moves the figure: not the
+    /// ADC width it reports, not the gain index on a receiver that has none. A
+    /// constant boost for an HF+'s 8-bit stream was tried and reverted — it
+    /// clipped the quantiser flat on every band that had a signal on it, and
+    /// the symptom, identical levels on every band, reads as a dead receiver
+    /// rather than an overdriven one. Whatever an HF+ needs on a quiet band is
+    /// the closed loop's to find, not this table's to guess.
     #[test]
-    fn an_hf_plus_gets_its_eight_bit_boost_whatever_resolution_the_server_claims() {
+    fn an_hf_plus_opens_at_decimation_gain_alone_whatever_the_server_says_about_itself() {
         for resolution in [8, 16, 18] {
             let hf = DeviceInfo { resolution, ..hf_plus() };
             assert!(
-                (hf.digital_gain_db(0, 0, SpyServerFormat::Uint8) - 44.0).abs() < 1e-9,
-                "an 8-bit stream from an HF+ reporting {resolution}-bit needs the boost"
+                hf.digital_gain_db(0, 0).abs() < 1e-9,
+                "an HF+ reporting {resolution}-bit opens at nothing at stage 0"
             );
             assert!(
-                hf.digital_gain_db(0, 0, SpyServerFormat::Int16).abs() < 1e-9,
-                "a 16-bit stream from an HF+ reporting {resolution}-bit does not"
+                (hf.digital_gain_db(0, 4) - 12.04).abs() < 1e-9,
+                "and at four stages of 3.01 dB at stage 4"
             );
         }
     }

--- a/crates/sdroxide-spyserver/tests/spyserver.rs
+++ b/crates/sdroxide-spyserver/tests/spyserver.rs
@@ -79,6 +79,10 @@ struct Spec {
     device_center: u32,
     /// Send an 8-bit I/Q burst once the stream is enabled.
     stream_iq: bool,
+    /// The byte both components of every 8-bit I/Q sample carry, and the whole
+    /// dB the header claims was applied to them. `None` keeps the burst the
+    /// framing tests want: mid-scale and both extremes.
+    iq_fill: Option<(u8, u16)>,
     /// Send an 8-bit FFT frame once the stream is enabled.
     stream_fft: bool,
 }
@@ -100,6 +104,7 @@ impl Default for Spec {
             can_control: 1,
             device_center: 100_000_000,
             stream_iq: false,
+            iq_fill: None,
             stream_fft: false,
         }
     }
@@ -256,14 +261,13 @@ impl Fake {
                 if streaming {
                     let mut out = Vec::new();
                     if spec.stream_iq {
-                        // Four complex samples: mid-scale, then the extremes.
-                        out.extend_from_slice(&msg(
-                            MSG_UINT8_IQ,
-                            0,
-                            1,
-                            seq,
-                            &[128, 128, 255, 0, 128, 128, 0, 255],
-                        ));
+                        // Four complex samples: mid-scale, then the extremes —
+                        // or whatever byte the test asked to be flooded with.
+                        let (body, flags) = match spec.iq_fill {
+                            Some((byte, db)) => (vec![byte; 8], db),
+                            None => (vec![128, 128, 255, 0, 128, 128, 0, 255], 0),
+                        };
+                        out.extend_from_slice(&msg(MSG_UINT8_IQ, flags, 1, seq, &body));
                     }
                     if spec.stream_fft {
                         let bins: Vec<u8> = (0..64u32).map(|i| (i * 4) as u8).collect();
@@ -610,13 +614,14 @@ fn the_configured_gain_survives_the_servers_opening_sync() {
     assert_eq!(fake.value_of(SETTING_IQ_DIGITAL_GAIN), Some(24));
 }
 
-/// An Airspy HF+ sent as 8-bit needs 44 dB of digital gain or its quiet-band
-/// I/Q arrives as three sample values — and the boost was keyed on the ADC
-/// width the server reports, which for a real HF+ is 16 or 18, never 8, so it
-/// was never sent. It is keyed on the stream format now; the format is the
-/// only thing that decides whether the samples have the room.
+/// An Airspy HF+ gets the reference client's digital gain and nothing more:
+/// decimation gain, and at stage 0 that is nothing at all. A constant boost
+/// keyed on the stream being 8-bit was tried and reverted — the gain a band
+/// needs is a property of the band, and 44 dB drove the quantiser twenty-odd
+/// dB past full scale on every band with a signal on it, which is not a level
+/// error but a stream of rails with no information left in it.
 #[test]
-fn an_hf_plus_sent_as_eight_bit_is_asked_for_its_forty_four_db() {
+fn an_hf_plus_is_asked_for_the_reference_digital_gain_in_either_format() {
     // As a real HF+ server describes itself: 768 ksps, 660 kHz of analog
     // bandwidth, no gain stages, and a 16-bit ADC.
     let hf_plus = Spec {
@@ -643,9 +648,10 @@ fn an_hf_plus_sent_as_eight_bit_is_asked_for_its_forty_four_db() {
     assert!(eventually(Duration::from_secs(2), || fake
         .value_of(SETTING_IQ_DIGITAL_GAIN)
         .is_some()));
-    assert_eq!(fake.value_of(SETTING_IQ_DIGITAL_GAIN), Some(44), "8-bit at stage 0");
+    assert_eq!(fake.value_of(SETTING_IQ_DIGITAL_GAIN), Some(0), "8-bit at stage 0");
 
-    // The same receiver sent as 16-bit has 48 dB more room and gets none of it.
+    // The same receiver sent as 16-bit: the same figure, the format is not
+    // an input.
     let fake = Fake::start(hf_plus);
     let cfg = SpyServerConfig {
         iq_format: SpyServerFormat::Int16,
@@ -658,6 +664,168 @@ fn an_hf_plus_sent_as_eight_bit_is_asked_for_its_forty_four_db() {
         .value_of(SETTING_IQ_DIGITAL_GAIN)
         .is_some()));
     assert_eq!(fake.value_of(SETTING_IQ_DIGITAL_GAIN), Some(0), "16-bit at stage 0");
+}
+
+// --- the digital-gain loop ---------------------------------------------------
+
+/// An HF+ as a real server describes one: 768 ksps, 660 kHz of analog
+/// bandwidth, no gain stages, a 16-bit ADC — streaming whatever byte the test
+/// asks for, with whatever gain the header claims.
+fn hf_plus_streaming(byte: u8, header_db: u16) -> Spec {
+    Spec {
+        device_type: 2,
+        max_rate: 768_000,
+        max_bw: 660_000,
+        stages: 8,
+        min_decim: 0,
+        max_gain: 0,
+        min_freq: 0,
+        max_freq: 1_700_000_000,
+        resolution: 16,
+        stream_iq: true,
+        iq_fill: Some((byte, header_db)),
+        ..Spec::default()
+    }
+}
+
+/// The digital gain is a closed loop on an 8-bit stream: a server sending
+/// rails is a server being driven past full scale, and the client has to back
+/// off rather than divide the wreckage by an ever larger number. Nothing the
+/// loop does shows up in the level — the decoder divides by the gain the
+/// header states, so the samples come out the same amplitude either side of a
+/// change; what moves is how many of the eight bits the signal is using.
+///
+/// It comes down a step at a time rather than in one jump, because a rail
+/// hides how far past full scale it is: a byte pinned at 255 reads the same
+/// 6 dB over as 30 dB over. Each step is what would put a rail at the target,
+/// and the next step sees an honest peak as soon as the rail lets go.
+#[test]
+fn an_eight_bit_stream_that_arrives_clipped_walks_the_digital_gain_down() {
+    let fake = Fake::start(hf_plus_streaming(255, 12));
+    let cfg = SpyServerConfig {
+        // Stage 4, so the reference formula opens at 12 dB and the loop has
+        // somewhere to go. At stage 0 it opens at nothing and the test would
+        // pass without a loop at all.
+        iq_format: SpyServerFormat::Uint8,
+        iq_decimation: 4,
+        auto_digital_gain: true,
+        fft_enabled: false,
+        ..fake.cfg()
+    };
+    let _h = SpyServerHandle::connect_wideband(&cfg, 1_081_400.0).expect("connect");
+
+    assert!(
+        eventually(Duration::from_secs(2), || fake.value_of(SETTING_IQ_DIGITAL_GAIN) == Some(12)),
+        "it opens at the reference formula's figure"
+    );
+    assert!(
+        eventually(Duration::from_secs(5), || fake
+            .values_of(SETTING_IQ_DIGITAL_GAIN)
+            .last()
+            .copied()
+            == Some(0)),
+        "the rails never walked it down to the floor: {:?}",
+        fake.values_of(SETTING_IQ_DIGITAL_GAIN)
+    );
+    // 6 dB a step: a rail at full scale, brought to the target of half.
+    assert_eq!(fake.values_of(SETTING_IQ_DIGITAL_GAIN), vec![12, 6, 0]);
+
+    // And at the floor it stops asking. Repeating a figure the server already
+    // has costs one of the eight settings a second it will take.
+    std::thread::sleep(Duration::from_millis(600));
+    assert_eq!(fake.values_of(SETTING_IQ_DIGITAL_GAIN), vec![12, 6, 0], "still at the stop");
+}
+
+/// The other half of the loop, and the reason it exists at all: on a quiet
+/// band an HF+'s 8-bit I/Q sits below one LSB and arrives as mid-scale, every
+/// sample, which is no information at all. That stream *has* arrived, and it
+/// is the strongest possible argument for more gain — a loop that read an
+/// all-zero peak as "nothing to judge by" would leave the band dead forever.
+///
+/// It goes up slowly: a step at a time, and only after the peak has been below
+/// target for a whole two seconds, so a pause in the traffic does not pump the
+/// gain up for the next syllable to clip on.
+#[test]
+fn an_eight_bit_stream_that_arrives_below_one_lsb_walks_the_digital_gain_up_slowly() {
+    let fake = Fake::start(hf_plus_streaming(128, 0));
+    let cfg = SpyServerConfig {
+        iq_format: SpyServerFormat::Uint8,
+        iq_decimation: 0,
+        auto_digital_gain: true,
+        fft_enabled: false,
+        ..fake.cfg()
+    };
+    let _h = SpyServerHandle::connect_wideband(&cfg, 14_100_000.0).expect("connect");
+    assert!(
+        eventually(Duration::from_secs(2), || fake.value_of(SETTING_IQ_DIGITAL_GAIN) == Some(0))
+    );
+
+    // Not yet: room to spare has to be a settled fact before it is acted on.
+    std::thread::sleep(Duration::from_millis(1000));
+    assert_eq!(fake.values_of(SETTING_IQ_DIGITAL_GAIN), vec![0], "raised before the quiet time");
+
+    assert!(
+        eventually(Duration::from_secs(4), || fake
+            .values_of(SETTING_IQ_DIGITAL_GAIN)
+            .last()
+            .copied()
+            == Some(3)),
+        "a stream of mid-scale never raised the gain: {:?}",
+        fake.values_of(SETTING_IQ_DIGITAL_GAIN)
+    );
+    // One step, not a leap, however far below target the peak is.
+    assert_eq!(fake.values_of(SETTING_IQ_DIGITAL_GAIN), vec![0, 3]);
+}
+
+/// The loop is for 8-bit streams and nothing else. A 16-bit one has 48 dB of
+/// room it will never need, and moving its gain would spend the server's
+/// settings budget for no gain in the samples.
+///
+/// The fake still sends 8-bit messages here, on purpose: the client reads the
+/// body in the format it *asked* for, so what the bytes mean is beside the
+/// point — what matters is that a stream is flowing and the loop leaves it be.
+#[test]
+fn a_sixteen_bit_stream_is_left_at_the_reference_figure() {
+    let fake = Fake::start(hf_plus_streaming(255, 12));
+    let cfg = SpyServerConfig {
+        iq_format: SpyServerFormat::Int16,
+        iq_decimation: 4,
+        auto_digital_gain: true,
+        fft_enabled: false,
+        ..fake.cfg()
+    };
+    let _h = SpyServerHandle::connect_wideband(&cfg, 1_081_400.0).expect("connect");
+    assert!(
+        eventually(Duration::from_secs(2), || fake.value_of(SETTING_IQ_DIGITAL_GAIN) == Some(12))
+    );
+    std::thread::sleep(Duration::from_secs(1));
+    assert_eq!(
+        fake.values_of(SETTING_IQ_DIGITAL_GAIN),
+        vec![12],
+        "a 16-bit stream keeps the figure the formula gave it, and is asked once"
+    );
+}
+
+/// The operator's own figure is never touched. Automatic off means a number
+/// was typed, and the loop has no business second-guessing it — including the
+/// right to clip a whole band flat.
+#[test]
+fn a_manual_digital_gain_is_sent_as_typed_and_left_alone() {
+    let fake = Fake::start(hf_plus_streaming(255, 40));
+    let cfg = SpyServerConfig {
+        iq_format: SpyServerFormat::Uint8,
+        iq_decimation: 0,
+        auto_digital_gain: false,
+        digital_gain_db: 40.0,
+        fft_enabled: false,
+        ..fake.cfg()
+    };
+    let _h = SpyServerHandle::connect_wideband(&cfg, 1_081_400.0).expect("connect");
+    assert!(
+        eventually(Duration::from_secs(2), || fake.value_of(SETTING_IQ_DIGITAL_GAIN) == Some(40))
+    );
+    std::thread::sleep(Duration::from_secs(1));
+    assert_eq!(fake.values_of(SETTING_IQ_DIGITAL_GAIN), vec![40], "the rails are the operator's");
 }
 
 /// The opposite case: where another client owns the receiver, the gain is

--- a/crates/sdroxide-ui/src/app/settings/radio.rs
+++ b/crates/sdroxide-ui/src/app/settings/radio.rs
@@ -1979,12 +1979,15 @@ pub(in crate::app) fn settings_spyserver_tab(
 
         ui.label("Digital gain").on_hover_text(
             "How far the server scales its samples up before quantising them \
-             for the wire. Automatic computes it the way every other client \
-             does — from the receiver type, the gain index and the decimation \
-             stage — and is almost always right.\n\n\
-             It matters most at 8 bits: a signal sitting far below full scale \
-             loses its lower bits to the quantiser, and the scaling is what \
-             puts it back. Applies immediately.",
+             for the wire. Automatic watches what actually arrives and holds \
+             the peak at half of full scale, which is the only thing that can \
+             be right on both a dead band and a crowded one — the two are \
+             thirty decibels apart and no fixed figure serves both.\n\n\
+             It matters only at 8 bits, where a signal far below full scale \
+             loses its lower bits to the quantiser and one above it is clipped \
+             flat. Wider formats have room to spare and get the figure every \
+             other client computes, from the gain index and the decimation \
+             stage. Applies immediately.",
         );
         ui.horizontal(|ui| {
             let mut auto = cfg.auto_digital_gain;


### PR DESCRIPTION
Fixes #390.

## The bug

Sample format set to 8-bit against a SpyServer publishing an Airspy HF+, and the signal is gone: the same flat floor on every band, nothing demodulates. 16-bit and float are fine. Introduced by c2ce6c12; not in any release yet, and the next one would carry it to every HF+ owner on 8-bit, which is the default.

## Root cause

c2ce6c12 keyed a flat +44 dB of `IQ_DIGITAL_GAIN` on an HF+ whenever the stream is 8-bit. The server multiplies by 158.5 _before_ quantising, so on any band with a signal on it the quantiser is driven twenty-odd dB past full scale: every sample is a rail. The client then divides by the same 158.5 — from the header, correctly — and what is left is a flat stub 26 dB below the truth with nothing in it, byte-identical on 80 m, 40 m and 20 m. The wire measurements are in #390.

The 44 dB was fixing a real problem: on a quiet band an HF+'s 8-bit I/Q sits below one LSB and arrives as three sample values, a slicer-noise floor 23 dB above the receiver's own. But how much gain a band needs is a property of the _band_ — a dead 20 m and 80 m at night are thirty decibels apart — and no constant is right at both ends.

## The fix

Two parts, both here.

**Back to the formula v1.6.5 had.** `DeviceInfo::digital_gain_db` is the decimation stage and, on an Airspy R2, the gain index, and nothing else. The wire format is no longer a parameter at all: a signature that cannot take it is a better guard against the next constant than a test saying it does not matter.

**A closed loop instead of a constant.** On an 8-bit stream in automatic, `maintain_digital_gain` in `net.rs` watches the peak of what arrives — `max|out| × header gain`, the raw fraction of full scale, so the decoder is untouched — and walks `IQ_DIGITAL_GAIN` to hold it at half of full scale:

- down immediately on a rail, 6 dB a step: a rail hides how far past full scale it is, so each step sees an honest peak the moment the rail lets go;
- up 3 dB a step, and only after two seconds continuously below target, so a pause in the traffic does not pump the gain for the next syllable to clip on;
- a 3 dB deadband, since the wire is whole dB; at most one setting per 250 ms against the server's budget of about eight a second;
- a stream of pure mid-scale — the dead-band symptom itself — is read as the strongest case for more gain, not as nothing having arrived.

Nothing the loop does shows in the level: the decoder divides by the gain the _header_ states, so the amplitude is the same either side of a change. What moves is how many of the eight bits the signal is using. Manual mode is never touched, and 16/32-bit streams keep the formula's figure — they have 48 dB of room, and moving them would only spend settings.

On a dead band starting from 0 dB the loop takes roughly 25 s to climb to where the band sits. That is the price of not pumping on pauses, and it is strictly better than the slicer noise v1.6.5 lives with for the whole session.

The "Digital gain" hint in the Radio tab now says what Automatic does.

**Separately, in its own commit:** the float32 decode path multiplied by the header gain, copied from SDR++. A real server amplifies floats exactly as it does integers, so that applied the gain twice; it now divides like the other formats.

## Tests

- `an_hf_plus_is_asked_for_the_reference_digital_gain_in_either_format`: 0 dB at stage 0 on the wire, 8-bit and 16-bit alike.
- `an_eight_bit_stream_that_arrives_clipped_walks_the_digital_gain_down`: a fake HF+ streaming rails with 12 dB in the header; the wire goes `12, 6, 0` and then stops asking.
- `an_eight_bit_stream_that_arrives_below_one_lsb_walks_the_digital_gain_up_slowly`: a fake streaming pure mid-scale; nothing for the first second, then one 3 dB step.
- `a_sixteen_bit_stream_is_left_at_the_reference_figure`, `a_manual_digital_gain_is_sent_as_typed_and_left_alone`: the loop keeps its hands off.
- The formula's own unit tests, and the float32 decode against a literal.

`spyserver_level` (new example in the crate) is what the figures in #390 were measured with: it pulls I/Q through the real client and reports the level it arrives at.

## Verified on hardware

Against a live Airspy HF+ over SpyServer at 8-bit, automatic: the stream is no longer clipped, and the loop's steps (`RUST_LOG=info,sdroxide_spyserver::net=debug`) stop once it has settled.
