### PR TITLE
Give each VFO its own antenna socket, kept across an A/B press inside one band and handed back to the band memory when the dial crosses one; fixes #404

### DIFF
--- a/crates/sdroxide-config/src/lib.rs
+++ b/crates/sdroxide-config/src/lib.rs
@@ -1219,6 +1219,20 @@ pub struct Session {
     /// Absent in a session written before this existed.
     #[serde(default)]
     pub band_antenna: BandAntennas,
+    /// The antenna sockets each VFO was left on, `[A, B]`, as `(RX, TX)`.
+    ///
+    /// The companion to [`Self::vfo_modes`], and there for the same reason: a
+    /// VFO is a whole listening position, not a dial. [`Self::band_antenna`]
+    /// cannot stand in for this — it holds one socket per band, so two VFOs at
+    /// opposite ends of the same band write the same entry and the second
+    /// choice wins for both (issue #404).
+    ///
+    /// Either side may be `None`, for a VFO that has never had a socket chosen
+    /// on it or a direction with no port to choose; the whole field is absent
+    /// in a session written before this was remembered. No preference means no
+    /// assertion, the same rule the two memories above follow.
+    #[serde(default)]
+    pub vfo_antennas: Option<[(Option<String>, Option<String>); 2]>,
 }
 
 /// Which antenna socket was last chosen on each band — see
@@ -1267,6 +1281,10 @@ impl Default for Session {
             tx_gains: Vec::new(),
             recording_mono: radio.recording_mono,
             band_antenna: BandAntennas::new(),
+            // And no socket of its own for either VFO until one has been
+            // chosen on it — nothing moves a relay before the operator has
+            // said what belongs where.
+            vfo_antennas: None,
         }
     }
 }
@@ -2179,6 +2197,12 @@ mod tests {
             band_antenna: BandAntennas::from([
                 (sdroxide_types::Band::M40, (Some("ANT1".into()), None)),
                 (sdroxide_types::Band::M2, (Some("ANT2".into()), Some("ANT2".into()))),
+            ]),
+            // Both VFOs on 40 m, one on each socket — what the band map above
+            // cannot express on its own.
+            vfo_antennas: Some([
+                (Some("ANT1".into()), None),
+                (Some("ANT2".into()), Some("ANT2".into())),
             ]),
         };
         let back: Session = serde_json::from_str(&serde_json::to_string(&s).unwrap()).unwrap();

--- a/crates/sdroxide-radio/src/engine.rs
+++ b/crates/sdroxide-radio/src/engine.rs
@@ -2139,24 +2139,48 @@ impl ZoomLane {
 }
 
 /// The listening position a VFO keeps while the other one is in use: the mode
-/// it was left in and the passband that went with it.
+/// it was left in, the passband that went with it, and the antenna socket it
+/// was heard on.
 ///
 /// The filter travels with the mode because it belongs to it — selecting a mode
 /// installs that mode's default width, so a VFO restored on its mode alone
 /// would come back with a passband the operator had already narrowed and lost.
-#[derive(Debug, Clone, Copy, PartialEq)]
+///
+/// The antenna is an `Option` because it is a preference and not an assertion:
+/// a VFO nobody has chosen a socket on leaves the front end exactly where it
+/// is, the same "no preference means no assertion" rule
+/// [`Engine::restore_antennas`] and [`Engine::follow_band_antenna`] follow.
+#[derive(Debug, Clone, PartialEq)]
 struct VfoMemory {
     mode: Mode,
     filter_lo: f32,
     filter_hi: f32,
+    antenna_rx: Option<String>,
+    antenna_tx: Option<String>,
 }
 
 impl VfoMemory {
     /// What the receiver is listening in right now, ready to be shelved under
     /// the VFO that is being left.
-    fn of(rx: &RxState) -> VfoMemory {
-        VfoMemory { mode: rx.mode, filter_lo: rx.filter_lo, filter_hi: rx.filter_hi }
+    fn of(state: &RadioState) -> VfoMemory {
+        let rx = &state.rx[0];
+        VfoMemory {
+            mode: rx.mode,
+            filter_lo: rx.filter_lo,
+            filter_hi: rx.filter_hi,
+            // The socket in use, not the one last asked for: a rig that moved
+            // its own selector while this VFO was in front is still what the
+            // operator was listening on.
+            antenna_rx: chosen(&state.antenna_rx),
+            antenna_tx: chosen(&state.antenna_tx),
+        }
     }
+}
+
+/// A socket name worth remembering, or `None` for a front end that has no
+/// selector and reports an empty one.
+fn chosen(name: &str) -> Option<String> {
+    (!name.is_empty()).then(|| name.to_string())
 }
 
 struct Engine {
@@ -3727,7 +3751,7 @@ fn engine_thread(
     // mode the receiver came up in — the command line's, the session's, or the
     // default — and the *inactive* one is then given back the mode it was
     // actually left in, just below.
-    let initial_vfo_memory = VfoMemory::of(&state.rx[0]);
+    let initial_vfo_memory = VfoMemory::of(&state);
 
     let mut engine = Engine {
         // Out of declaration order on purpose: literal fields are evaluated
@@ -3943,7 +3967,7 @@ fn engine_thread(
         good_vfo_hz: source_center_hz,
         // Both VFOs start on the mode the receiver came up in; the remembered
         // pair is folded in below, once the engine owns them.
-        vfo_memory: [initial_vfo_memory; 2],
+        vfo_memory: [initial_vfo_memory.clone(), initial_vfo_memory],
         spots: sdroxide_net::SpotManager::new(),
         winlink: open_mailbox(&sdroxide_types::WinlinkConfig::default()),
         kiss: None,
@@ -4100,6 +4124,15 @@ fn engine_thread(
             _ => engine.state.vfo_b_hz,
         });
         (engine.vfo_memory[idle].filter_lo, engine.vfo_memory[idle].filter_hi) = (lo, hi);
+    }
+    // And the socket it was left on, on the same terms: the active VFO is
+    // already on whatever the front end opened on, and `restore_antennas` has
+    // the last word there, so only the other slot is filled in (issue #404).
+    if let Some(ants) = engine.session.as_ref().and_then(|s| s.vfo_antennas.clone()) {
+        let idle = 1 - engine.state.active_vfo.index();
+        let (rx, tx) = ants[idle].clone();
+        engine.vfo_memory[idle].antenna_rx = rx;
+        engine.vfo_memory[idle].antenna_tx = tx;
     }
     engine.push_rx_mode();
     engine.keep_vfo_in_span();
@@ -7530,26 +7563,29 @@ impl Engine {
                 self.update_tuning();
             }
             SelectVfo(v) => {
-                // The mode goes with the VFO. Shelve what the one being left
-                // was listening in, and put the receiver into what the one
-                // being taken up was left in (issue #286).
-                self.shelve_vfo_mode();
+                // The mode goes with the VFO, and so does the antenna socket.
+                // Shelve what the one being left was listening in, and put the
+                // receiver into what the one being taken up was left in
+                // (issues #286 and #404).
+                self.shelve_vfo_state();
                 self.state.active_vfo = v;
                 self.recall_vfo_mode();
+                self.recall_vfo_antenna();
                 self.state.band = Band::containing(self.state.active_freq_hz());
                 self.follow_dial();
                 self.update_tuning();
             }
             SwapVfos => {
                 // A swap exchanges the whole listening position, not just the
-                // two numbers: A's mode and passband go to B along with its
-                // dial. The active VFO does not change, so what it is now
-                // holding is the *other* one's setup, and the receiver has to
-                // be put into it.
-                self.shelve_vfo_mode();
+                // two numbers: A's mode, passband and antenna go to B along
+                // with its dial. The active VFO does not change, so what it is
+                // now holding is the *other* one's setup, and the receiver has
+                // to be put into it.
+                self.shelve_vfo_state();
                 std::mem::swap(&mut self.state.vfo_a_hz, &mut self.state.vfo_b_hz);
                 self.vfo_memory.swap(0, 1);
                 self.recall_vfo_mode();
+                self.recall_vfo_antenna();
                 self.state.band = Band::containing(self.state.active_freq_hz());
                 self.follow_dial();
                 self.update_tuning();
@@ -7559,12 +7595,13 @@ impl Engine {
                 // A=B copies the position, mode included — otherwise the VFO
                 // that was just made a duplicate of A would listen to A's
                 // frequency in something else.
-                self.shelve_vfo_mode();
-                self.vfo_memory[Vfo::B.index()] = self.vfo_memory[Vfo::A.index()];
+                self.shelve_vfo_state();
+                self.vfo_memory[Vfo::B.index()] = self.vfo_memory[Vfo::A.index()].clone();
                 // A no-op while A is the active VFO, and the whole point of the
                 // call while B is: the receiver has just been moved onto A's
-                // frequency and has to hear it in A's mode.
+                // frequency and has to hear it in A's mode, on A's antenna.
                 self.recall_vfo_mode();
+                self.recall_vfo_antenna();
                 self.update_tuning();
             }
             SetSplit(on) => self.state.split = on,
@@ -11939,8 +11976,8 @@ impl Engine {
         self.update_tuning();
     }
 
-    /// Record what the active VFO is listening in, so taking up the other one
-    /// can leave it there.
+    /// Record the position the active VFO is listening in — mode, passband and
+    /// antenna socket — so taking up the other one can leave it there.
     ///
     /// Called on the way *out* of a VFO rather than on every mode change: the
     /// only thing that has to be true is that the shelf is current at the
@@ -11948,8 +11985,8 @@ impl Engine {
     /// path that can change a mode or a filter width — the mode buttons, a band
     /// stack recall, a memory, the scanner, rigctld, a remote client, the rig's
     /// own knob.
-    fn shelve_vfo_mode(&mut self) {
-        self.vfo_memory[self.state.active_vfo.index()] = VfoMemory::of(&self.state.rx[0]);
+    fn shelve_vfo_state(&mut self) {
+        self.vfo_memory[self.state.active_vfo.index()] = VfoMemory::of(&self.state);
     }
 
     /// Put the main receiver into the mode and passband the now-active VFO was
@@ -11961,7 +11998,7 @@ impl Engine {
     /// afterwards because selecting a mode installs that mode's default width,
     /// which would otherwise throw away a passband the operator had narrowed.
     fn recall_vfo_mode(&mut self) {
-        let want = self.vfo_memory[self.state.active_vfo.index()];
+        let want = self.vfo_memory[self.state.active_vfo.index()].clone();
         if want.mode != self.state.rx[0].mode {
             self.set_rx_mode(RxId::Main, want.mode);
         }
@@ -11978,6 +12015,79 @@ impl Engine {
         // too — exactly as `set_rx_mode` does for the mode it commands.
         // Self-guarded, and a no-op on every front end that filters here.
         self.push_control_filter();
+    }
+
+    /// Put the now-active VFO back on the antenna socket it was last heard on —
+    /// but only while the switch stays inside one band.
+    ///
+    /// Two VFOs at the same end of the same band is the one case the per-band
+    /// memory cannot cover. [`Engine::band_antenna`] holds one socket per band,
+    /// so an RSPdx operator listening on Antenna A with VFO A and on Antenna B
+    /// with VFO B writes both choices into the same entry and the second one
+    /// wins for both — switching back left the front end on the wrong socket
+    /// while the frequency and the mode came back correctly (issue #404).
+    ///
+    /// Crossing a band edge is the band's business and not the VFO's, so this
+    /// stands aside for it: an A/B press onto a VFO parked on another band is a
+    /// band change like any other, and [`Engine::poll_band_change`] calls
+    /// [`Engine::follow_band_antenna`] for it a moment later. Which aerial
+    /// hears 2 m is a fact about the station rather than about a VFO, and a
+    /// shelf written the last time that VFO happened to be on the band would
+    /// argue with the operator's standing choice for it. The division is the
+    /// one an operator would state: the A/B button keeps the socket, a band
+    /// change recalls it.
+    ///
+    /// Nothing is written back into the band memory here either. That record
+    /// holds the operator's explicit choice on a band — `SetAntenna` and
+    /// nothing else puts anything in it — and the finer, per-VFO record does
+    /// not get to speak for the band as a whole.
+    ///
+    /// Unlike a band change this *is* compared against the cached socket before
+    /// it is sent. `follow_band_antenna` asserts rather than compares because a
+    /// rig moves its own selector when its band stacking register changes under
+    /// it (issue #258); an A/B press within one band moves no register, so an
+    /// unconditional write here would only click a relay on every press.
+    fn recall_vfo_antenna(&mut self) {
+        // The band the dial has landed on — read from the dial rather than
+        // taken from `state.band`, which the callers set *after* this so that a
+        // mode moving the dial of its own accord (APRS does) is accounted for —
+        // against the band being left, which `state.band` still holds.
+        if Band::containing(self.state.active_freq_hz()) != self.state.band {
+            return;
+        }
+        let want = self.vfo_memory[self.state.active_vfo.index()].clone();
+        let before = (self.state.antenna_rx.clone(), self.state.antenna_tx.clone());
+        // Not where the source owns the receive port: a LimeSDR with a LimeRFE
+        // in front of it listens on the socket the front end is cabled to. Same
+        // exemption as `restore_antennas` and `follow_band_antenna`.
+        if let Some(name) = want
+            .antenna_rx
+            .filter(|n| !self.source.owns_rx_antenna() && self.caps.antennas_rx.contains(n))
+            .filter(|n| *n != self.state.antenna_rx)
+        {
+            if let Err(e) = self.source.set_antenna(&name) {
+                warn!("switching to RX antenna {name} for VFO {:?}: {e}", self.state.active_vfo);
+            }
+            self.state.antenna_rx = self.source.current_antenna();
+            // A Hi-Z port has fewer front-end states than the 50 Ohm one beside
+            // it, exactly as it does for a socket chosen by hand.
+            self.refresh_rx_gains();
+            self.want_antenna.0 = Some(name);
+        }
+        if let Some(name) = want
+            .antenna_tx
+            .filter(|n| self.caps.antennas_tx.contains(n))
+            .filter(|n| *n != self.state.antenna_tx)
+        {
+            if let Err(e) = self.source.set_tx_antenna(&name) {
+                warn!("switching to TX antenna {name} for VFO {:?}: {e}", self.state.active_vfo);
+            }
+            self.state.antenna_tx = self.source.current_tx_antenna();
+            self.want_antenna.1 = Some(name);
+        }
+        if before != (self.state.antenna_rx.clone(), self.state.antenna_tx.clone()) {
+            let _ = self.event_tx.send(RadioEvent::State(self.state.clone()));
+        }
     }
 
     fn set_rx_mode(&mut self, rx: RxId, mode: Mode) {
@@ -13261,7 +13371,6 @@ impl Engine {
         // What the hardware reports, not what was asked for, and dropped when it
         // is empty: a front end with no antenna to choose (a CAT rig, a file)
         // must not erase the port a real radio was left on.
-        let keep = |name: &str| (!name.is_empty()).then(|| name.to_string());
         // Both dials and which one was in use, so a station left listening on
         // B — or split, with the other VFO on the DX's transmit frequency —
         // comes back set up the way it was rather than with B collapsed onto A.
@@ -13279,8 +13388,8 @@ impl Engine {
                 m[self.state.active_vfo.index()] = self.state.rx[0].mode;
                 m
             }),
-            antenna_rx: keep(&self.state.antenna_rx).or_else(|| saved.antenna_rx.clone()),
-            antenna_tx: keep(&self.state.antenna_tx).or_else(|| saved.antenna_tx.clone()),
+            antenna_rx: chosen(&self.state.antenna_rx).or_else(|| saved.antenna_rx.clone()),
+            antenna_tx: chosen(&self.state.antenna_tx).or_else(|| saved.antenna_tx.clone()),
             volume: self.state.rx[0].volume,
             muted: self.state.rx[0].muted,
             rx_gain_db: self.state.rx[0].manual_gain_db,
@@ -13307,6 +13416,18 @@ impl Engine {
             tx_gains: self.want_gains.1.clone(),
             recording_mono: self.state.recording_mono,
             band_antenna: self.band_antenna.clone(),
+            // The shelf again, with the live socket written into the active
+            // slot on the way past for the same reason the modes are: the shelf
+            // is only current for the VFO that is *not* in use.
+            vfo_antennas: Some({
+                let mut a = [
+                    (self.vfo_memory[0].antenna_rx.clone(), self.vfo_memory[0].antenna_tx.clone()),
+                    (self.vfo_memory[1].antenna_rx.clone(), self.vfo_memory[1].antenna_tx.clone()),
+                ];
+                a[self.state.active_vfo.index()] =
+                    (chosen(&self.state.antenna_rx), chosen(&self.state.antenna_tx));
+                a
+            }),
         };
         if now == *saved {
             return;

--- a/crates/sdroxide-radio/tests/vfo_keeps_its_antenna.rs
+++ b/crates/sdroxide-radio/tests/vfo_keeps_its_antenna.rs
@@ -1,0 +1,226 @@
+//! Each VFO remembers the antenna socket it was left on.
+//!
+//! The per-band memory cannot stand in for this. It holds one socket per band,
+//! so an RSPdx operator listening on Antenna A with VFO A and on Antenna B with
+//! VFO B — both at the same end of the same band — writes both choices into the
+//! same entry, and the second one wins for both. Switching back gave the
+//! frequency and the mode correctly and left the front end on the wrong socket
+//! (issue #404).
+//!
+//! The antenna rides in the same shelf as the mode and the passband, written on
+//! the way out of a VFO and read on the way into one, so a swap and an A=B copy
+//! carry it for free.
+//!
+//! The two memories divide the work by what the operator just did. An A/B press
+//! that stays inside one band is the VFO's: the band has one socket and this is
+//! two. Crossing a band edge — by the dial, or by an A/B press onto a VFO parked
+//! on another band — is the band's, because which aerial hears 2 m is a fact
+//! about the station rather than about a VFO. Choosing a socket by hand writes
+//! the band's entry and nothing else does.
+
+use std::time::Duration;
+
+use sdroxide_radio::{Complex32, EngineConfig, IqSource, Result, start_engine};
+use sdroxide_types::{Command, DeviceCaps, Direction, Mode, RadioEvent, RadioState, RxId, Vfo};
+
+const RATE: f64 = 2_400_000.0;
+
+/// A front end with two sockets, like an RSPdx's Antenna A and Antenna B.
+struct MockSource {
+    center: f64,
+    antenna: String,
+}
+
+impl IqSource for MockSource {
+    fn sample_rate(&self) -> f64 {
+        RATE
+    }
+    fn center_hz(&self) -> f64 {
+        self.center
+    }
+    fn set_center_hz(&mut self, hz: f64) -> Result<()> {
+        self.center = hz;
+        Ok(())
+    }
+    fn set_antenna(&mut self, name: &str) -> Result<()> {
+        self.antenna = name.to_string();
+        Ok(())
+    }
+    fn current_antenna(&self) -> String {
+        self.antenna.clone()
+    }
+    fn read(&mut self, buf: &mut [Complex32]) -> Result<usize> {
+        std::thread::sleep(Duration::from_millis(5));
+        let n = buf.len().min(2048);
+        buf[..n].fill(Complex32::new(0.0, 0.0));
+        Ok(n)
+    }
+    fn describe(&self) -> String {
+        "mock two-socket source".into()
+    }
+}
+
+/// Point the config at a scratch directory, once for the whole binary — the
+/// engine reads and seeds files as it starts, and no test may write to the
+/// operator's own.
+fn isolate_config() {
+    static ONCE: std::sync::Once = std::sync::Once::new();
+    ONCE.call_once(|| {
+        let root = std::env::temp_dir().join(format!("sdroxide-vfo-ant-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&root);
+        std::fs::create_dir_all(&root).unwrap();
+        unsafe { std::env::set_var("SDROXIDE_CONFIG_DIR", &root) };
+    });
+}
+
+fn caps() -> DeviceCaps {
+    DeviceCaps {
+        driver: "mock".into(),
+        label: "mock".into(),
+        rx_channels: 1,
+        sample_rates: vec![RATE],
+        freq_ranges_rx: vec![(0.0, 1_000_000_000.0)],
+        antennas_rx: vec!["Antenna A".into(), "Antenna B".into()],
+        ..DeviceCaps::default()
+    }
+}
+
+/// Run `cmds` against a fresh engine and report the last state it published.
+fn after(cmds: &[Command]) -> RadioState {
+    isolate_config();
+    let mut h = start_engine(
+        Box::new(MockSource { center: 14_200_000.0, antenna: "Antenna A".into() }),
+        caps(),
+        EngineConfig { tx_ham_only: false, ..Default::default() },
+    );
+    let thread = h.thread.take();
+
+    std::thread::sleep(Duration::from_millis(150));
+    for c in cmds {
+        h.cmd_tx.send(c.clone()).unwrap();
+        std::thread::sleep(Duration::from_millis(60));
+    }
+    std::thread::sleep(Duration::from_millis(200));
+
+    let mut last = None;
+    while let Ok(ev) = h.event_rx.try_recv() {
+        if let RadioEvent::State(s) = ev {
+            last = Some(s);
+        }
+    }
+
+    drop(h.cmd_tx);
+    if let Some(t) = thread {
+        let _ = t.join();
+    }
+    last.expect("the engine should publish state")
+}
+
+fn on(vfo: Vfo, hz: f64, antenna: &str) -> Vec<Command> {
+    vec![
+        Command::SelectVfo(vfo),
+        Command::SetVfo { vfo, hz },
+        Command::SetAntenna { dir: Direction::Rx, name: antenna.into() },
+    ]
+}
+
+/// The whole of issue #404, and the reporter's own steps: two VFOs on one band,
+/// a socket each. The band memory holds whichever was chosen last and cannot
+/// tell them apart, so this is the VFO's shelf answering.
+#[test]
+fn each_vfo_comes_back_on_the_socket_it_was_left_on() {
+    let mut cmds = on(Vfo::A, 7_100_000.0, "Antenna A");
+    cmds.extend(on(Vfo::B, 7_150_000.0, "Antenna B"));
+    cmds.push(Command::SelectVfo(Vfo::A));
+    let s = after(&cmds);
+    assert_eq!(s.antenna_rx, "Antenna A", "A was left on Antenna A");
+
+    // And over to B again, which was left on the other one.
+    let mut cmds = on(Vfo::A, 7_100_000.0, "Antenna A");
+    cmds.extend(on(Vfo::B, 7_150_000.0, "Antenna B"));
+    cmds.push(Command::SelectVfo(Vfo::A));
+    cmds.push(Command::SelectVfo(Vfo::B));
+    let s = after(&cmds);
+    assert_eq!(s.antenna_rx, "Antenna B", "B was left on Antenna B");
+}
+
+/// Tuning across a band edge is the band memory's business, unchanged: the
+/// socket chosen on the band being entered is the one that comes back.
+#[test]
+fn tuning_across_a_band_edge_recalls_the_band() {
+    let mut cmds = on(Vfo::A, 14_200_000.0, "Antenna B");
+    // Down to 40 m, where the other socket is chosen, and back up.
+    cmds.push(Command::SetVfo { vfo: Vfo::A, hz: 7_100_000.0 });
+    cmds.push(Command::SetAntenna { dir: Direction::Rx, name: "Antenna A".into() });
+    cmds.push(Command::SetVfo { vfo: Vfo::A, hz: 14_200_000.0 });
+    let s = after(&cmds);
+    assert_eq!(s.antenna_rx, "Antenna B", "20 m was left on Antenna B");
+}
+
+/// And an A/B press onto a VFO parked on another band is a band change like any
+/// other, so the band wins there even against the VFO's own shelf.
+///
+/// A is left on 20 m on Antenna A. The band's own choice for 20 m is then moved
+/// to Antenna B from the other VFO, so that the two records disagree — and
+/// coming back to A has to give the band's answer, not A's.
+#[test]
+fn a_vfo_switch_onto_another_band_defers_to_the_band() {
+    let mut cmds = on(Vfo::A, 14_200_000.0, "Antenna A");
+    cmds.extend(on(Vfo::B, 7_100_000.0, "Antenna B"));
+    // B visits 20 m, changes its mind about the band, and goes back to 40 m.
+    cmds.push(Command::SetVfo { vfo: Vfo::B, hz: 14_200_000.0 });
+    cmds.push(Command::SetAntenna { dir: Direction::Rx, name: "Antenna B".into() });
+    cmds.push(Command::SetVfo { vfo: Vfo::B, hz: 7_100_000.0 });
+    cmds.push(Command::SelectVfo(Vfo::A));
+    let s = after(&cmds);
+    assert!((s.active_freq_hz() - 14_200_000.0).abs() < 1.0);
+    assert_eq!(s.antenna_rx, "Antenna B", "20 m's own socket, not the one A was left on");
+}
+
+/// A swap exchanges the listening positions, so the active VFO — which does not
+/// change — is holding the other one's socket afterwards.
+#[test]
+fn swapping_exchanges_the_sockets_as_well_as_the_dials() {
+    let mut cmds = on(Vfo::B, 7_150_000.0, "Antenna B");
+    cmds.extend(on(Vfo::A, 7_100_000.0, "Antenna A"));
+    cmds.push(Command::SwapVfos);
+    let s = after(&cmds);
+    assert_eq!(s.active_vfo, Vfo::A, "a swap does not change which VFO is in use");
+    assert_eq!(s.antenna_rx, "Antenna B", "A is holding what B had");
+}
+
+/// A=B copies the whole position, the socket included.
+#[test]
+fn copying_a_to_b_copies_the_socket_with_it() {
+    let mut cmds = on(Vfo::B, 7_150_000.0, "Antenna B");
+    cmds.extend(on(Vfo::A, 7_100_000.0, "Antenna A"));
+    cmds.push(Command::CopyAtoB);
+    cmds.push(Command::SelectVfo(Vfo::B));
+    let s = after(&cmds);
+    assert_eq!(s.antenna_rx, "Antenna A", "B is a copy of A now, socket included");
+}
+
+/// Re-selecting the VFO already in use must not undo a socket the operator has
+/// just chosen: the shelf is written on the way out, so a redundant select
+/// shelves what is in force and puts it straight back.
+#[test]
+fn selecting_the_vfo_already_in_use_changes_nothing() {
+    let mut cmds = on(Vfo::A, 7_100_000.0, "Antenna A");
+    cmds.push(Command::SetAntenna { dir: Direction::Rx, name: "Antenna B".into() });
+    cmds.push(Command::SelectVfo(Vfo::A));
+    let s = after(&cmds);
+    assert_eq!(s.antenna_rx, "Antenna B");
+}
+
+/// The mode memory is untouched by all this — the two ride the same shelf.
+#[test]
+fn the_mode_still_goes_with_the_vfo() {
+    let mut cmds = on(Vfo::A, 7_100_000.0, "Antenna A");
+    cmds.push(Command::SetMode { rx: RxId::Main, mode: Mode::Cw });
+    cmds.extend(on(Vfo::B, 7_150_000.0, "Antenna B"));
+    cmds.push(Command::SetMode { rx: RxId::Main, mode: Mode::Lsb });
+    cmds.push(Command::SelectVfo(Vfo::A));
+    let s = after(&cmds);
+    assert_eq!(s.rx[0].mode, Mode::Cw);
+    assert_eq!(s.antenna_rx, "Antenna A");
+}

--- a/docs/USER_MANUAL.md
+++ b/docs/USER_MANUAL.md
@@ -334,19 +334,31 @@ The **VFO** module has:
 - **SPLIT** — transmit on one VFO and receive on the other.
 - **SUB** — enable a second receiver, routed to the right ear.
 
-**Each VFO keeps its own mode**, and its own filter width with it. A VFO is a
-whole listening position rather than just a number — CW on A while B sits on an
-SSB net is what the pair is for — so switching between them puts the receiver
-into the mode that VFO was left in, exactly as the A/B button on a transceiver
-does. Swap and Copy A to B move the mode along with the frequency: after a swap
-each VFO holds what the other one had, and after a copy B is A in every respect.
+**Each VFO keeps its own mode**, its own filter width, and its own antenna. A
+VFO is a whole listening position rather than just a number — CW on A while B
+sits on an SSB net is what the pair is for — so switching between them puts the
+receiver into the mode that VFO was left in and back on the socket it was heard
+on, exactly as the A/B button on a transceiver does. Swap and Copy A to B move
+all of it along with the frequency: after a swap each VFO holds what the other
+one had, and after a copy B is A in every respect.
 
-Both VFOs, the mode each was left in, and which of the two was selected are
-remembered per radio in `session.json`, so a station left listening on B — or set
-up for split, with the other VFO on the DX's transmit frequency — comes back the
-same way at the next start rather than with B collapsed onto A. `--freq` and
-`--mode` still override the dial and the mode for a run, and they apply to
-whichever VFO was active.
+The antenna is remembered per band as well
+([6.2](#62-radio-choosing-and-configuring-the-rig)), and the two memories divide
+the work by what you have just done. **An A/B press that stays inside one band
+keeps each VFO's socket** — Antenna A on a broadcast station and Antenna B on
+the amateur allocation below it is one band and two sockets, which the band
+memory alone cannot express. **Crossing a band edge recalls the band's socket
+instead**, whether you got there by the dial or by pressing A/B onto a VFO
+parked on another band: which aerial hears 2 m is a fact about the station
+rather than about a VFO. Choosing a socket by hand is what writes the band's
+entry, so the band always holds your last explicit choice on it.
+
+Both VFOs, the mode and socket each was left in, and which of the two was
+selected are remembered per radio in `session.json`, so a station left listening
+on B — or set up for split, with the other VFO on the DX's transmit frequency —
+comes back the same way at the next start rather than with B collapsed onto A.
+`--freq` and `--mode` still override the dial and the mode for a run, and they
+apply to whichever VFO was active.
 
 The sub-receiver tunes **independently of A/B**: swapping VFOs or turning the
 dial leaves it where you parked it. Switching it on reveals a **SUB module** in
@@ -6521,7 +6533,10 @@ exposes, and nothing it does not:
 > channel is where you change your mind about which one that should be
 > ([2.12](#212-memory-channels)). A band you have never chosen a socket on is
 > left exactly where the radio already is, so nothing moves a relay for you
-> until you have said what belongs on that band.
+> until you have said what belongs on that band. **Each VFO remembers its socket
+> too**, which is what lets you keep A and B on different sockets at the same
+> end of one band; a change of band hands the choice back to the band
+> ([2.5](#25-vfos-split-and-the-sub-receiver)).
 - **Stream** — **Sample rate** and **Baseband filter**, listing the values this
   device says it accepts. Both default to leaving things as they were: the rate
   falls back to the app-wide `sample_rate`, and the filter to whatever the


### PR DESCRIPTION
Fixes #404.

An RSPdx operator listening on Antenna A with VFO A and on Antenna B with VFO B got the frequency and the mode back on every A/B press and the wrong socket. The only antenna memory was the per-band one, which holds a single socket per band, so both choices landed in the same entry and the second one won for both.

## What changes

The socket now rides in the same shelf as the mode and the passband (#286): `VfoMemory` gains an RX and a TX port, written on the way out of a VFO and read on the way into one, so a swap and an A=B copy carry it for free. `session.json` gains `vfo_antennas`, the companion to `vfo_modes`, so both VFOs come back on their own sockets at the next start.

## How the two memories divide the work

This is the part worth reviewing, since there are now two records that can disagree.

- **An A/B press that stays inside one band is the VFO's.** One band, two sockets, which the band memory cannot express — that is the whole of #404.
- **Crossing a band edge is the band's**, whether by the dial or by an A/B press onto a VFO parked on another band. Which aerial hears 2 m is a fact about the station rather than about a VFO, so #235 and #238 keep the last word there. `recall_vfo_antenna` compares the dial's band against the one being left and returns early when they differ, leaving `poll_band_change` to call `follow_band_antenna` a moment later.
- **Choosing a socket by hand is still the only thing that writes a band entry.** The finer, per-VFO record does not get to speak for the band as a whole.

One asymmetry with `follow_band_antenna` is deliberate: this recall is compared against the cached socket before it is sent. `follow_band_antenna` asserts rather than compares because a rig moves its own selector when its band stacking register changes under it (#258); an A/B press within one band moves no register, so an unconditional write would only click a relay on every press.

## Tested

On an RSPdx (serial 210307BB44), driving a running engine over the built-in rigctld server and reading the front end's socket back out of `session.json`:

| Action | Front end went to |
| --- | --- |
| A on 7.100 → B on 7.150 | Antenna B |
| B → A, same band | Antenna A |
| A tuned 7.100 → 14.200, with Antenna C recorded for 20 m | Antenna C |
| A tuned 14.200 → 7.100 | Antenna A |

The 40 m band entry stayed on Antenna A throughout, and no driver warning appeared on any switch.

Also covered by `crates/sdroxide-radio/tests/vfo_keeps_its_antenna.rs`, seven cases; three of them fail without the change. `docs/USER_MANUAL.md` §2.5 and §6.2 describe the division.

No wire-protocol change, so `PROTO_VERSION` is untouched.
